### PR TITLE
feat: add per-model lighting controls to Appearance settings

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -725,7 +725,7 @@ if (!app.requestSingleInstanceLock()) {
       (_event, modelId) =>
         publishSettings(settingsStore.resetModelLighting(modelId)),
     );
-    ipcMain.handle("persona:settings-get-mcp-status" , () =>
+    ipcMain.handle("persona:settings-get-mcp-status", () =>
       createMcpSettingsStatus({
         error: mcpServerError,
         health: mcpServerHealth,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -715,7 +715,17 @@ if (!app.requestSingleInstanceLock()) {
     ipcMain.handle("persona:settings-set-character-size", (_event, size) =>
       publishSettings(settingsStore.setCharacterSize(size)),
     );
-    ipcMain.handle("persona:settings-get-mcp-status", () =>
+    ipcMain.handle(
+      "persona:settings-set-model-lighting",
+      (_event, modelId, lighting) =>
+        publishSettings(settingsStore.setModelLighting(modelId, lighting)),
+    );
+    ipcMain.handle(
+      "persona:settings-reset-model-lighting",
+      (_event, modelId) =>
+        publishSettings(settingsStore.resetModelLighting(modelId)),
+    );
+    ipcMain.handle("persona:settings-get-mcp-status" , () =>
       createMcpSettingsStatus({
         error: mcpServerError,
         health: mcpServerHealth,

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -42,6 +42,10 @@ contextBridge.exposeInMainWorld("personaSettings", {
     ipcRenderer.invoke("persona:settings-set-default-model", modelId),
   setCharacterSize: (size) =>
     ipcRenderer.invoke("persona:settings-set-character-size", size),
+  setModelLighting: (modelId, lighting) =>
+    ipcRenderer.invoke("persona:settings-set-model-lighting", modelId, lighting),
+  resetModelLighting: (modelId) =>
+    ipcRenderer.invoke("persona:settings-reset-model-lighting", modelId),
   getMcpStatus: () =>
     ipcRenderer.invoke("persona:settings-get-mcp-status"),
   setWindowTheme: (theme) =>

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -43,7 +43,11 @@ contextBridge.exposeInMainWorld("personaSettings", {
   setCharacterSize: (size) =>
     ipcRenderer.invoke("persona:settings-set-character-size", size),
   setModelLighting: (modelId, lighting) =>
-    ipcRenderer.invoke("persona:settings-set-model-lighting", modelId, lighting),
+    ipcRenderer.invoke(
+      "persona:settings-set-model-lighting",
+      modelId,
+      lighting,
+    ),
   resetModelLighting: (modelId) =>
     ipcRenderer.invoke("persona:settings-reset-model-lighting", modelId),
   getMcpStatus: () =>

--- a/electron/preload.test.cjs
+++ b/electron/preload.test.cjs
@@ -75,6 +75,11 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
   await settings.deleteModel("model-id");
   await settings.setDefaultModel("model-id");
   await settings.setCharacterSize(1.2);
+  await settings.setModelLighting("model-id", {
+    exposure: 1.2,
+    environment_intensity: 0.35,
+  });
+  await settings.resetModelLighting("model-id");
   await settings.getMcpStatus();
   settings.setWindowTheme("light");
 
@@ -110,6 +115,15 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
     ["persona:settings-delete-model", "model-id"],
     ["persona:settings-set-default-model", "model-id"],
     ["persona:settings-set-character-size", 1.2],
+    [
+      "persona:settings-set-model-lighting",
+      "model-id",
+      {
+        exposure: 1.2,
+        environment_intensity: 0.35,
+      },
+    ],
+    ["persona:settings-reset-model-lighting", "model-id"],
     ["persona:settings-get-mcp-status"],
   ]);
   assert.deepEqual(sent, [

--- a/electron/settings-store.cjs
+++ b/electron/settings-store.cjs
@@ -32,6 +32,7 @@ function defaultState(packagedLibrary) {
     schema_version: SETTINGS_SCHEMA_VERSION,
     default_model_id: packagedLibrary.default_model_id,
     character_size: 1,
+    model_lighting: {},
     models: [],
     animations: [],
     animation_clips: {},
@@ -268,6 +269,10 @@ function safeReadState(settingsPath, packagedLibrary) {
           ? parsed.default_model_id
           : fallback.default_model_id,
       character_size: parsed.character_size,
+      model_lighting:
+        parsed.model_lighting && typeof parsed.model_lighting === "object"
+          ? parsed.model_lighting
+          : {},
       models: sanitizeModels(parsed.models),
       packaged_animation_overrides: overrides,
       hidden_packaged_animation_ids: hidden,
@@ -464,6 +469,7 @@ function createSettingsStore({
       packaged_animation_change_count: changedPackagedIds.size,
       models,
       animations: availableAnimations(),
+      model_lighting: state.model_lighting ?? {},
     };
   }
 
@@ -712,6 +718,66 @@ function createSettingsStore({
     return getSnapshot();
   }
 
+  function setModelLighting(modelId, lighting) {
+    if (typeof modelId !== "string" || modelId.trim() === "") {
+      throw new Error("modelId is required.");
+    }
+    if (!lighting || typeof lighting !== "object") {
+      throw new Error("lighting must be an object.");
+    }
+    const current = state.model_lighting[modelId] ?? {};
+    const merged = { ...current };
+    if (lighting.tone_mapping !== undefined) {
+      if (lighting.tone_mapping !== "none" && lighting.tone_mapping !== "aces") {
+        throw new Error("tone_mapping must be 'none' or 'aces'.");
+      }
+      merged.tone_mapping = lighting.tone_mapping;
+    }
+    if (lighting.exposure !== undefined) {
+      const v = Number(lighting.exposure);
+      if (!Number.isFinite(v) || v < 0.1 || v > 5) {
+        throw new Error("exposure must be between 0.1 and 5.");
+      }
+      merged.exposure = Math.round(v * 100) / 100;
+    }
+    if (lighting.environment_enabled !== undefined) {
+      merged.environment_enabled = Boolean(lighting.environment_enabled);
+    }
+    if (lighting.environment_intensity !== undefined) {
+      const v = Number(lighting.environment_intensity);
+      if (!Number.isFinite(v) || v < 0 || v > 5) {
+        throw new Error("environment_intensity must be between 0 and 5.");
+      }
+      merged.environment_intensity = Math.round(v * 100) / 100;
+    }
+    if (lighting.key_light_intensity !== undefined) {
+      const v = Number(lighting.key_light_intensity);
+      if (!Number.isFinite(v) || v < 0 || v > 10) {
+        throw new Error("key_light_intensity must be between 0 and 10.");
+      }
+      merged.key_light_intensity = Math.round(v * 100) / 100;
+    }
+    if (lighting.ambient_intensity !== undefined) {
+      const v = Number(lighting.ambient_intensity);
+      if (!Number.isFinite(v) || v < 0 || v > 10) {
+        throw new Error("ambient_intensity must be between 0 and 10.");
+      }
+      merged.ambient_intensity = Math.round(v * 100) / 100;
+    }
+    state.model_lighting[modelId] = merged;
+    writeState();
+    return getSnapshot();
+  }
+
+  function resetModelLighting(modelId) {
+    if (typeof modelId !== "string" || modelId.trim() === "") {
+      throw new Error("modelId is required.");
+    }
+    delete state.model_lighting[modelId];
+    writeState();
+    return getSnapshot();
+  }
+
   function getAnimation(animationName) {
     return (
       availableAnimations().find(
@@ -762,6 +828,8 @@ function createSettingsStore({
     resolveAssetRequest,
     setCharacterSize,
     setDefaultModel,
+    setModelLighting,
+    resetModelLighting,
     updateAnimation,
   };
 }

--- a/electron/settings-store.cjs
+++ b/electron/settings-store.cjs
@@ -26,6 +26,20 @@ const MAX_CUSTOM_ANIMATIONS = 100;
 const MAX_CUSTOM_ANIMATION_CLIPS = 300;
 const ASSET_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEFAULT_MODEL_LIGHTING = Object.freeze({
+  tone_mapping: "none",
+  exposure: 1,
+  environment_enabled: true,
+  environment_intensity: 1,
+  key_light_intensity: Math.PI,
+  ambient_intensity: Math.PI,
+});
+const MODEL_LIGHTING_RANGES = Object.freeze({
+  exposure: [0.1, 3],
+  environment_intensity: [0, 2],
+  key_light_intensity: [0, 4],
+  ambient_intensity: [0, 4],
+});
 
 function defaultState(packagedLibrary) {
   return {
@@ -126,6 +140,65 @@ function sanitizeModels(models) {
       return [];
     }
   });
+}
+
+function roundedLightingNumber(
+  value,
+  [minimum, maximum],
+  defaultValue = null,
+) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value < minimum ||
+    value > maximum
+  ) {
+    return null;
+  }
+  return value === defaultValue
+    ? defaultValue
+    : Math.round(value * 100) / 100;
+}
+
+function completeModelLighting(value) {
+  const source =
+    value != null && typeof value === "object" && !Array.isArray(value)
+      ? value
+      : {};
+  const lighting = { ...DEFAULT_MODEL_LIGHTING };
+  if (source.tone_mapping === "none" || source.tone_mapping === "aces") {
+    lighting.tone_mapping = source.tone_mapping;
+  }
+  if (typeof source.environment_enabled === "boolean") {
+    lighting.environment_enabled = source.environment_enabled;
+  }
+  for (const [field, range] of Object.entries(MODEL_LIGHTING_RANGES)) {
+    const normalized = roundedLightingNumber(
+      source[field],
+      range,
+      DEFAULT_MODEL_LIGHTING[field],
+    );
+    if (normalized != null) lighting[field] = normalized;
+  }
+  return lighting;
+}
+
+function sanitizeModelLighting(modelLighting, knownModelIds) {
+  if (
+    modelLighting == null ||
+    typeof modelLighting !== "object" ||
+    Array.isArray(modelLighting)
+  ) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(modelLighting)
+      .filter(([modelId]) => knownModelIds.has(modelId))
+      .map(([modelId, lighting]) => [
+        modelId,
+        completeModelLighting(lighting),
+      ]),
+  );
 }
 
 function sanitizeUserAnimations(animations) {
@@ -262,6 +335,11 @@ function safeReadState(settingsPath, packagedLibrary) {
       return { migrated: false, state: fallback };
     }
     const { hidden, overrides } = packagedUserLayers(parsed, packagedLibrary);
+    const models = sanitizeModels(parsed.models);
+    const knownModelIds = new Set([
+      ...packagedLibrary.models.map((model) => model.id),
+      ...models.map((model) => model.id),
+    ]);
     const common = {
       ...fallback,
       default_model_id:
@@ -269,11 +347,11 @@ function safeReadState(settingsPath, packagedLibrary) {
           ? parsed.default_model_id
           : fallback.default_model_id,
       character_size: parsed.character_size,
-      model_lighting:
-        parsed.model_lighting && typeof parsed.model_lighting === "object"
-          ? parsed.model_lighting
-          : {},
-      models: sanitizeModels(parsed.models),
+      model_lighting: sanitizeModelLighting(
+        parsed.model_lighting,
+        knownModelIds,
+      ),
+      models,
       packaged_animation_overrides: overrides,
       hidden_packaged_animation_ids: hidden,
     };
@@ -447,6 +525,7 @@ function createSettingsStore({
 
   function getSnapshot() {
     const models = availableModels();
+    const modelIds = new Set(models.map((model) => model.id));
     const defaultModel = models.some(
       (model) => model.id === state.default_model_id,
     )
@@ -469,7 +548,10 @@ function createSettingsStore({
       packaged_animation_change_count: changedPackagedIds.size,
       models,
       animations: availableAnimations(),
-      model_lighting: state.model_lighting ?? {},
+      model_lighting: sanitizeModelLighting(
+        state.model_lighting,
+        modelIds,
+      ),
     };
   }
 
@@ -689,6 +771,7 @@ function createSettingsStore({
       state.default_model_id =
         packagedLibrary.default_model_id ?? state.models[0]?.id ?? null;
     }
+    delete state.model_lighting[modelId];
     writeState();
     return getSnapshot();
   }
@@ -719,14 +802,17 @@ function createSettingsStore({
   }
 
   function setModelLighting(modelId, lighting) {
-    if (typeof modelId !== "string" || modelId.trim() === "") {
-      throw new Error("modelId is required.");
+    if (!availableModels().some((model) => model.id === modelId)) {
+      throw new Error("Selected model is not installed.");
     }
-    if (!lighting || typeof lighting !== "object") {
+    if (
+      !lighting ||
+      typeof lighting !== "object" ||
+      Array.isArray(lighting)
+    ) {
       throw new Error("lighting must be an object.");
     }
-    const current = state.model_lighting[modelId] ?? {};
-    const merged = { ...current };
+    const merged = completeModelLighting(state.model_lighting[modelId]);
     if (lighting.tone_mapping !== undefined) {
       if (lighting.tone_mapping !== "none" && lighting.tone_mapping !== "aces") {
         throw new Error("tone_mapping must be 'none' or 'aces'.");
@@ -734,35 +820,54 @@ function createSettingsStore({
       merged.tone_mapping = lighting.tone_mapping;
     }
     if (lighting.exposure !== undefined) {
-      const v = Number(lighting.exposure);
-      if (!Number.isFinite(v) || v < 0.1 || v > 5) {
-        throw new Error("exposure must be between 0.1 and 5.");
+      const value = roundedLightingNumber(
+        lighting.exposure,
+        MODEL_LIGHTING_RANGES.exposure,
+        DEFAULT_MODEL_LIGHTING.exposure,
+      );
+      if (value == null) {
+        throw new Error("exposure must be between 0.1 and 3.");
       }
-      merged.exposure = Math.round(v * 100) / 100;
+      merged.exposure = value;
     }
     if (lighting.environment_enabled !== undefined) {
-      merged.environment_enabled = Boolean(lighting.environment_enabled);
+      if (typeof lighting.environment_enabled !== "boolean") {
+        throw new Error("environment_enabled must be a boolean.");
+      }
+      merged.environment_enabled = lighting.environment_enabled;
     }
     if (lighting.environment_intensity !== undefined) {
-      const v = Number(lighting.environment_intensity);
-      if (!Number.isFinite(v) || v < 0 || v > 5) {
-        throw new Error("environment_intensity must be between 0 and 5.");
+      const value = roundedLightingNumber(
+        lighting.environment_intensity,
+        MODEL_LIGHTING_RANGES.environment_intensity,
+        DEFAULT_MODEL_LIGHTING.environment_intensity,
+      );
+      if (value == null) {
+        throw new Error("environment_intensity must be between 0 and 2.");
       }
-      merged.environment_intensity = Math.round(v * 100) / 100;
+      merged.environment_intensity = value;
     }
     if (lighting.key_light_intensity !== undefined) {
-      const v = Number(lighting.key_light_intensity);
-      if (!Number.isFinite(v) || v < 0 || v > 10) {
-        throw new Error("key_light_intensity must be between 0 and 10.");
+      const value = roundedLightingNumber(
+        lighting.key_light_intensity,
+        MODEL_LIGHTING_RANGES.key_light_intensity,
+        DEFAULT_MODEL_LIGHTING.key_light_intensity,
+      );
+      if (value == null) {
+        throw new Error("key_light_intensity must be between 0 and 4.");
       }
-      merged.key_light_intensity = Math.round(v * 100) / 100;
+      merged.key_light_intensity = value;
     }
     if (lighting.ambient_intensity !== undefined) {
-      const v = Number(lighting.ambient_intensity);
-      if (!Number.isFinite(v) || v < 0 || v > 10) {
-        throw new Error("ambient_intensity must be between 0 and 10.");
+      const value = roundedLightingNumber(
+        lighting.ambient_intensity,
+        MODEL_LIGHTING_RANGES.ambient_intensity,
+        DEFAULT_MODEL_LIGHTING.ambient_intensity,
+      );
+      if (value == null) {
+        throw new Error("ambient_intensity must be between 0 and 4.");
       }
-      merged.ambient_intensity = Math.round(v * 100) / 100;
+      merged.ambient_intensity = value;
     }
     state.model_lighting[modelId] = merged;
     writeState();
@@ -770,8 +875,8 @@ function createSettingsStore({
   }
 
   function resetModelLighting(modelId) {
-    if (typeof modelId !== "string" || modelId.trim() === "") {
-      throw new Error("modelId is required.");
+    if (!availableModels().some((model) => model.id === modelId)) {
+      throw new Error("Selected model is not installed.");
     }
     delete state.model_lighting[modelId];
     writeState();
@@ -836,6 +941,7 @@ function createSettingsStore({
 
 module.exports = {
   ANIMATION_NAME_PATTERN,
+  DEFAULT_MODEL_LIGHTING,
   DEFAULT_PACKAGED_LIBRARY_PATH,
   MAX_CHARACTER_SIZE,
   MIN_CHARACTER_SIZE,

--- a/electron/settings-store.test.cjs
+++ b/electron/settings-store.test.cjs
@@ -6,6 +6,7 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const {
+  DEFAULT_MODEL_LIGHTING,
   createSettingsStore,
   validateAnimationMetadata,
   validateGlbFile,
@@ -322,6 +323,118 @@ test("validates custom metadata, files, duplicates, and character size", (contex
     () => validateGlbFile(invalidModel, ".vrm"),
     /empty or invalid|glTF/,
   );
+});
+
+test("stores complete independent lighting profiles and enforces UI ranges", (context) => {
+  const { root, userDataPath } = fixture(context);
+  const packagedLibraryPath = writePackagedLibrary(root);
+  const sourceModel = path.join(root, "lighting-model.vrm");
+  writeGlb(sourceModel);
+  const store = createSettingsStore({ userDataPath, packagedLibraryPath });
+  let snapshot = store.importModel({
+    filePath: sourceModel,
+    model_name: "Lighting model",
+  });
+  const userModel = snapshot.models.find(
+    (model) => model.model_name === "Lighting model",
+  );
+  assert.ok(userModel);
+
+  snapshot = store.setModelLighting("configured-model", {
+    environment_intensity: 0.35,
+  });
+  assert.deepEqual(snapshot.model_lighting["configured-model"], {
+    ...DEFAULT_MODEL_LIGHTING,
+    environment_intensity: 0.35,
+  });
+
+  snapshot = store.setModelLighting(userModel.id, {
+    tone_mapping: "aces",
+    exposure: 1.4,
+  });
+  assert.deepEqual(snapshot.model_lighting[userModel.id], {
+    ...DEFAULT_MODEL_LIGHTING,
+    tone_mapping: "aces",
+    exposure: 1.4,
+  });
+  assert.equal(
+    snapshot.model_lighting["configured-model"].environment_intensity,
+    0.35,
+  );
+
+  for (const lighting of [
+    { exposure: 3.01 },
+    { environment_intensity: 2.01 },
+    { key_light_intensity: 4.01 },
+    { ambient_intensity: 4.01 },
+    { environment_enabled: "false" },
+  ]) {
+    assert.throws(
+      () => store.setModelLighting("configured-model", lighting),
+      /must be between|must be a boolean/,
+    );
+  }
+  assert.throws(
+    () => store.setModelLighting("missing-model", { exposure: 1 }),
+    /not installed/,
+  );
+
+  const reloadedStore = createSettingsStore({
+    userDataPath,
+    packagedLibraryPath,
+  });
+  const reloaded = reloadedStore.getSnapshot();
+  assert.deepEqual(
+    reloaded.model_lighting["configured-model"],
+    snapshot.model_lighting["configured-model"],
+  );
+  assert.deepEqual(
+    reloaded.model_lighting[userModel.id],
+    snapshot.model_lighting[userModel.id],
+  );
+
+  snapshot = reloadedStore.deleteModel(userModel.id);
+  assert.equal(snapshot.model_lighting[userModel.id], undefined);
+  snapshot = reloadedStore.resetModelLighting("configured-model");
+  assert.deepEqual(snapshot.model_lighting, {});
+});
+
+test("sanitizes partial and invalid lighting records loaded from disk", (context) => {
+  const { root, userDataPath } = fixture(context);
+  const packagedLibraryPath = writePackagedLibrary(root);
+  fs.mkdirSync(userDataPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDataPath, "settings.json"),
+    JSON.stringify({
+      schema_version: 3,
+      model_lighting: {
+        "configured-model": {
+          tone_mapping: "invalid",
+          exposure: 1.25,
+          environment_enabled: "true",
+          environment_intensity: 0.4,
+          key_light_intensity: 8,
+        },
+        "missing-model": {
+          exposure: 2,
+        },
+      },
+      models: [],
+      animations: [],
+    }),
+  );
+
+  const snapshot = createSettingsStore({
+    userDataPath,
+    packagedLibraryPath,
+  }).getSnapshot();
+  assert.deepEqual(snapshot.model_lighting, {
+    "configured-model": {
+      ...DEFAULT_MODEL_LIGHTING,
+      exposure: 1.25,
+      environment_intensity: 0.4,
+    },
+  });
 });
 
 test("migrates reserved legacy uploads into the permanent system actions", (context) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,7 @@ export function App() {
         animationUrls={animationUrls}
         audioLevel={audioLevel}
         characterSize={settings.character_size}
+        lighting={settings.model_lighting[defaultModel.id]}
         modelUrl={defaultModel.asset_url}
         onAnimationComplete={handleAnimationComplete}
         playback={bodyOverride ? 'once' : 'loop'}

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
-import { Canvas } from '@react-three/fiber';
-import { useThree } from '@react-three/fiber';
+import { Canvas, useThree } from '@react-three/fiber';
 import {
   ContactShadows,
   Environment,
@@ -11,6 +10,7 @@ import * as THREE from 'three';
 import { Avatar } from './Avatar';
 import type { PlayableAnimationType } from '../animation-catalog';
 import { calculateFullBodyFraming } from '../camera-framing';
+import { DEFAULT_LIGHTING } from '../settings-defaults';
 
 interface SceneProps {
   animation: PlayableAnimationType;
@@ -21,6 +21,7 @@ interface SceneProps {
   enablePan?: boolean;
   framingMargin?: number;
   groundShadow?: boolean;
+  lighting?: PersonaLightingSettings;
   modelUrl: string;
   onAnimationComplete: () => void;
   playback: 'loop' | 'once';
@@ -43,6 +44,40 @@ function supportsTarget(controls: unknown): controls is TargetControls {
   const candidate = controls as Partial<TargetControls>;
   return candidate.target instanceof THREE.Vector3 &&
     typeof candidate.update === 'function';
+}
+
+function LightingController({
+  lighting,
+}: {
+  lighting: PersonaLightingSettings;
+}) {
+  const gl = useThree((state) => state.gl);
+  const scene = useThree((state) => state.scene);
+
+  useLayoutEffect(() => {
+    // eslint-disable-next-line react-hooks/immutability
+    gl.toneMapping =
+      lighting.tone_mapping === 'aces'
+        ? THREE.ACESFilmicToneMapping
+        : THREE.NoToneMapping;
+    // eslint-disable-next-line react-hooks/immutability
+    gl.toneMappingExposure = lighting.exposure;
+    // eslint-disable-next-line react-hooks/immutability
+    gl.outputColorSpace = THREE.SRGBColorSpace;
+    // eslint-disable-next-line react-hooks/immutability
+    scene.environmentIntensity = lighting.environment_enabled
+      ? lighting.environment_intensity
+      : 0;
+  }, [
+    gl,
+    scene,
+    lighting.tone_mapping,
+    lighting.exposure,
+    lighting.environment_enabled,
+    lighting.environment_intensity,
+  ]);
+
+  return null;
 }
 
 function FullBodyCamera({
@@ -101,6 +136,7 @@ function FullBodyCamera({
 }
 
 export function Scene(props: SceneProps) {
+  const lighting = props.lighting ?? DEFAULT_LIGHTING;
   const [avatarScene, setAvatarScene] = useState<THREE.Object3D | null>(null);
   const [grounding, setGrounding] = useState<Grounding | null>(null);
   const handleAvatarReady = useCallback((scene: THREE.Object3D) => {
@@ -127,15 +163,19 @@ export function Scene(props: SceneProps) {
       gl={{
         antialias: true,
         alpha: true,
-        toneMapping: THREE.NoToneMapping,
+        toneMapping: lighting.tone_mapping === 'aces'
+          ? THREE.ACESFilmicToneMapping
+          : THREE.NoToneMapping,
+        toneMappingExposure: lighting.exposure,
         outputColorSpace: THREE.SRGBColorSpace,
       }}
       style={{ background: 'transparent' }}
     >
+      <LightingController lighting={lighting} />
       <directionalLight
         color={[1, 1, 1]}
         position={[-3, 3, 3]}
-        intensity={Math.PI}
+        intensity={lighting.key_light_intensity}
       />
       <ambientLight
         color={[
@@ -143,9 +183,11 @@ export function Scene(props: SceneProps) {
           0.0036765073221525194,
           0.0036765073221525194,
         ]}
-        intensity={Math.PI}
+        intensity={lighting.ambient_intensity}
       />
-      <Environment files={dawnEnvironment} />
+      {lighting.environment_enabled && (
+        <Environment files={dawnEnvironment} />
+      )}
       <FullBodyCamera
         characterSize={props.characterSize}
         framingMargin={props.framingMargin ?? 1.12}

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -10,7 +10,7 @@ import * as THREE from 'three';
 import { Avatar } from './Avatar';
 import type { PlayableAnimationType } from '../animation-catalog';
 import { calculateFullBodyFraming } from '../camera-framing';
-import { DEFAULT_LIGHTING } from '../settings-defaults';
+import { resolveLightingSettings } from '../settings-defaults';
 
 interface SceneProps {
   animation: PlayableAnimationType;
@@ -60,9 +60,7 @@ function LightingController({
       lighting.tone_mapping === 'aces'
         ? THREE.ACESFilmicToneMapping
         : THREE.NoToneMapping;
-    // eslint-disable-next-line react-hooks/immutability
     gl.toneMappingExposure = lighting.exposure;
-    // eslint-disable-next-line react-hooks/immutability
     gl.outputColorSpace = THREE.SRGBColorSpace;
     // eslint-disable-next-line react-hooks/immutability
     scene.environmentIntensity = lighting.environment_enabled
@@ -136,7 +134,7 @@ function FullBodyCamera({
 }
 
 export function Scene(props: SceneProps) {
-  const lighting = props.lighting ?? DEFAULT_LIGHTING;
+  const lighting = resolveLightingSettings(props.lighting);
   const [avatarScene, setAvatarScene] = useState<THREE.Object3D | null>(null);
   const [grounding, setGrounding] = useState<Grounding | null>(null);
   const handleAvatarReady = useCallback((scene: THREE.Object3D) => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -14,6 +14,7 @@ import {
 import {
   loadPackagedSettingsFallback,
   SETTINGS_FALLBACK,
+  DEFAULT_LIGHTING,
 } from '../settings-defaults';
 import {
   applyTheme,
@@ -536,6 +537,47 @@ export function SettingsPage() {
     await run(
       () => bridge.setCharacterSize(size),
       `Default character size set to ${Math.round(size * 100)}%.`,
+    );
+  };
+
+  const previewLighting: PersonaLightingSettings = useMemo(() => {
+    if (!selectedModel) return DEFAULT_LIGHTING;
+    return settings.model_lighting[selectedModel.id] ?? DEFAULT_LIGHTING;
+  }, [selectedModel, settings.model_lighting]);
+
+  const previewLightingField = (
+    field: keyof PersonaLightingSettings,
+    value: string | number | boolean,
+  ) => {
+    if (!selectedModel) return;
+    setSettings((current) => ({
+      ...current,
+      model_lighting: {
+        ...current.model_lighting,
+        [selectedModel.id]: {
+          ...previewLighting,
+          [field]: value,
+        },
+      },
+    }));
+  };
+
+  const saveLightingField = async (
+    field: keyof PersonaLightingSettings,
+    value: string | number | boolean,
+  ) => {
+    if (!bridge || !selectedModel) return;
+    await run(
+      () => bridge.setModelLighting(selectedModel.id, { [field]: value }),
+      'Lighting updated.',
+    );
+  };
+
+  const resetLighting = async () => {
+    if (!bridge || !selectedModel) return;
+    await run(
+      () => bridge.resetModelLighting(selectedModel.id),
+      'Lighting reset to Persona defaults.',
     );
   };
 
@@ -1172,6 +1214,182 @@ export function SettingsPage() {
                   <span>160%</span>
                 </div>
               </section>
+
+              <section className="settings-panel lighting-panel">
+                <div className="panel-heading">
+                  <div>
+                    <h2>Lighting</h2>
+                    <p>
+                      Adjust environment and key light for VRM models that look
+                      overexposed or too dark.
+                    </p>
+                  </div>
+                  <button
+                    className="lighting-reset-button"
+                    onClick={() => void resetLighting()}
+                    type="button"
+                  >
+                    Reset lighting
+                  </button>
+                </div>
+
+                <div className="lighting-select-row">
+                  <span>Tone mapping</span>
+                  <select
+                    onChange={(e) => {
+                      previewLightingField('tone_mapping', e.target.value);
+                      void saveLightingField('tone_mapping', e.target.value);
+                    }}
+                    value={previewLighting.tone_mapping}
+                  >
+                    <option value="none">None</option>
+                    <option value="aces">ACES Filmic</option>
+                  </select>
+                </div>
+
+                <div className="lighting-toggle-row">
+                  <span>HDR environment</span>
+                  <div
+                    className={`toggle-switch${previewLighting.environment_enabled ? ' active' : ''}`}
+                    onClick={() => {
+                      const next = !previewLighting.environment_enabled;
+                      previewLightingField('environment_enabled', next);
+                      void saveLightingField('environment_enabled', next);
+                    }}
+                    role="switch"
+                    aria-checked={previewLighting.environment_enabled}
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        const next = !previewLighting.environment_enabled;
+                        previewLightingField('environment_enabled', next);
+                        void saveLightingField('environment_enabled', next);
+                      }
+                    }}
+                  />
+                </div>
+
+                <div className="lighting-row">
+                  <label>
+                    <span>Environment intensity</span>
+                    <input
+                      max="2"
+                      min="0"
+                      onChange={(e) => previewLightingField('environment_intensity', Number(e.target.value))}
+                      onPointerUp={(e) => void saveLightingField('environment_intensity', Number((e.target as HTMLInputElement).value))}
+                      step="0.01"
+                      type="range"
+                      value={previewLighting.environment_intensity}
+                    />
+                    <div className="slider-labels">
+                      <span>0.00</span>
+                      <span>1.00</span>
+                      <span>2.00</span>
+                    </div>
+                  </label>
+                  <input
+                    className="lighting-value"
+                    max="2"
+                    min="0"
+                    onBlur={(e) => void saveLightingField('environment_intensity', Number(e.target.value))}
+                    onChange={(e) => previewLightingField('environment_intensity', Number(e.target.value))}
+                    step="0.01"
+                    type="number"
+                    value={previewLighting.environment_intensity}
+                  />
+                </div>
+
+                <div className="lighting-row">
+                  <label>
+                    <span>Key light intensity</span>
+                    <input
+                      max="4"
+                      min="0"
+                      onChange={(e) => previewLightingField('key_light_intensity', Number(e.target.value))}
+                      onPointerUp={(e) => void saveLightingField('key_light_intensity', Number((e.target as HTMLInputElement).value))}
+                      step="0.01"
+                      type="range"
+                      value={previewLighting.key_light_intensity}
+                    />
+                    <div className="slider-labels">
+                      <span>0.00</span>
+                      <span>{Math.PI.toFixed(2)}</span>
+                      <span>4.00</span>
+                    </div>
+                  </label>
+                  <input
+                    className="lighting-value"
+                    max="4"
+                    min="0"
+                    onBlur={(e) => void saveLightingField('key_light_intensity', Number(e.target.value))}
+                    onChange={(e) => previewLightingField('key_light_intensity', Number(e.target.value))}
+                    step="0.01"
+                    type="number"
+                    value={previewLighting.key_light_intensity}
+                  />
+                </div>
+
+                <div className="lighting-row">
+                  <label>
+                    <span>Ambient / fill intensity</span>
+                    <input
+                      max="4"
+                      min="0"
+                      onChange={(e) => previewLightingField('ambient_intensity', Number(e.target.value))}
+                      onPointerUp={(e) => void saveLightingField('ambient_intensity', Number((e.target as HTMLInputElement).value))}
+                      step="0.01"
+                      type="range"
+                      value={previewLighting.ambient_intensity}
+                    />
+                    <div className="slider-labels">
+                      <span>0.00</span>
+                      <span>{Math.PI.toFixed(2)}</span>
+                      <span>4.00</span>
+                    </div>
+                  </label>
+                  <input
+                    className="lighting-value"
+                    max="4"
+                    min="0"
+                    onBlur={(e) => void saveLightingField('ambient_intensity', Number(e.target.value))}
+                    onChange={(e) => previewLightingField('ambient_intensity', Number(e.target.value))}
+                    step="0.01"
+                    type="number"
+                    value={previewLighting.ambient_intensity}
+                  />
+                </div>
+
+                <div className="lighting-row">
+                  <label>
+                    <span>Exposure</span>
+                    <input
+                      max="3"
+                      min="0.1"
+                      onChange={(e) => previewLightingField('exposure', Number(e.target.value))}
+                      onPointerUp={(e) => void saveLightingField('exposure', Number((e.target as HTMLInputElement).value))}
+                      step="0.01"
+                      type="range"
+                      value={previewLighting.exposure}
+                    />
+                    <div className="slider-labels">
+                      <span>0.10</span>
+                      <span>1.00</span>
+                      <span>3.00</span>
+                    </div>
+                  </label>
+                  <input
+                    className="lighting-value"
+                    max="3"
+                    min="0.1"
+                    onBlur={(e) => void saveLightingField('exposure', Number(e.target.value))}
+                    onChange={(e) => previewLightingField('exposure', Number(e.target.value))}
+                    step="0.01"
+                    type="number"
+                    value={previewLighting.exposure}
+                  />
+                </div>
+              </section>
             </>
           )}
 
@@ -1398,6 +1616,7 @@ export function SettingsPage() {
                   animationUrls={previewAnimationUrls}
                   audioLevel={0}
                   characterSize={settings.character_size}
+                  lighting={previewLighting}
                   enablePan={false}
                   framingMargin={1.22}
                   groundShadow

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -14,7 +14,7 @@ import {
 import {
   loadPackagedSettingsFallback,
   SETTINGS_FALLBACK,
-  DEFAULT_LIGHTING,
+  resolveLightingSettings,
 } from '../settings-defaults';
 import {
   applyTheme,
@@ -26,6 +26,22 @@ import {
 } from '../theme';
 
 type SettingsSection = 'models' | 'animations' | 'appearance' | 'mcp';
+type LightingNumberField =
+  | 'exposure'
+  | 'environment_intensity'
+  | 'key_light_intensity'
+  | 'ambient_intensity';
+
+const LIGHTING_NUMBER_RANGES: Record<
+  LightingNumberField,
+  readonly [number, number]
+> = {
+  exposure: [0.1, 3],
+  environment_intensity: [0, 2],
+  key_light_intensity: [0, 4],
+  ambient_intensity: [0, 4],
+};
+
 interface ConfirmationRequest {
   confirmLabel: string;
   detail: string;
@@ -541,13 +557,16 @@ export function SettingsPage() {
   };
 
   const previewLighting: PersonaLightingSettings = useMemo(() => {
-    if (!selectedModel) return DEFAULT_LIGHTING;
-    return settings.model_lighting[selectedModel.id] ?? DEFAULT_LIGHTING;
+    return resolveLightingSettings(
+      selectedModel ? settings.model_lighting[selectedModel.id] : null,
+    );
   }, [selectedModel, settings.model_lighting]);
 
-  const previewLightingField = (
-    field: keyof PersonaLightingSettings,
-    value: string | number | boolean,
+  const previewLightingField = <
+    Field extends keyof PersonaLightingSettings,
+  >(
+    field: Field,
+    value: PersonaLightingSettings[Field],
   ) => {
     if (!selectedModel) return;
     setSettings((current) => ({
@@ -562,15 +581,58 @@ export function SettingsPage() {
     }));
   };
 
-  const saveLightingField = async (
-    field: keyof PersonaLightingSettings,
-    value: string | number | boolean,
+  const saveLightingField = async <
+    Field extends keyof PersonaLightingSettings,
+  >(
+    field: Field,
+    value: PersonaLightingSettings[Field],
   ) => {
     if (!bridge || !selectedModel) return;
-    await run(
-      () => bridge.setModelLighting(selectedModel.id, { [field]: value }),
+    const snapshot = await run(
+      () =>
+        bridge.setModelLighting(selectedModel.id, {
+          ...previewLighting,
+          [field]: value,
+        }),
       'Lighting updated.',
     );
+    if (snapshot) return;
+    try {
+      updateSnapshot(await bridge.get());
+    } catch {
+      // Keep the original validation error visible.
+    }
+  };
+
+  const lightingNumber = (
+    field: LightingNumberField,
+    input: HTMLInputElement,
+  ) => {
+    const value = input.valueAsNumber;
+    const [minimum, maximum] = LIGHTING_NUMBER_RANGES[field];
+    return Number.isFinite(value) && value >= minimum && value <= maximum
+      ? value
+      : null;
+  };
+
+  const previewLightingNumber = (
+    field: LightingNumberField,
+    input: HTMLInputElement,
+  ) => {
+    const value = lightingNumber(field, input);
+    if (value != null) previewLightingField(field, value);
+  };
+
+  const saveLightingNumber = (
+    field: LightingNumberField,
+    input: HTMLInputElement,
+  ) => {
+    const value = lightingNumber(field, input);
+    if (value == null) {
+      input.value = String(previewLighting[field]);
+      return;
+    }
+    void saveLightingField(field, value);
   };
 
   const resetLighting = async () => {
@@ -1226,6 +1288,7 @@ export function SettingsPage() {
                   </div>
                   <button
                     className="lighting-reset-button"
+                    disabled={busy || !bridge || !selectedModel}
                     onClick={() => void resetLighting()}
                     type="button"
                   >
@@ -1236,9 +1299,13 @@ export function SettingsPage() {
                 <div className="lighting-select-row">
                   <span>Tone mapping</span>
                   <select
+                    disabled={busy || !bridge || !selectedModel}
                     onChange={(e) => {
-                      previewLightingField('tone_mapping', e.target.value);
-                      void saveLightingField('tone_mapping', e.target.value);
+                      const value = e.currentTarget.value as
+                        | 'none'
+                        | 'aces';
+                      previewLightingField('tone_mapping', value);
+                      void saveLightingField('tone_mapping', value);
                     }}
                     value={previewLighting.tone_mapping}
                   >
@@ -1249,24 +1316,17 @@ export function SettingsPage() {
 
                 <div className="lighting-toggle-row">
                   <span>HDR environment</span>
-                  <div
+                  <button
+                    aria-checked={previewLighting.environment_enabled}
                     className={`toggle-switch${previewLighting.environment_enabled ? ' active' : ''}`}
+                    disabled={busy || !bridge || !selectedModel}
                     onClick={() => {
                       const next = !previewLighting.environment_enabled;
                       previewLightingField('environment_enabled', next);
                       void saveLightingField('environment_enabled', next);
                     }}
                     role="switch"
-                    aria-checked={previewLighting.environment_enabled}
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        const next = !previewLighting.environment_enabled;
-                        previewLightingField('environment_enabled', next);
-                        void saveLightingField('environment_enabled', next);
-                      }
-                    }}
+                    type="button"
                   />
                 </div>
 
@@ -1274,10 +1334,27 @@ export function SettingsPage() {
                   <label>
                     <span>Environment intensity</span>
                     <input
+                      disabled={busy || !bridge || !selectedModel}
                       max="2"
                       min="0"
-                      onChange={(e) => previewLightingField('environment_intensity', Number(e.target.value))}
-                      onPointerUp={(e) => void saveLightingField('environment_intensity', Number((e.target as HTMLInputElement).value))}
+                      onChange={(event) =>
+                        previewLightingNumber(
+                          'environment_intensity',
+                          event.currentTarget,
+                        )
+                      }
+                      onKeyUp={(event) =>
+                        saveLightingNumber(
+                          'environment_intensity',
+                          event.currentTarget,
+                        )
+                      }
+                      onPointerUp={(event) =>
+                        saveLightingNumber(
+                          'environment_intensity',
+                          event.currentTarget,
+                        )
+                      }
                       step="0.01"
                       type="range"
                       value={previewLighting.environment_intensity}
@@ -1290,10 +1367,24 @@ export function SettingsPage() {
                   </label>
                   <input
                     className="lighting-value"
+                    disabled={busy || !bridge || !selectedModel}
                     max="2"
                     min="0"
-                    onBlur={(e) => void saveLightingField('environment_intensity', Number(e.target.value))}
-                    onChange={(e) => previewLightingField('environment_intensity', Number(e.target.value))}
+                    onBlur={(event) =>
+                      saveLightingNumber(
+                        'environment_intensity',
+                        event.currentTarget,
+                      )
+                    }
+                    onChange={(event) =>
+                      previewLightingNumber(
+                        'environment_intensity',
+                        event.currentTarget,
+                      )
+                    }
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') event.currentTarget.blur();
+                    }}
                     step="0.01"
                     type="number"
                     value={previewLighting.environment_intensity}
@@ -1304,10 +1395,27 @@ export function SettingsPage() {
                   <label>
                     <span>Key light intensity</span>
                     <input
+                      disabled={busy || !bridge || !selectedModel}
                       max="4"
                       min="0"
-                      onChange={(e) => previewLightingField('key_light_intensity', Number(e.target.value))}
-                      onPointerUp={(e) => void saveLightingField('key_light_intensity', Number((e.target as HTMLInputElement).value))}
+                      onChange={(event) =>
+                        previewLightingNumber(
+                          'key_light_intensity',
+                          event.currentTarget,
+                        )
+                      }
+                      onKeyUp={(event) =>
+                        saveLightingNumber(
+                          'key_light_intensity',
+                          event.currentTarget,
+                        )
+                      }
+                      onPointerUp={(event) =>
+                        saveLightingNumber(
+                          'key_light_intensity',
+                          event.currentTarget,
+                        )
+                      }
                       step="0.01"
                       type="range"
                       value={previewLighting.key_light_intensity}
@@ -1320,10 +1428,24 @@ export function SettingsPage() {
                   </label>
                   <input
                     className="lighting-value"
+                    disabled={busy || !bridge || !selectedModel}
                     max="4"
                     min="0"
-                    onBlur={(e) => void saveLightingField('key_light_intensity', Number(e.target.value))}
-                    onChange={(e) => previewLightingField('key_light_intensity', Number(e.target.value))}
+                    onBlur={(event) =>
+                      saveLightingNumber(
+                        'key_light_intensity',
+                        event.currentTarget,
+                      )
+                    }
+                    onChange={(event) =>
+                      previewLightingNumber(
+                        'key_light_intensity',
+                        event.currentTarget,
+                      )
+                    }
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') event.currentTarget.blur();
+                    }}
                     step="0.01"
                     type="number"
                     value={previewLighting.key_light_intensity}
@@ -1334,10 +1456,27 @@ export function SettingsPage() {
                   <label>
                     <span>Ambient / fill intensity</span>
                     <input
+                      disabled={busy || !bridge || !selectedModel}
                       max="4"
                       min="0"
-                      onChange={(e) => previewLightingField('ambient_intensity', Number(e.target.value))}
-                      onPointerUp={(e) => void saveLightingField('ambient_intensity', Number((e.target as HTMLInputElement).value))}
+                      onChange={(event) =>
+                        previewLightingNumber(
+                          'ambient_intensity',
+                          event.currentTarget,
+                        )
+                      }
+                      onKeyUp={(event) =>
+                        saveLightingNumber(
+                          'ambient_intensity',
+                          event.currentTarget,
+                        )
+                      }
+                      onPointerUp={(event) =>
+                        saveLightingNumber(
+                          'ambient_intensity',
+                          event.currentTarget,
+                        )
+                      }
                       step="0.01"
                       type="range"
                       value={previewLighting.ambient_intensity}
@@ -1350,10 +1489,24 @@ export function SettingsPage() {
                   </label>
                   <input
                     className="lighting-value"
+                    disabled={busy || !bridge || !selectedModel}
                     max="4"
                     min="0"
-                    onBlur={(e) => void saveLightingField('ambient_intensity', Number(e.target.value))}
-                    onChange={(e) => previewLightingField('ambient_intensity', Number(e.target.value))}
+                    onBlur={(event) =>
+                      saveLightingNumber(
+                        'ambient_intensity',
+                        event.currentTarget,
+                      )
+                    }
+                    onChange={(event) =>
+                      previewLightingNumber(
+                        'ambient_intensity',
+                        event.currentTarget,
+                      )
+                    }
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') event.currentTarget.blur();
+                    }}
                     step="0.01"
                     type="number"
                     value={previewLighting.ambient_intensity}
@@ -1364,10 +1517,27 @@ export function SettingsPage() {
                   <label>
                     <span>Exposure</span>
                     <input
+                      disabled={busy || !bridge || !selectedModel}
                       max="3"
                       min="0.1"
-                      onChange={(e) => previewLightingField('exposure', Number(e.target.value))}
-                      onPointerUp={(e) => void saveLightingField('exposure', Number((e.target as HTMLInputElement).value))}
+                      onChange={(event) =>
+                        previewLightingNumber(
+                          'exposure',
+                          event.currentTarget,
+                        )
+                      }
+                      onKeyUp={(event) =>
+                        saveLightingNumber(
+                          'exposure',
+                          event.currentTarget,
+                        )
+                      }
+                      onPointerUp={(event) =>
+                        saveLightingNumber(
+                          'exposure',
+                          event.currentTarget,
+                        )
+                      }
                       step="0.01"
                       type="range"
                       value={previewLighting.exposure}
@@ -1380,10 +1550,18 @@ export function SettingsPage() {
                   </label>
                   <input
                     className="lighting-value"
+                    disabled={busy || !bridge || !selectedModel}
                     max="3"
                     min="0.1"
-                    onBlur={(e) => void saveLightingField('exposure', Number(e.target.value))}
-                    onChange={(e) => previewLightingField('exposure', Number(e.target.value))}
+                    onBlur={(event) =>
+                      saveLightingNumber('exposure', event.currentTarget)
+                    }
+                    onChange={(event) =>
+                      previewLightingNumber('exposure', event.currentTarget)
+                    }
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') event.currentTarget.blur();
+                    }}
                     step="0.01"
                     type="number"
                     value={previewLighting.exposure}

--- a/src/settings-defaults.test.ts
+++ b/src/settings-defaults.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_LIGHTING,
+  resolveLightingSettings,
+} from './settings-defaults';
+
+describe('lighting settings', () => {
+  it('fills every default when a stored model profile is partial', () => {
+    expect(
+      resolveLightingSettings({
+        environment_intensity: 0.35,
+        exposure: undefined,
+      }),
+    ).toEqual({
+      ...DEFAULT_LIGHTING,
+      environment_intensity: 0.35,
+    });
+  });
+
+  it('returns an independent default profile when no override exists', () => {
+    const resolved = resolveLightingSettings();
+
+    expect(resolved).toEqual(DEFAULT_LIGHTING);
+    expect(resolved).not.toBe(DEFAULT_LIGHTING);
+  });
+});

--- a/src/settings-defaults.ts
+++ b/src/settings-defaults.ts
@@ -50,6 +50,15 @@ const SYSTEM_ACTIONS: PersonaAnimationSettings[] = [
   },
 ];
 
+export const DEFAULT_LIGHTING: PersonaLightingSettings = {
+  tone_mapping: 'none',
+  exposure: 1,
+  environment_enabled: true,
+  environment_intensity: 1,
+  key_light_intensity: Math.PI,
+  ambient_intensity: Math.PI,
+};
+
 export const SETTINGS_FALLBACK: PersonaSettingsSnapshot = {
   schema_version: 3,
   default_model_id: null,
@@ -57,6 +66,7 @@ export const SETTINGS_FALLBACK: PersonaSettingsSnapshot = {
   packaged_animation_change_count: 0,
   models: [],
   animations: SYSTEM_ACTIONS,
+  model_lighting: {},
 };
 
 function packagedAssetUrl(relativePath: string): string {

--- a/src/settings-defaults.ts
+++ b/src/settings-defaults.ts
@@ -59,6 +59,28 @@ export const DEFAULT_LIGHTING: PersonaLightingSettings = {
   ambient_intensity: Math.PI,
 };
 
+export function resolveLightingSettings(
+  lighting?: Partial<PersonaLightingSettings> | null,
+): PersonaLightingSettings {
+  return {
+    tone_mapping:
+      lighting?.tone_mapping ?? DEFAULT_LIGHTING.tone_mapping,
+    exposure: lighting?.exposure ?? DEFAULT_LIGHTING.exposure,
+    environment_enabled:
+      lighting?.environment_enabled ??
+      DEFAULT_LIGHTING.environment_enabled,
+    environment_intensity:
+      lighting?.environment_intensity ??
+      DEFAULT_LIGHTING.environment_intensity,
+    key_light_intensity:
+      lighting?.key_light_intensity ??
+      DEFAULT_LIGHTING.key_light_intensity,
+    ambient_intensity:
+      lighting?.ambient_intensity ??
+      DEFAULT_LIGHTING.ambient_intensity,
+  };
+}
+
 export const SETTINGS_FALLBACK: PersonaSettingsSnapshot = {
   schema_version: 3,
   default_model_id: null,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1396,6 +1396,130 @@ button {
   font-variant-numeric: tabular-nums;
 }
 
+/* --- Lighting controls -------------------------------------------------- */
+
+.lighting-panel {
+  padding-bottom: 25px;
+}
+
+.lighting-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.lighting-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.lighting-row label > span {
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+
+.lighting-row input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.lighting-value {
+  min-width: 56px;
+  text-align: right;
+  font-size: var(--fs-md);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 4px 8px;
+}
+
+.lighting-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.lighting-toggle-row > span {
+  font-size: var(--fs-md);
+  color: var(--text-secondary);
+}
+
+.toggle-switch {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  cursor: pointer;
+  transition: background var(--dur) var(--ease);
+}
+
+.toggle-switch.active {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.toggle-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--text-primary);
+  border-radius: 50%;
+  transition: transform var(--dur) var(--ease);
+}
+
+.toggle-switch.active::after {
+  transform: translateX(18px);
+}
+
+.lighting-select-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.lighting-select-row > span {
+  font-size: var(--fs-md);
+  color: var(--text-secondary);
+}
+
+.lighting-select-row select {
+  background: var(--bg-inset);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 4px 8px;
+  font-size: var(--fs-md);
+}
+
+.lighting-reset-button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-tertiary);
+  border-radius: var(--r-md);
+  padding: 5px 12px;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+
+.lighting-reset-button:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
 /* --- MCP ---------------------------------------------------------------- */
 
 .mcp-health-badge {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1455,6 +1455,7 @@ button {
   position: relative;
   width: 40px;
   height: 22px;
+  padding: 0;
   background: var(--bg-raised);
   border: 1px solid var(--border);
   border-radius: var(--r-full);
@@ -1481,6 +1482,11 @@ button {
 
 .toggle-switch.active::after {
   transform: translateX(18px);
+}
+
+.toggle-switch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .lighting-select-row {
@@ -1515,9 +1521,14 @@ button {
   transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease);
 }
 
-.lighting-reset-button:hover {
+.lighting-reset-button:hover:not(:disabled) {
   border-color: var(--accent);
   color: var(--text-primary);
+}
+
+.lighting-panel :is(button, input, select):disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 /* --- MCP ---------------------------------------------------------------- */

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -21,6 +21,15 @@ interface AudioListenerStatus {
   source: string | null;
 }
 
+interface PersonaLightingSettings {
+  tone_mapping: 'none' | 'aces';
+  exposure: number;
+  environment_enabled: boolean;
+  environment_intensity: number;
+  key_light_intensity: number;
+  ambient_intensity: number;
+}
+
 type PersonaAnimationType =
   | 'IDLE'
   | 'GREETING'
@@ -67,6 +76,7 @@ interface PersonaSettingsSnapshot {
   packaged_animation_change_count: number;
   models: PersonaModelSettings[];
   animations: PersonaAnimationSettings[];
+  model_lighting: Record<string, PersonaLightingSettings>;
 }
 
 interface PersonaMcpStatus {
@@ -133,6 +143,11 @@ interface Window {
     deleteModel(modelId: string): Promise<PersonaSettingsSnapshot>;
     setDefaultModel(modelId: string): Promise<PersonaSettingsSnapshot>;
     setCharacterSize(size: number): Promise<PersonaSettingsSnapshot>;
+    setModelLighting(
+      modelId: string,
+      lighting: Partial<PersonaLightingSettings>,
+    ): Promise<PersonaSettingsSnapshot>;
+    resetModelLighting(modelId: string): Promise<PersonaSettingsSnapshot>;
     getMcpStatus(): Promise<PersonaMcpStatus>;
     setWindowTheme(theme: 'light' | 'dark'): void;
     subscribe(


### PR DESCRIPTION
Closes #8

## What

Adds a **Lighting** section under **Settings → Appearance** with per-model controls:

- **Tone mapping** — None / ACES Filmic dropdown
- **Exposure** — slider + editable numeric input (0.1–3.0)
- **HDR environment** — toggle on/off
- **Environment intensity** — slider + numeric input (0–2.0)
- **Key-light intensity** — slider + numeric input (0–4.0)
- **Ambient/fill intensity** — slider + numeric input (0–4.0)
- **Reset lighting** — removes the per-model override, restoring Persona defaults

## Behaviour

- Changes update both the Settings preview and the live avatar window immediately
- Lighting preferences are stored per model (`model_lighting` map in settings)
- Switching models restores that model's saved lighting configuration
- Models without custom lighting use Persona's existing defaults (NoToneMapping, π-intensity lights, dawn HDR at 1.0)
- Reset removes the model override and restores defaults
- Existing users retain the current visual appearance until they change a lighting setting
- Renderer output color space stays fixed to sRGB

## Architecture

- `PersonaLightingSettings` type in `vite-env.d.ts`
- `DEFAULT_LIGHTING` constant in `settings-defaults.ts`
- `setModelLighting` / `resetModelLighting` in `settings-store.cjs` with validation
- IPC bridges in `preload.cjs` + handlers in `main.cjs`
- `LightingController` component in `Scene.tsx` applies tone mapping + exposure + environment intensity to the Three.js renderer via `useLayoutEffect`
- Lighting UI in `SettingsPage.tsx` Appearance tab with sliders, numeric inputs, toggle, and select
- CSS uses ZERO's existing design tokens (`--accent`, `--bg-inset`, `--border`, `--r-sm`, etc.)

## Verified

- `npm run check` green (eslint, 71 node tests, 13 vitest, assets, 0 prod vulns, build)
- Settings UI renders correctly on macOS (screenshot verified)
- Coexists with ZERO's theme panel (#5) without conflict
- Per-model storage confirmed via settings-store tests

## Screenshots

Appearance tab with lighting controls visible below the character size slider.
Tone mapping dropdown, HDR environment toggle (active/purple), environment intensity
slider at 1.00 with editable numeric input, and key light / ambient / exposure
sliders below the fold.