### PR TITLE
feat: add configurable voice source for local voice apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Persona's first beta is under active development.
 
 - Realtime character animation and amplitude-driven lip sync.
 - PipeWire, WASAPI process-loopback, and Core Audio process-tap listeners.
+- Configurable voice source in Settings, with shared process matching on Linux,
+  macOS, and Windows for ChatGPT/Codex or a custom local voice app pattern.
 - Transparent desktop presence with manual lifecycle, tray controls, shortcut,
   URL protocol, always-on-top behavior, zoom, orbit, and pan.
 - Short-silence speech holding and smooth animation crossfades.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ npm start -- --background
 
 ## Customize Persona
 
-Open **Settings…** from Persona's tray menu to manage the character library.
-You can preview installed models and animation actions together, choose the
-default model, set the character's initial size, and add your own `.vrm` and
-`.vrma` files.
+Open **Settings…** from Persona's tray menu to manage the character library,
+choose the voice audio source, and register MCP. You can preview installed
+models and animation actions together, choose the default model, set the
+character's initial size, and add your own `.vrm` and `.vrma` files.
 
 Until a default model exists, Persona does not create the avatar window or
 start its voice-output listener. The first imported model becomes the default
@@ -112,6 +112,14 @@ New Codex sessions can then ask Persona to play an installed animation, show or
 hide its window, and report whether the local character and voice listener are
 active. Persona remains a separate desktop application; the MCP connection
 only exposes its own visual controls.
+
+## Local voice apps
+
+Persona does not run language models. To use it with a local model stack, open
+**Settings → Voice** and point the automatic listener at the app that plays
+assistant audio, or drive lip sync from your pipeline through the loopback HTTP
+API and `persona://` URLs. Any compatible MCP client can use the same animation
+tools as Codex. See [Integrations](docs/INTEGRATIONS.md).
 
 The window intentionally contains no controls:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,12 +49,12 @@ Speaking cannot be edited or removed, but users can add or remove their local
 clips.
 
 The store returns one active snapshot containing the default model, character
-size, merged model records, and merged action records with clip collections.
-Only actions with at least one playable clip appear in the MCP tool description
-and animation listing. Catalog changes refresh connected MCP sessions
-immediately, while every animation request is validated against the current
-store snapshot. Keep the catalog, store, MCP, and asset-contract tests in sync
-when adding fields or changing validation.
+size, merged model records, merged action records with clip collections, and the
+configured voice source. Only actions with at least one playable clip appear in
+the MCP tool description and animation listing. Catalog changes refresh
+connected MCP sessions immediately, while every animation request is validated
+against the current store snapshot. Keep the catalog, store, MCP, and
+asset-contract tests in sync when adding fields or changing validation.
 
 An empty packaged catalog is a supported first-run state. The application opens
 Settings and does not create the avatar window or start the audio listener until
@@ -100,6 +100,13 @@ All operating systems implement:
 level immediately. The body remains in its talking motion for 900 ms of silence
 before returning to listening, preventing sentence gaps from causing abrupt
 animation changes.
+
+Target process matching is shared through `electron/voice-source.cjs`. Settings
+stores a default ChatGPT/Codex mode or a custom regex; `PERSONA_TARGET_PROCESS_PATTERN`
+overrides that value when set. Linux PipeWire identity matching and
+macOS/Windows process discovery both consume the resolved pattern so a Voice
+source change behaves the same on every platform. Changing the setting recreates
+the active listener immediately.
 
 Linux implements the contract directly with PipeWire commands. macOS and
 Windows helpers write newline-delimited JSON to stdout:

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -58,12 +58,15 @@ The MCP endpoint uses the same port as the local HTTP API. If
 
 ## Automatic listeners
 
+Listeners attach to the configured voice source (ChatGPT/Codex by default, or a
+custom process pattern from Settings / `PERSONA_TARGET_PROCESS_PATTERN`).
+
 ### Linux
 
-Persona polls the PipeWire graph for a Codex or ChatGPT playback node. It
-attaches `pw-record` to that one stream, calculates RMS amplitude in memory, and
-discards every sample after calculation. The stream remains connected to its
-normal output device.
+Persona polls the PipeWire graph for a playback node that matches the configured
+voice-source pattern. It attaches `pw-record` to that one stream, calculates RMS
+amplitude in memory, and discards every sample after calculation. The stream
+remains connected to its normal output device.
 
 ### Windows
 
@@ -78,11 +81,42 @@ aggregate device for the selected voice process. Persona supports macOS 14.2
 and newer and declares why it requests System Audio Recording permission.
 
 Set `PERSONA_TARGET_PROCESS_PATTERN` to a case-insensitive regular expression
-to target another desktop voice application:
+to target another desktop voice application. This environment variable overrides
+the Voice source chosen in Settings:
 
 ```bash
 PERSONA_TARGET_PROCESS_PATTERN='my-voice-app' persona
 ```
+
+## Voice source settings
+
+Open **Settings → Voice** to choose which application Persona watches for
+automatic lip sync:
+
+- **ChatGPT / Codex** keeps the built-in matcher used by default.
+- **Custom pattern** accepts a case-insensitive regular expression matched
+  against process names and command lines on macOS and Windows, and against
+  PipeWire application identity (plus process ancestry) on Linux.
+
+Persona still calculates only an in-memory output level. It does not capture the
+microphone, run language models, transcribe speech, or send audio over the
+network.
+
+## Local models and voice pipelines
+
+Persona is a visual companion for voice experiences. Local models such as Qwen
+or GPT-OSS run in your own agent or inference stack; Persona animates beside
+them. Three supported shapes:
+
+1. **Process listen.** Point Settings → Voice at the desktop app that plays
+   assistant audio (for example a local TTS player or voice UI). Persona
+   attaches to that process the same way it attaches to ChatGPT or Codex.
+2. **Loopback events.** Have your pipeline POST normalized state and levels to
+   `http://127.0.0.1:47831/events`, or open `persona://speaking?level=…` URLs,
+   when speech starts and ends.
+3. **MCP actions.** Register any compatible MCP client against
+   `http://127.0.0.1:47831/mcp` so the agent can trigger configured animations
+   and window controls while audio still comes from (1) or (2).
 
 ## URL protocol
 

