### PR TITLE
fix(macOS): stabilize Core Audio startup and isolate settings tests

### DIFF
--- a/electron/library-catalog.test.cjs
+++ b/electron/library-catalog.test.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const { execSync } = require("node:child_process");
 const path = require("node:path");
 const test = require("node:test");
 const {
@@ -11,9 +12,23 @@ const {
 } = require("./library-catalog.cjs");
 
 test("keeps permanent empty system actions in the packaged library", () => {
-  const library = readPackagedLibrary(
-    path.join(__dirname, "..", "public", "assets", "library.json"),
-  );
+  // Read the committed blob so the guard survives local uncommitted edits
+  // (e.g. the documented `cp library.json.example library.json` setup step).
+  const repoRoot = path.join(__dirname, "..");
+  let committedJson;
+  try {
+    committedJson = execSync(
+      "git show HEAD:public/assets/library.json",
+      { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+  } catch {
+    // Not in a git repo or file not tracked — fall back to disk.
+    committedJson = require("node:fs").readFileSync(
+      path.join(repoRoot, "public", "assets", "library.json"),
+      "utf8",
+    );
+  }
+  const library = validatePackagedLibrary(JSON.parse(committedJson));
 
   assert.equal(library.default_model_id, null);
   assert.deepEqual(library.models, []);

--- a/electron/settings-store.test.cjs
+++ b/electron/settings-store.test.cjs
@@ -11,11 +11,26 @@ const {
   validateGlbFile,
 } = require("./settings-store.cjs");
 
+function writeEmptyPackagedLibrary(root) {
+  const packagedLibraryPath = path.join(root, "library.json");
+  fs.writeFileSync(
+    packagedLibraryPath,
+    JSON.stringify({
+      schema_version: 1,
+      default_model_id: null,
+      models: [],
+      animations: [],
+    }),
+  );
+  return packagedLibraryPath;
+}
+
 function fixture(context) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "persona-settings-"));
   const userDataPath = path.join(root, "user-data");
+  const packagedLibraryPath = writeEmptyPackagedLibrary(root);
   context.after(() => fs.rmSync(root, { force: true, recursive: true }));
-  return { root, userDataPath };
+  return { root, userDataPath, packagedLibraryPath };
 }
 
 function writeGlb(filePath) {
@@ -56,8 +71,8 @@ function writePackagedLibrary(root) {
 }
 
 test("starts with permanent empty Idle and Speaking actions", (context) => {
-  const { userDataPath } = fixture(context);
-  const snapshot = createSettingsStore({ userDataPath }).getSnapshot();
+  const { userDataPath, packagedLibraryPath } = fixture(context);
+  const snapshot = createSettingsStore({ userDataPath, packagedLibraryPath }).getSnapshot();
 
   assert.equal(snapshot.character_size, 1);
   assert.equal(snapshot.packaged_animation_change_count, 0);
@@ -90,14 +105,14 @@ test("starts with permanent empty Idle and Speaking actions", (context) => {
 });
 
 test("imports, persists, resolves, and deletes user assets", (context) => {
-  const { root, userDataPath } = fixture(context);
+  const { root, userDataPath, packagedLibraryPath } = fixture(context);
   const sourceModel = path.join(root, "assistant.vrm");
   const alternateModel = path.join(root, "alternate.vrm");
   const sourceAnimation = path.join(root, "wave.vrma");
   writeGlb(sourceModel);
   writeGlb(alternateModel);
   writeGlb(sourceAnimation);
-  const store = createSettingsStore({ userDataPath });
+  const store = createSettingsStore({ userDataPath, packagedLibraryPath });
 
   let snapshot = store.importModel({
     filePath: sourceModel,
@@ -154,7 +169,7 @@ test("imports, persists, resolves, and deletes user assets", (context) => {
   snapshot = store.deleteModel(alternate.id);
   assert.equal(snapshot.default_model_id, null);
 
-  const reloaded = createSettingsStore({ userDataPath }).getSnapshot();
+  const reloaded = createSettingsStore({ userDataPath, packagedLibraryPath }).getSnapshot();
   assert.equal(
     reloaded.models.some((candidate) => candidate.id === model.id),
     false,
@@ -162,7 +177,7 @@ test("imports, persists, resolves, and deletes user assets", (context) => {
 });
 
 test("keeps user library records when migrating the earlier settings schema", (context) => {
-  const { userDataPath } = fixture(context);
+  const { userDataPath, packagedLibraryPath } = fixture(context);
   const modelId = "11111111-1111-4111-8111-111111111111";
   const animationId = "22222222-2222-4222-8222-222222222222";
   const modelDirectory = path.join(userDataPath, "assets", "models");
@@ -196,7 +211,7 @@ test("keeps user library records when migrating the earlier settings schema", (c
     }),
   );
 
-  const snapshot = createSettingsStore({ userDataPath }).getSnapshot();
+  const snapshot = createSettingsStore({ userDataPath, packagedLibraryPath }).getSnapshot();
   assert.equal(snapshot.schema_version, 3);
   assert.equal(snapshot.default_model_id, modelId);
   assert.equal(snapshot.character_size, 1.15);
@@ -275,10 +290,10 @@ test("uses copy-on-write packaged edits and resets only that layer", (context) =
 });
 
 test("validates custom metadata, files, duplicates, and character size", (context) => {
-  const { root, userDataPath } = fixture(context);
+  const { root, userDataPath, packagedLibraryPath } = fixture(context);
   const sourceAnimation = path.join(root, "wave.vrma");
   writeGlb(sourceAnimation);
-  const store = createSettingsStore({ userDataPath });
+  const store = createSettingsStore({ userDataPath, packagedLibraryPath });
   const metadata = {
     animation_name: "user-wave",
     animation_description: "A wave.",
@@ -310,7 +325,7 @@ test("validates custom metadata, files, duplicates, and character size", (contex
 });
 
 test("migrates reserved legacy uploads into the permanent system actions", (context) => {
-  const { userDataPath } = fixture(context);
+  const { userDataPath, packagedLibraryPath } = fixture(context);
   const idleId = "33333333-3333-4333-8333-333333333333";
   const speakingId = "44444444-4444-4444-8444-444444444444";
   const animationDirectory = path.join(
@@ -344,7 +359,7 @@ test("migrates reserved legacy uploads into the permanent system actions", (cont
     }),
   );
 
-  const snapshot = createSettingsStore({ userDataPath }).getSnapshot();
+  const snapshot = createSettingsStore({ userDataPath, packagedLibraryPath }).getSnapshot();
 
   const idle = snapshot.animations.find(
     (animation) => animation.animation_name === "idle",
@@ -365,12 +380,12 @@ test("migrates reserved legacy uploads into the permanent system actions", (cont
 });
 
 test("groups multiple uploaded clips under one action and removes them independently", (context) => {
-  const { root, userDataPath } = fixture(context);
+  const { root, userDataPath, packagedLibraryPath } = fixture(context);
   const firstSource = path.join(root, "first.vrma");
   const secondSource = path.join(root, "second.vrma");
   writeGlb(firstSource);
   writeGlb(secondSource);
-  const store = createSettingsStore({ userDataPath });
+  const store = createSettingsStore({ userDataPath, packagedLibraryPath });
   let snapshot = store.createAnimation({
     animation_name: "wave",
     animation_description: "A friendly wave.",

--- a/native/macos/PersonaAudioListener.mm
+++ b/native/macos/PersonaAudioListener.mm
@@ -234,17 +234,37 @@ int main(int argc, const char *argv[]) {
     }
 
     MeterContext meter;
-    auto formatAddress = propertyAddress(
-        kAudioDevicePropertyStreamFormat, kAudioDevicePropertyScopeInput);
-    UInt32 formatSize = sizeof(meter.format);
-    status = AudioObjectGetPropertyData(
-        aggregateID, &formatAddress, 0, nullptr, &formatSize, &meter.format);
-    if (status != noErr) {
-      formatAddress = propertyAddress(kAudioDevicePropertyStreamFormat);
-      formatSize = sizeof(meter.format);
-      status = AudioObjectGetPropertyData(
-          aggregateID, &formatAddress, 0, nullptr, &formatSize, &meter.format);
+    // Core Audio publishes the aggregate device's tapped input stream
+    // asynchronously after the tap list is attached. Reading the format on the
+    // first attempt races that setup and intermittently fails with
+    // kAudioHardwareBadObjectError, so poll both scopes until the stream
+    // appears rather than giving up immediately.
+    const AudioObjectPropertyScope formatScopes[] = {
+        kAudioDevicePropertyScopeInput,
+        kAudioObjectPropertyScopeGlobal,
+    };
+    status = kAudioHardwareBadObjectError;
+    const auto formatDeadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (true) {
+      for (const AudioObjectPropertyScope scope : formatScopes) {
+        auto formatAddress =
+            propertyAddress(kAudioDevicePropertyStreamFormat, scope);
+        UInt32 formatSize = sizeof(meter.format);
+        const OSStatus readStatus = AudioObjectGetPropertyData(
+            aggregateID, &formatAddress, 0, nullptr, &formatSize, &meter.format);
+        if (readStatus == noErr && meter.format.mSampleRate > 0 &&
+            meter.format.mBitsPerChannel > 0) {
+          status = noErr;
+          break;
+        }
+        status = readStatus != noErr ? readStatus : kAudioHardwareBadObjectError;
+      }
+      if (status == noErr) break;
+      if (std::chrono::steady_clock::now() >= formatDeadline) break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
     }
+
     if (status != noErr) {
       AudioHardwareDestroyAggregateDevice(aggregateID);
       AudioHardwareDestroyProcessTap(tapID);


### PR DESCRIPTION
## What

Two fixes found while testing the Settings update (#4) on macOS (Apple Silicon, macOS 26.5.2).

---

### 1. Core Audio tap format race (`native/macos/PersonaAudioListener.mm`)

**Problem:** The code reads the aggregate device's stream format immediately after attaching the Core Audio tap. macOS publishes that stream *asynchronously*. Losing the race returns `kAudioHardwareBadObjectError` and the helper exits 1, killing the voice listener.

**Evidence before fix** (same command, repeated):

| pids tapped | failures |
|---|---|
| 1 (ChatGPT main) | 3 of 4 |
| 32 | 5 of 6 |
| 63 (what Persona passes) | 3 of 6 |

**Fix:** Poll both property scopes for up to 3s instead of giving up on the first read.

**After fix: 24 of 24 passed**, and the tap held open 5 continuous minutes.

Note: pid count is a red herring — it only shifts timing. The regex is fine.

---

### 2. Test hermeticity (`electron/settings-store.test.cjs`, `electron/library-catalog.test.cjs`)

**Problem:** Running the documented setup step (`cp library.json.example library.json`) then `npm run check` causes 4 test failures. The tests read `public/assets/library.json` from the working tree and assume it's empty.

- `settings-store.test.cjs`: Tests that expect an empty packaged library now create their own fixture file via `writeEmptyPackagedLibrary()` instead of falling back to the live source tree.
- `library-catalog.test.cjs`: The "committed stub must stay empty" guard now reads the committed blob via `git show HEAD:...` instead of the working tree, so it still catches a real regression but tolerates local uncommitted edits.

---

## Secondary findings (not code changes, FYI)

1. **Electron half-extract on `npm install`**: `npm install` leaves only `LICENSES.chromium.html` in `node_modules/electron/dist/` — no `Electron.app` — and still exits 0. Fix: `ditto -xk ~/Library/Caches/electron/<hash>/electron-v39.8.10-darwin-arm64.zip node_modules/electron/dist`. Hits any Mac contributor.

---

## Verified

- `npm run check` green (lint, 68 node tests, 13 vitest, assets, 0 prod vulns, build)
- Real VRM renders + idle animation plays (CDP screenshots)
- Settings UI: all 4 tabs render correctly on macOS
- MCP: 4 tools, session protocol, `get_status` + `list_animations` round-trip
- Bridge server: `/health` ok
- Asset contract: valid with populated configs