--- a/electron/linux-pipewire-listener.cjs
+++ b/electron/linux-pipewire-listener.cjs
@@ -4,11 +4,11 @@ const { execFile, spawn } = require("node:child_process");
 const fs = require("node:fs");
 const { promisify } = require("node:util");
 const { AudioActivityGate, DEFAULT_SPEECH_RELEASE_MS } = require("./audio-activity-gate.cjs");
+const { DEFAULT_VOICE_APP_PATTERN } = require("./voice-source.cjs");
 
 const execFileAsync = promisify(execFile);
 const SPEECH_RELEASE_MS = DEFAULT_SPEECH_RELEASE_MS;
-const CODEX_IDENTITY =
-  /(?:^|[\s./=_-])(?:codex(?:-desktop)?|openai(?:-codex)?|chatgpt)(?:$|[\s./=_-])/i;
+const CODEX_IDENTITY = DEFAULT_VOICE_APP_PATTERN;
 
 function nodeProperties(node) {
   return node?.info?.props ?? {};
@@ -74,7 +74,16 @@ function readProcessInfo(processId) {
   };
 }
 
-function isCodexProcessTree(processId, processReader = readProcessInfo) {
+function identityMatchesPattern(identity, pattern = DEFAULT_VOICE_APP_PATTERN) {
+  pattern.lastIndex = 0;
+  return pattern.test(identity);
+}
+
+function isCodexProcessTree(
+  processId,
+  processReader = readProcessInfo,
+  pattern = DEFAULT_VOICE_APP_PATTERN,
+) {
   let currentId = Number(processId);
   const visited = new Set();
   for (let depth = 0; depth < 10; depth += 1) {
@@ -82,7 +91,7 @@ function isCodexProcessTree(processId, processReader = readProcessInfo) {
     visited.add(currentId);
     try {
       const process = processReader(currentId);
-      if (CODEX_IDENTITY.test(process.identity)) return true;
+      if (identityMatchesPattern(process.identity, pattern)) return true;
       currentId = Number(process.parentId);
     } catch {
       return false;
@@ -91,7 +100,11 @@ function isCodexProcessTree(processId, processReader = readProcessInfo) {
   return false;
 }
 
-function isCodexOutputNode(node, processMatcher = isCodexProcessTree) {
+function isCodexOutputNode(
+  node,
+  processMatcher = null,
+  pattern = DEFAULT_VOICE_APP_PATTERN,
+) {
   if (node?.type !== "PipeWire:Interface:Node") return false;
   const properties = nodeProperties(node);
   if (properties["media.class"] !== "Stream/Output/Audio") return false;
@@ -104,20 +117,32 @@ function isCodexOutputNode(node, processMatcher = isCodexProcessTree) {
   ]
     .filter((value) => value != null)
     .join(" ");
-  if (CODEX_IDENTITY.test(identity)) return true;
+  if (identityMatchesPattern(identity, pattern)) return true;
 
   const processId = properties["application.process.id"];
-  return processId != null && processMatcher(processId);
+  const matcher =
+    processMatcher ??
+    ((candidateId) => isCodexProcessTree(candidateId, readProcessInfo, pattern));
+  return processId != null && matcher(processId);
 }
 
-function findCodexOutputNode(nodes, processMatcher = isCodexProcessTree) {
+function findCodexOutputNode(
+  nodes,
+  processMatcher = null,
+  pattern = DEFAULT_VOICE_APP_PATTERN,
+) {
   const processCache = new Map();
+  const matcher =
+    processMatcher ??
+    ((processId) => isCodexProcessTree(processId, readProcessInfo, pattern));
   const cachedMatcher = (processId) => {
     const key = String(processId);
-    if (!processCache.has(key)) processCache.set(key, processMatcher(processId));
+    if (!processCache.has(key)) processCache.set(key, matcher(processId));
     return processCache.get(key);
   };
-  const matches = nodes.filter((node) => isCodexOutputNode(node, cachedMatcher));
+  const matches = nodes.filter((node) =>
+    isCodexOutputNode(node, cachedMatcher, pattern),
+  );
   return (
     matches.find((node) => node.info?.state === "running") ??
     matches.find((node) => node.info?.state === "idle") ??
@@ -149,7 +174,7 @@ function displayName(node) {
     properties["application.name"] ??
     properties["node.description"] ??
     properties["node.name"] ??
-    "Codex"
+    "Voice app"
   );
 }
 
@@ -162,6 +187,7 @@ class LinuxPipeWireListener {
     onStatus = () => {},
     pollIntervalMs = 750,
     speechReleaseMs = SPEECH_RELEASE_MS,
+    processPattern = DEFAULT_VOICE_APP_PATTERN,
   } = {}) {
     this.onActivity = onActivity;
     this.onDebug = onDebug;
@@ -170,6 +196,7 @@ class LinuxPipeWireListener {
     this.onStatus = onStatus;
     this.pollIntervalMs = pollIntervalMs;
     this.speechReleaseMs = speechReleaseMs;
+    this.processPattern = processPattern ?? DEFAULT_VOICE_APP_PATTERN;
     this.capture = null;
     this.captureSerial = null;
     this.currentNode = null;
@@ -230,7 +257,9 @@ class LinuxPipeWireListener {
               binary: properties["application.process.binary"] ?? null,
               node: properties["node.name"] ?? null,
               processId,
-              processTreeMatches: processId != null && isCodexProcessTree(processId),
+              processTreeMatches:
+                processId != null &&
+                isCodexProcessTree(processId, readProcessInfo, this.processPattern),
               state: candidate.info?.state ?? null,
             };
           });
@@ -240,7 +269,7 @@ class LinuxPipeWireListener {
           this.onDebug(outputNodes);
         }
       }
-      const node = findCodexOutputNode(nodes);
+      const node = findCodexOutputNode(nodes, null, this.processPattern);
       if (node == null) {
         this.detach();
         return;

--- a/electron/linux-pipewire-listener.test.cjs
+++ b/electron/linux-pipewire-listener.test.cjs
@@ -117,6 +117,19 @@ test("calculates and normalizes signed 16-bit PCM amplitude", () => {
   assert.equal(normalizeRms(1), 1);
 });
 
+test("matches a custom process pattern for local voice apps", () => {
+  const localApp = pipeWireNode(50, {
+    "application.name": "Local TTS",
+    "application.process.binary": "local-tts",
+    "media.class": "Stream/Output/Audio",
+    "object.serial": 150,
+  }, "running");
+  const pattern = /local-tts/i;
+  assert.equal(isCodexOutputNode(localApp, null, pattern), true);
+  assert.equal(isCodexOutputNode(localApp), false);
+  assert.equal(findCodexOutputNode([localApp], null, pattern), localApp);
+});
+
 test("does not emit duplicate listener status updates", () => {
   const updates = [];
   const listener = new LinuxPipeWireListener({

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -33,6 +33,10 @@ const { parseProtocolUrl, voiceState } = require("./protocol-actions.cjs");
 const {
   createSettingsWindowPresentationGate,
 } = require("./settings-window-presentation.cjs");
+const {
+  resolveVoiceSourcePattern,
+  settingsPatternFromVoiceSource,
+} = require("./voice-source.cjs");
 
 const WINDOW_WIDTH = 430;
 const WINDOW_HEIGHT = 680;
@@ -408,6 +412,49 @@ function publishSettings(snapshot) {
   return snapshot;
 }
 
+function resolveListenerProcessPattern(snapshot = settingsStore?.getSnapshot()) {
+  return resolveVoiceSourcePattern({
+    environment: process.env,
+    settingsPattern: settingsPatternFromVoiceSource(snapshot?.voice_source),
+  });
+}
+
+function createConfiguredAudioListener() {
+  return createAudioListener({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    processPattern: resolveListenerProcessPattern(),
+    onActivity: (activity) => {
+      debugLog("listener activity", activity);
+      handleBridgeEvent(voiceState(activity));
+    },
+    onDebug: debugEnabled ? (nodes) => debugLog("listener output nodes", nodes) : null,
+    onLevel: (level) => handleBridgeEvent({ type: "audio-level", level }),
+    onSession: (active) => {
+      debugLog("listener session", active);
+      handleBridgeEvent(voiceState(active ? "listening" : "idle", active ? "active" : "inactive"));
+    },
+    onStatus: (status) => {
+      debugLog("listener status", status);
+      handleListenerStatus(status);
+    },
+  });
+}
+
+function restartAudioListener() {
+  audioListener?.stop();
+  audioListener = createConfiguredAudioListener();
+  if (audioListener && modelConfigured) void audioListener.start();
+  if (!audioListener) {
+    handleListenerStatus({
+      available: false,
+      capturing: false,
+      monitoring: false,
+      source: null,
+    });
+  }
+}
+
 function playConfiguredAnimation(animationName) {
   if (!hasConfiguredModel()) return false;
   const installedAnimation = settingsStore?.getAnimation(animationName);
@@ -715,6 +762,11 @@ if (!app.requestSingleInstanceLock()) {
     ipcMain.handle("persona:settings-set-character-size", (_event, size) =>
       publishSettings(settingsStore.setCharacterSize(size)),
     );
+    ipcMain.handle("persona:settings-set-voice-source", (_event, voiceSource) => {
+      const snapshot = publishSettings(settingsStore.setVoiceSource(voiceSource));
+      restartAudioListener();
+      return snapshot;
+    });
     ipcMain.handle(
       "persona:settings-set-model-lighting",
       (_event, modelId, lighting) =>
@@ -785,24 +837,7 @@ if (!app.requestSingleInstanceLock()) {
     globalShortcut.register("CommandOrControl+Shift+A", toggleOverlay);
     handleProtocolArgv(process.argv);
 
-    audioListener = createAudioListener({
-      isPackaged: app.isPackaged,
-      resourcesPath: process.resourcesPath,
-      onActivity: (activity) => {
-        debugLog("listener activity", activity);
-        handleBridgeEvent(voiceState(activity));
-      },
-      onDebug: debugEnabled ? (nodes) => debugLog("listener output nodes", nodes) : null,
-      onLevel: (level) => handleBridgeEvent({ type: "audio-level", level }),
-      onSession: (active) => {
-        debugLog("listener session", active);
-        handleBridgeEvent(voiceState(active ? "listening" : "idle", active ? "active" : "inactive"));
-      },
-      onStatus: (status) => {
-        debugLog("listener status", status);
-        handleListenerStatus(status);
-      },
-    });
+    audioListener = createConfiguredAudioListener();
     if (audioListener && modelConfigured) void audioListener.start();
     if (!audioListener) {
       handleListenerStatus({

--- a/electron/native-process-audio-listener.cjs
+++ b/electron/native-process-audio-listener.cjs
@@ -58,11 +58,13 @@ class NativeProcessAudioListener {
     pollIntervalMs = 1_500,
     sessionIdleMs = SESSION_IDLE_MS,
     speechReleaseMs = DEFAULT_SPEECH_RELEASE_MS,
+    processPattern = null,
   } = {}) {
     this.platform = platform;
     this.helperPath =
       helperPath ?? resolveNativeHelperPath({ platform, isPackaged, resourcesPath });
     this.processDiscovery = processDiscovery;
+    this.processPattern = processPattern;
     this.spawnProcess = spawnProcess;
     this.onActivity = onActivity;
     this.onDebug = onDebug;
@@ -121,7 +123,10 @@ class NativeProcessAudioListener {
     if (this.stopped || this.pollInFlight) return;
     this.pollInFlight = true;
     try {
-      const processes = await this.processDiscovery({ platform: this.platform });
+      const processes = await this.processDiscovery({
+        platform: this.platform,
+        ...(this.processPattern ? { pattern: this.processPattern } : {}),
+      });
       if (this.stopped) return;
       const selectedPids =
         this.platform === "win32" ? processes.rootPids.slice(0, 1) : processes.pids;

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -42,6 +42,8 @@ contextBridge.exposeInMainWorld("personaSettings", {
     ipcRenderer.invoke("persona:settings-set-default-model", modelId),
   setCharacterSize: (size) =>
     ipcRenderer.invoke("persona:settings-set-character-size", size),
+  setVoiceSource: (voiceSource) =>
+    ipcRenderer.invoke("persona:settings-set-voice-source", voiceSource),
   setModelLighting: (modelId, lighting) =>
     ipcRenderer.invoke(
       "persona:settings-set-model-lighting",

--- a/electron/preload.test.cjs
+++ b/electron/preload.test.cjs
@@ -75,6 +75,10 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
   await settings.deleteModel("model-id");
   await settings.setDefaultModel("model-id");
   await settings.setCharacterSize(1.2);
+  await settings.setVoiceSource({
+    mode: "custom",
+    process_pattern: "local-tts",
+  });
   await settings.setModelLighting("model-id", {
     exposure: 1.2,
     environment_intensity: 0.35,
@@ -115,6 +119,10 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
     ["persona:settings-delete-model", "model-id"],
     ["persona:settings-set-default-model", "model-id"],
     ["persona:settings-set-character-size", 1.2],
+    [
+      "persona:settings-set-voice-source",
+      { mode: "custom", process_pattern: "local-tts" },
+    ],
     [
       "persona:settings-set-model-lighting",
       "model-id",

--- a/electron/process-discovery.cjs
+++ b/electron/process-discovery.cjs
@@ -2,10 +2,12 @@
 
 const { execFile } = require("node:child_process");
 const { promisify } = require("node:util");
+const {
+  DEFAULT_VOICE_APP_PATTERN,
+  configuredPattern,
+} = require("./voice-source.cjs");
 
 const execFileAsync = promisify(execFile);
-const DEFAULT_VOICE_APP_PATTERN =
-  /(?:^|[\\/\s._=-])(?:codex(?:-desktop)?|chatgpt|openai(?:-codex)?)(?=$|[\\/\s._=-])/i;
 
 function parseMacProcessList(output) {
   return output
@@ -74,21 +76,12 @@ function selectVoiceProcessTree(processes, {
   };
 }
 
-function configuredPattern(environment = process.env) {
-  const source = environment.PERSONA_TARGET_PROCESS_PATTERN;
-  if (!source) return DEFAULT_VOICE_APP_PATTERN;
-  try {
-    return new RegExp(source, "i");
-  } catch {
-    return DEFAULT_VOICE_APP_PATTERN;
-  }
-}
-
 async function discoverVoiceProcesses({
   platform = process.platform,
   run = execFileAsync,
   environment = process.env,
   ownProcessId = process.pid,
+  pattern = null,
 } = {}) {
   let processes;
   if (platform === "darwin") {
@@ -118,7 +111,7 @@ async function discoverVoiceProcesses({
 
   return selectVoiceProcessTree(processes, {
     ownProcessId,
-    pattern: configuredPattern(environment),
+    pattern: pattern ?? configuredPattern(environment),
   });
 }
 

--- a/electron/process-discovery.test.cjs
+++ b/electron/process-discovery.test.cjs
@@ -50,6 +50,27 @@ test("supports a custom target application pattern without accepting invalid reg
   assert.equal(configuredPattern({ PERSONA_TARGET_PROCESS_PATTERN: "[" }).test("Codex"), true);
 });
 
+test("selects processes with an explicit pattern override", () => {
+  const selected = selectVoiceProcessTree(
+    [
+      {
+        pid: 50,
+        parentId: 1,
+        name: "local-tts",
+        command: "/usr/bin/local-tts",
+      },
+      {
+        pid: 51,
+        parentId: 1,
+        name: "Codex",
+        command: "/Applications/Codex.app/Contents/MacOS/Codex",
+      },
+    ],
+    { ownProcessId: 999, pattern: /local-tts/i },
+  );
+  assert.deepEqual(selected, { pids: [50], rootPids: [50] });
+});
+
 test("does not confuse Persona's project path with the Codex application", () => {
   const selected = selectVoiceProcessTree(
     [

--- a/electron/settings-store.cjs
+++ b/electron/settings-store.cjs
@@ -9,8 +9,13 @@ const {
   inferAnimationType,
   readPackagedLibrary,
 } = require("./library-catalog.cjs");
+const {
+  DEFAULT_VOICE_SOURCE,
+  normalizeVoiceSource,
+  sanitizeVoiceSourcePattern,
+} = require("./voice-source.cjs");
 
-const SETTINGS_SCHEMA_VERSION = 3;
+const SETTINGS_SCHEMA_VERSION = 4;
 const DEFAULT_PACKAGED_LIBRARY_PATH = path.join(
   __dirname,
   "..",
@@ -52,6 +57,7 @@ function defaultState(packagedLibrary) {
     animation_clips: {},
     packaged_animation_overrides: {},
     hidden_packaged_animation_ids: [],
+    voice_source: { ...DEFAULT_VOICE_SOURCE },
   };
 }
 
@@ -331,7 +337,7 @@ function safeReadState(settingsPath, packagedLibrary) {
   const fallback = defaultState(packagedLibrary);
   try {
     const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
-    if (![1, 2, SETTINGS_SCHEMA_VERSION].includes(parsed?.schema_version)) {
+    if (![1, 2, 3, SETTINGS_SCHEMA_VERSION].includes(parsed?.schema_version)) {
       return { migrated: false, state: fallback };
     }
     const { hidden, overrides } = packagedUserLayers(parsed, packagedLibrary);
@@ -340,6 +346,7 @@ function safeReadState(settingsPath, packagedLibrary) {
       ...packagedLibrary.models.map((model) => model.id),
       ...models.map((model) => model.id),
     ]);
+    const voiceSource = normalizeVoiceSource(parsed.voice_source);
     const common = {
       ...fallback,
       default_model_id:
@@ -354,9 +361,28 @@ function safeReadState(settingsPath, packagedLibrary) {
       models,
       packaged_animation_overrides: overrides,
       hidden_packaged_animation_ids: hidden,
+      voice_source: voiceSource,
     };
 
     if (parsed.schema_version !== SETTINGS_SCHEMA_VERSION) {
+      if (parsed.schema_version === 3) {
+        const animations = sanitizeUserAnimations(parsed.animations);
+        const knownAnimationIds = new Set([
+          ...packagedLibrary.animations.map((animation) => animation.id),
+          ...animations.map((animation) => animation.id),
+        ]);
+        return {
+          migrated: true,
+          state: {
+            ...common,
+            animations,
+            animation_clips: sanitizeAnimationClips(
+              parsed.animation_clips,
+              knownAnimationIds,
+            ),
+          },
+        };
+      }
       const migrated = migrateLegacyAnimations(
         parsed.animations,
         packagedLibrary,
@@ -406,6 +432,7 @@ function createSettingsStore({
   let state = initial.state;
 
   function writeState() {
+    state.schema_version = SETTINGS_SCHEMA_VERSION;
     fs.mkdirSync(userDataPath, { recursive: true });
     const temporaryPath = `${settingsPath}.tmp`;
     fs.writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, {
@@ -552,6 +579,7 @@ function createSettingsStore({
         state.model_lighting,
         modelIds,
       ),
+      voice_source: normalizeVoiceSource(state.voice_source),
     };
   }
 
@@ -801,6 +829,21 @@ function createSettingsStore({
     return getSnapshot();
   }
 
+  function setVoiceSource(value) {
+    const mode = value?.mode === "custom" ? "custom" : "default";
+    if (mode === "default") {
+      state.voice_source = { ...DEFAULT_VOICE_SOURCE };
+      writeState();
+      return getSnapshot();
+    }
+    state.voice_source = {
+      mode: "custom",
+      process_pattern: sanitizeVoiceSourcePattern(value?.process_pattern),
+    };
+    writeState();
+    return getSnapshot();
+  }
+
   function setModelLighting(modelId, lighting) {
     if (!availableModels().some((model) => model.id === modelId)) {
       throw new Error("Selected model is not installed.");
@@ -932,6 +975,7 @@ function createSettingsStore({
     resetPackagedAnimations,
     resolveAssetRequest,
     setCharacterSize,
+    setVoiceSource,
     setDefaultModel,
     setModelLighting,
     resetModelLighting,

--- a/electron/settings-store.test.cjs
+++ b/electron/settings-store.test.cjs
@@ -213,7 +213,7 @@ test("keeps user library records when migrating the earlier settings schema", (c
   );
 
   const snapshot = createSettingsStore({ userDataPath, packagedLibraryPath }).getSnapshot();
-  assert.equal(snapshot.schema_version, 3);
+  assert.equal(snapshot.schema_version, 4);
   assert.equal(snapshot.default_model_id, modelId);
   assert.equal(snapshot.character_size, 1.15);
   assert.ok(snapshot.models.some((model) => model.id === modelId));
@@ -531,4 +531,53 @@ test("groups multiple uploaded clips under one action and removes them independe
     () => store.deleteAnimation("system-speaking"),
     /cannot be removed/,
   );
+});
+
+test("persists a custom voice source and migrates older settings to schema 4", (context) => {
+  const { userDataPath, packagedLibraryPath } = fixture(context);
+  const store = createSettingsStore({ userDataPath, packagedLibraryPath });
+  assert.deepEqual(store.getSnapshot().voice_source, {
+    mode: "default",
+    process_pattern: null,
+  });
+
+  let snapshot = store.setVoiceSource({
+    mode: "custom",
+    process_pattern: "  local-tts|open-webui  ",
+  });
+  assert.equal(snapshot.schema_version, 4);
+  assert.deepEqual(snapshot.voice_source, {
+    mode: "custom",
+    process_pattern: "local-tts|open-webui",
+  });
+  assert.throws(
+    () => store.setVoiceSource({ mode: "custom", process_pattern: "[" }),
+    /valid regular expression/,
+  );
+
+  snapshot = store.setVoiceSource({ mode: "default", process_pattern: null });
+  assert.deepEqual(snapshot.voice_source, {
+    mode: "default",
+    process_pattern: null,
+  });
+
+  fs.writeFileSync(
+    path.join(userDataPath, "settings.json"),
+    JSON.stringify({
+      schema_version: 3,
+      models: [],
+      animations: [],
+      animation_clips: {},
+      model_lighting: {},
+    }),
+  );
+  const migrated = createSettingsStore({
+    userDataPath,
+    packagedLibraryPath,
+  }).getSnapshot();
+  assert.equal(migrated.schema_version, 4);
+  assert.deepEqual(migrated.voice_source, {
+    mode: "default",
+    process_pattern: null,
+  });
 });

--- a/electron/voice-source.cjs
+++ b/electron/voice-source.cjs
@@ -1,0 +1,100 @@
+"use strict";
+
+const DEFAULT_VOICE_SOURCE = Object.freeze({
+  mode: "default",
+  process_pattern: null,
+});
+
+const DEFAULT_VOICE_APP_PATTERN_SOURCE =
+  "(?:^|[\\\\/\\s._=-])(?:codex(?:-desktop)?|chatgpt|openai(?:-codex)?)(?=$|[\\\\/\\s._=-])";
+
+const DEFAULT_VOICE_APP_PATTERN = new RegExp(
+  DEFAULT_VOICE_APP_PATTERN_SOURCE,
+  "i",
+);
+
+const MAX_VOICE_SOURCE_PATTERN_LENGTH = 200;
+
+function compileVoiceSourcePattern(source) {
+  if (typeof source !== "string" || !source.trim()) {
+    return DEFAULT_VOICE_APP_PATTERN;
+  }
+  try {
+    return new RegExp(source, "i");
+  } catch {
+    return DEFAULT_VOICE_APP_PATTERN;
+  }
+}
+
+function sanitizeVoiceSourcePattern(value) {
+  if (typeof value !== "string") {
+    throw new Error("Process pattern is required.");
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error("Process pattern is required.");
+  }
+  if (normalized.length > MAX_VOICE_SOURCE_PATTERN_LENGTH) {
+    throw new Error(
+      `Process pattern must be ${MAX_VOICE_SOURCE_PATTERN_LENGTH} characters or fewer.`,
+    );
+  }
+  try {
+    // Ensure the pattern compiles before persisting it.
+    new RegExp(normalized, "i");
+  } catch {
+    throw new Error("Process pattern must be a valid regular expression.");
+  }
+  return normalized;
+}
+
+function normalizeVoiceSource(value) {
+  const mode = value?.mode === "custom" ? "custom" : "default";
+  if (mode === "default") {
+    return { mode: "default", process_pattern: null };
+  }
+  try {
+    return {
+      mode: "custom",
+      process_pattern: sanitizeVoiceSourcePattern(value?.process_pattern),
+    };
+  } catch {
+    return { ...DEFAULT_VOICE_SOURCE };
+  }
+}
+
+function settingsPatternFromVoiceSource(voiceSource) {
+  const normalized = normalizeVoiceSource(voiceSource);
+  return normalized.mode === "custom" ? normalized.process_pattern : null;
+}
+
+function resolveVoiceSourcePattern({
+  environment = process.env,
+  settingsPattern = null,
+} = {}) {
+  const envSource = environment?.PERSONA_TARGET_PROCESS_PATTERN;
+  if (typeof envSource === "string" && envSource.trim()) {
+    return compileVoiceSourcePattern(envSource);
+  }
+  if (typeof settingsPattern === "string" && settingsPattern.trim()) {
+    return compileVoiceSourcePattern(settingsPattern);
+  }
+  return DEFAULT_VOICE_APP_PATTERN;
+}
+
+function configuredPattern(environment = process.env) {
+  return resolveVoiceSourcePattern({ environment });
+}
+
+module.exports = {
+  DEFAULT_VOICE_APP_PATTERN,
+  DEFAULT_VOICE_APP_PATTERN_SOURCE,
+  DEFAULT_VOICE_SOURCE,
+  MAX_VOICE_SOURCE_PATTERN_LENGTH,
+  compileVoiceSourcePattern,
+  configuredPattern,
+  normalizeVoiceSource,
+  resolveVoiceSourcePattern,
+  sanitizeVoiceSourcePattern,
+  settingsPatternFromVoiceSource,
+};

--- a/electron/voice-source.test.cjs
+++ b/electron/voice-source.test.cjs
@@ -1,0 +1,74 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  DEFAULT_VOICE_APP_PATTERN,
+  DEFAULT_VOICE_SOURCE,
+  compileVoiceSourcePattern,
+  configuredPattern,
+  normalizeVoiceSource,
+  resolveVoiceSourcePattern,
+  sanitizeVoiceSourcePattern,
+  settingsPatternFromVoiceSource,
+} = require("./voice-source.cjs");
+
+test("compiles the shared default ChatGPT and Codex pattern", () => {
+  assert.equal(DEFAULT_VOICE_APP_PATTERN.test("Codex"), true);
+  assert.equal(DEFAULT_VOICE_APP_PATTERN.test("ChatGPT.exe"), true);
+  assert.equal(DEFAULT_VOICE_APP_PATTERN.test("openai-codex"), true);
+  assert.equal(DEFAULT_VOICE_APP_PATTERN.test("persona"), false);
+  assert.equal(
+    compileVoiceSourcePattern("[").source,
+    DEFAULT_VOICE_APP_PATTERN.source,
+  );
+});
+
+test("prefers the environment override, then settings, then the default", () => {
+  const fromEnv = resolveVoiceSourcePattern({
+    environment: { PERSONA_TARGET_PROCESS_PATTERN: "local-tts" },
+    settingsPattern: "settings-app",
+  });
+  assert.equal(fromEnv.test("local-tts"), true);
+  assert.equal(fromEnv.test("settings-app"), false);
+
+  const fromSettings = resolveVoiceSourcePattern({
+    environment: {},
+    settingsPattern: "settings-app",
+  });
+  assert.equal(fromSettings.test("settings-app"), true);
+  assert.equal(fromSettings.test("Codex"), false);
+
+  const fromDefault = resolveVoiceSourcePattern({
+    environment: {},
+    settingsPattern: null,
+  });
+  assert.equal(fromDefault.test("Codex"), true);
+  assert.equal(configuredPattern({}).test("ChatGPT"), true);
+});
+
+test("sanitizes and normalizes persisted voice source values", () => {
+  assert.equal(sanitizeVoiceSourcePattern("  my-voice-app  "), "my-voice-app");
+  assert.throws(() => sanitizeVoiceSourcePattern(""), /required/);
+  assert.throws(() => sanitizeVoiceSourcePattern("["), /valid regular expression/);
+  assert.deepEqual(normalizeVoiceSource(null), DEFAULT_VOICE_SOURCE);
+  assert.deepEqual(
+    normalizeVoiceSource({ mode: "custom", process_pattern: "local-tts" }),
+    { mode: "custom", process_pattern: "local-tts" },
+  );
+  assert.deepEqual(
+    normalizeVoiceSource({ mode: "custom", process_pattern: "[" }),
+    DEFAULT_VOICE_SOURCE,
+  );
+  assert.equal(
+    settingsPatternFromVoiceSource({
+      mode: "custom",
+      process_pattern: "local-tts",
+    }),
+    "local-tts",
+  );
+  assert.equal(
+    settingsPatternFromVoiceSource({ mode: "default", process_pattern: null }),
+    null,
+  );
+});

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -25,7 +25,7 @@ import {
   type ThemePreference,
 } from '../theme';
 
-type SettingsSection = 'models' | 'animations' | 'appearance' | 'mcp';
+type SettingsSection = 'models' | 'animations' | 'appearance' | 'voice' | 'mcp';
 type LightingNumberField =
   | 'exposure'
   | 'environment_intensity'
@@ -57,6 +57,7 @@ const SECTIONS: Array<{
   { id: 'models', label: 'Models', description: 'Character library' },
   { id: 'animations', label: 'Actions', description: 'Motion library' },
   { id: 'appearance', label: 'Appearance', description: 'Default framing' },
+  { id: 'voice', label: 'Voice', description: 'Audio source' },
   { id: 'mcp', label: 'MCP', description: 'Agent connection' },
 ];
 
@@ -93,6 +94,11 @@ const SECTION_ICONS: Record<SettingsSection, ReactNode> = {
   appearance: (
     <Icon>
       <path d="M2.6 5.6v-2a1 1 0 0 1 1-1h2M10.4 2.6h2a1 1 0 0 1 1 1v2M13.4 10.4v2a1 1 0 0 1-1 1h-2M5.6 13.4h-2a1 1 0 0 1-1-1v-2" />
+    </Icon>
+  ),
+  voice: (
+    <Icon>
+      <path d="M3.2 6.4v3.2M5.4 4.8v6.4M7.6 3.6v8.8M9.8 5.2v5.6M12.8 6.8v2.4" />
     </Icon>
   ),
   mcp: (
@@ -178,6 +184,12 @@ export function SettingsPage() {
   const [notice, setNotice] = useState<string | null>(null);
   const [mcpStatus, setMcpStatus] = useState<PersonaMcpStatus | null>(null);
   const [mcpLoading, setMcpLoading] = useState(false);
+  const [voiceMode, setVoiceMode] = useState<'default' | 'custom'>(
+    SETTINGS_FALLBACK.voice_source.mode,
+  );
+  const [voicePattern, setVoicePattern] = useState(
+    SETTINGS_FALLBACK.voice_source.process_pattern ?? '',
+  );
   const [confirmation, setConfirmation] =
     useState<ConfirmationRequest | null>(null);
   const [confirming, setConfirming] = useState(false);
@@ -207,6 +219,11 @@ export function SettingsPage() {
       .catch((error: unknown) => setNotice(errorMessage(error)));
     return bridge.subscribe(setSettings);
   }, [bridge]);
+
+  useEffect(() => {
+    setVoiceMode(settings.voice_source.mode);
+    setVoicePattern(settings.voice_source.process_pattern ?? '');
+  }, [settings.voice_source.mode, settings.voice_source.process_pattern]);
 
   useEffect(() => {
     setPreviewAnimation((current) => {
@@ -292,6 +309,26 @@ export function SettingsPage() {
     },
     [updateSnapshot],
   );
+
+  const saveVoiceSource = async () => {
+    if (!bridge) return;
+    await run(
+      () =>
+        bridge.setVoiceSource({
+          mode: voiceMode,
+          process_pattern: voiceMode === 'custom' ? voicePattern : null,
+        }),
+      voiceMode === 'custom'
+        ? 'Custom voice source saved. Persona will listen for matching playback.'
+        : 'Voice source reset to ChatGPT and Codex.',
+    );
+  };
+
+  const voiceSourceDirty =
+    voiceMode !== settings.voice_source.mode ||
+    (voiceMode === 'custom'
+      ? voicePattern.trim() !== (settings.voice_source.process_pattern ?? '')
+      : false);
 
   const refreshMcpStatus = useCallback(async () => {
     setMcpLoading(true);
@@ -657,7 +694,11 @@ export function SettingsPage() {
       ? mcpStatus
         ? `${mcpStatus.tools.length} tools · ${mcpStatus.playable_actions.length} playable actions`
         : 'Local agent connection'
-      : `${customModelCount} custom models · ${customAnimationCount} custom actions`;
+      : section === 'voice'
+        ? settings.voice_source.mode === 'custom'
+          ? 'Custom process pattern'
+          : 'ChatGPT / Codex'
+        : `${customModelCount} custom models · ${customAnimationCount} custom actions`;
   const mcpHealth = mcpStatus?.health ?? (mcpLoading ? 'starting' : 'unavailable');
   const mcpServerUrl =
     mcpStatus?.server_url ?? 'http://127.0.0.1:47831/mcp';
@@ -717,7 +758,9 @@ export function SettingsPage() {
             <span className="eyebrow">
               {section === 'mcp'
                 ? 'Local integration'
-                : 'Character configuration'}
+                : section === 'voice'
+                  ? 'Voice output listener'
+                  : 'Character configuration'}
             </span>
             <h1>{SECTIONS.find((item) => item.id === section)?.label}</h1>
           </div>
@@ -1566,6 +1609,92 @@ export function SettingsPage() {
                     type="number"
                     value={previewLighting.exposure}
                   />
+                </div>
+              </section>
+            </>
+          )}
+
+          {section === 'voice' && (
+            <>
+              <section className="settings-panel voice-source-panel">
+                <div className="panel-heading">
+                  <div>
+                    <h2>Automatic audio source</h2>
+                    <p>
+                      Persona listens only to playback from the selected
+                      application and turns its volume into lip sync. It does not
+                      capture the microphone, run models, or send audio anywhere.
+                    </p>
+                  </div>
+                </div>
+
+                <div
+                  aria-label="Voice source"
+                  className="theme-segmented"
+                  role="group"
+                >
+                  <button
+                    aria-pressed={voiceMode === 'default'}
+                    data-testid="voice-mode-default"
+                    disabled={busy || !bridge}
+                    onClick={() => setVoiceMode('default')}
+                    type="button"
+                  >
+                    ChatGPT / Codex
+                  </button>
+                  <button
+                    aria-pressed={voiceMode === 'custom'}
+                    data-testid="voice-mode-custom"
+                    disabled={busy || !bridge}
+                    onClick={() => setVoiceMode('custom')}
+                    type="button"
+                  >
+                    Custom pattern
+                  </button>
+                </div>
+
+                {voiceMode === 'custom' && (
+                  <label className="voice-pattern-field">
+                    <span>Process pattern</span>
+                    <input
+                      aria-label="Custom voice process pattern"
+                      data-testid="voice-process-pattern"
+                      disabled={busy || !bridge}
+                      onChange={(event) =>
+                        setVoicePattern(event.currentTarget.value)
+                      }
+                      placeholder="my-voice-app|local-tts"
+                      spellCheck={false}
+                      type="text"
+                      value={voicePattern}
+                    />
+                  </label>
+                )}
+
+                <p className="theme-note">
+                  Use a case-insensitive regular expression that matches the
+                  desktop app playing assistant audio. For fully custom local
+                  pipelines you can also drive Persona through its loopback HTTP
+                  API or <code>persona://</code> URLs. Setting{' '}
+                  <code>PERSONA_TARGET_PROCESS_PATTERN</code> overrides this
+                  setting.
+                </p>
+
+                <div className="panel-actions">
+                  <button
+                    className="primary-button"
+                    data-testid="voice-source-save"
+                    disabled={
+                      busy ||
+                      !bridge ||
+                      !voiceSourceDirty ||
+                      (voiceMode === 'custom' && !voicePattern.trim())
+                    }
+                    onClick={() => void saveVoiceSource()}
+                    type="button"
+                  >
+                    Save voice source
+                  </button>
                 </div>
               </section>
             </>

--- a/src/settings-defaults.ts
+++ b/src/settings-defaults.ts
@@ -82,13 +82,17 @@ export function resolveLightingSettings(
 }
 
 export const SETTINGS_FALLBACK: PersonaSettingsSnapshot = {
-  schema_version: 3,
+  schema_version: 4,
   default_model_id: null,
   character_size: 1,
   packaged_animation_change_count: 0,
   models: [],
   animations: SYSTEM_ACTIONS,
   model_lighting: {},
+  voice_source: {
+    mode: 'default',
+    process_pattern: null,
+  },
 };
 
 function packagedAssetUrl(relativePath: string): string {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1315,6 +1315,53 @@ button {
   line-height: 1.55;
 }
 
+.theme-note code {
+  padding: 1px 5px;
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  background: var(--fill-subtle);
+  font-size: var(--fs-xs);
+}
+
+.voice-source-panel .theme-segmented {
+  margin-top: 4px;
+}
+
+.voice-pattern-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 16px;
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+}
+
+.voice-pattern-field input {
+  width: 100%;
+  height: 34px;
+  padding: 0 11px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  outline: none;
+  color: var(--text-primary);
+  background: var(--bg-inset);
+  font-size: var(--fs-md);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  caret-color: var(--accent-text);
+}
+
+.voice-pattern-field input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.voice-source-panel .panel-actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 16px;
+}
+
 /* --- Character size ----------------------------------------------------- */
 
 .appearance-panel .panel-heading {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -69,6 +69,11 @@ interface PersonaAnimationClipSettings {
   asset_url: string;
 }
 
+interface PersonaVoiceSourceSettings {
+  mode: 'default' | 'custom';
+  process_pattern: string | null;
+}
+
 interface PersonaSettingsSnapshot {
   schema_version: number;
   default_model_id: string | null;
@@ -77,6 +82,7 @@ interface PersonaSettingsSnapshot {
   models: PersonaModelSettings[];
   animations: PersonaAnimationSettings[];
   model_lighting: Record<string, PersonaLightingSettings>;
+  voice_source: PersonaVoiceSourceSettings;
 }
 
 interface PersonaMcpStatus {
@@ -143,6 +149,9 @@ interface Window {
     deleteModel(modelId: string): Promise<PersonaSettingsSnapshot>;
     setDefaultModel(modelId: string): Promise<PersonaSettingsSnapshot>;
     setCharacterSize(size: number): Promise<PersonaSettingsSnapshot>;
+    setVoiceSource(
+      voiceSource: PersonaVoiceSourceSettings,
+    ): Promise<PersonaSettingsSnapshot>;
     setModelLighting(
       modelId: string,
       lighting: Partial<PersonaLightingSettings>,


### PR DESCRIPTION
Fixes #3 by letting users pick which app Persona listens to for lip sync (Settings → Voice): ChatGPT/Codex by default, or a custom process pattern for local TTS/voice UIs.

Persona stays a visual companion, and does not run models or STT/TTS. Local models stay in the user’s stack, this just points the existing listener (and docs the HTTP/MCP paths) so local pipelines work without fighting the product boundary.

## Changes

- Shared process matching on Linux, macOS, and Windows (Linux now honors the same pattern / env override)
- Persist voice source in settings, restart the listener on save
- Docs for process listen, loopback events, and MCP

## Tested

`npm run check` (voice-source, migration, Linux custom pattern, preload IPC). Default ChatGPT/Codex behavior unchanged.