### PR TITLE
feat: add complete cross-platform voice source selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Persona's first beta is under active development.
 
 - Realtime character animation and amplitude-driven lip sync.
 - PipeWire, WASAPI process-loopback, and Core Audio process-tap listeners.
-- Configurable voice source in Settings, with shared process matching on Linux,
-  macOS, and Windows for ChatGPT/Codex or a custom local voice app pattern.
+- Configurable voice sources with automatic detection, application and Linux
+  playback-stream selection, cross-platform regex matching, and external events.
 - Transparent desktop presence with manual lifecycle, tray controls, shortcut,
   URL protocol, always-on-top behavior, zoom, orbit, and pan.
 - Short-silence speech holding and smooth animation crossfades.

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ an expressive visual identity alongside your work.
 
 ## Platform support
 
-| Platform    | Automatic voice output listener | Distribution               |
-| ----------- | ------------------------------- | -------------------------- |
-| Linux       | PipeWire process-stream capture | AppImage and DEB           |
-| Windows     | WASAPI process-loopback capture | NSIS installer             |
-| macOS 14.2+ | Core Audio process tap          | DMG and ZIP, arm64 and x64 |
+| Platform    | Voice output listener            | Distribution               |
+| ----------- | -------------------------------- | -------------------------- |
+| Linux       | PipeWire playback-stream capture | AppImage and DEB           |
+| Windows     | WASAPI process-loopback capture  | NSIS installer             |
+| macOS 14.2+ | Core Audio process tap           | DMG and ZIP, arm64 and x64 |
 
 Linux requires `pw-dump` and `pw-record` on `PATH`. Windows process-loopback
 requires Windows 10 build 20348 or newer. macOS asks once for System Audio
 Recording permission.
 
-Each listener is scoped to the supported application's playback process. Persona
-does not capture the microphone, save audio, produce speech, transcribe content,
-or send audio over the network.
+Each listener is scoped to an automatically detected or user-selected playback
+process. Persona does not capture the microphone, save audio, produce speech,
+transcribe content, or send audio over the network.
 
 ## Try Persona locally
 
@@ -116,9 +116,10 @@ only exposes its own visual controls.
 ## Local voice apps
 
 Persona does not run language models. To use it with a local model stack, open
-**Settings → Voice** and point the automatic listener at the app that plays
-assistant audio, or drive lip sync from your pipeline through the loopback HTTP
-API and `persona://` URLs. Any compatible MCP client can use the same animation
+**Settings → Voice** and select the running app or Linux playback stream that
+produces assistant audio. Advanced users can supply a cross-platform process
+pattern, while pipelines that already calculate output levels can use the
+external-events mode. Any compatible MCP client can use the same animation
 tools as Codex. See [Integrations](docs/INTEGRATIONS.md).
 
 The window intentionally contains no controls:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,9 +9,12 @@ pull request before it has been reviewed.
 
 ## Data boundary
 
-Persona's automatic listeners calculate a numeric output level in memory. They
-do not capture the microphone, write audio to disk, transcribe it, or send it
-over the network.
+Persona's automatic and selected-application listeners calculate a numeric
+output level in memory. They do not capture the microphone, write audio to
+disk, transcribe it, or send it over the network. Source discovery exposes only
+bounded display names and executable or stream identity to Persona's sandboxed
+Settings renderer; command-line arguments are not exposed there. A selected
+source identity is persisted only in Persona's local settings.
 
 The integration server binds only to `127.0.0.1`, rejects non-loopback `Host`
 headers, restricts browser origins, and limits request bodies. Its event API

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -101,12 +101,17 @@ level immediately. The body remains in its talking motion for 900 ms of silence
 before returning to listening, preventing sentence gaps from causing abrupt
 animation changes.
 
-Target process matching is shared through `electron/voice-source.cjs`. Settings
-stores a default ChatGPT/Codex mode or a custom regex; `PERSONA_TARGET_PROCESS_PATTERN`
-overrides that value when set. Linux PipeWire identity matching and
-macOS/Windows process discovery both consume the resolved pattern so a Voice
-source change behaves the same on every platform. Changing the setting recreates
-the active listener immediately.
+Voice-source validation and stable identities are shared through
+`electron/voice-source.cjs`; discovery lives in
+`electron/voice-source-discovery.cjs`. Settings supports automatic detection,
+an exact application or PipeWire stream, an advanced regex, and external event
+mode. `PERSONA_TARGET_PROCESS_PATTERN` overrides automatic and advanced
+matching when set. Every source change recreates the listener immediately.
+
+Linux persists a composite PipeWire stream identity so generic application
+names such as `Electron` cannot collapse unrelated playback streams. macOS and
+Windows persist executable identity and resolve the current process tree before
+starting the native helper. PIDs and PipeWire object serials are never stored.
 
 Linux implements the contract directly with PipeWire commands. macOS and
 Windows helpers write newline-delimited JSON to stdout:

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -58,31 +58,36 @@ The MCP endpoint uses the same port as the local HTTP API. If
 
 ## Automatic listeners
 
-Listeners attach to the configured voice source (ChatGPT/Codex by default, or a
-custom process pattern from Settings / `PERSONA_TARGET_PROCESS_PATTERN`).
+Listeners attach to the configured voice source: automatic ChatGPT/Codex
+detection, one selected application, or an advanced process pattern.
 
 ### Linux
 
-Persona polls the PipeWire graph for a playback node that matches the configured
-voice-source pattern. It attaches `pw-record` to that one stream, calculates RMS
-amplitude in memory, and discards every sample after calculation. The stream
-remains connected to its normal output device.
+Persona polls the PipeWire graph for either the selected playback stream or a
+node matching the configured process pattern. It attaches `pw-record` to that
+one stream, calculates RMS amplitude in memory, and discards every sample after
+calculation. The stream remains connected to its normal output device.
 
 ### Windows
 
 The native helper uses WASAPI application loopback with
 `PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE`. Audio from other
 applications is excluded. Persona supports Windows 10 build 20348 and newer.
+Application mode resolves the saved executable identity to its current process
+tree before starting the helper.
 
 ### macOS
 
 The native helper creates a private, unmuted Core Audio process tap and private
 aggregate device for the selected voice process. Persona supports macOS 14.2
 and newer and declares why it requests System Audio Recording permission.
+Application mode resolves the saved executable identity to its current process
+tree before creating the tap.
 
 Set `PERSONA_TARGET_PROCESS_PATTERN` to a case-insensitive regular expression
-to target another desktop voice application. This environment variable overrides
-the Voice source chosen in Settings:
+to target another desktop voice application. This environment variable
+overrides automatic and advanced-pattern matching, but not an explicitly
+selected application or external mode:
 
 ```bash
 PERSONA_TARGET_PROCESS_PATTERN='my-voice-app' persona
@@ -93,10 +98,15 @@ PERSONA_TARGET_PROCESS_PATTERN='my-voice-app' persona
 Open **Settings → Voice** to choose which application Persona watches for
 automatic lip sync:
 
-- **ChatGPT / Codex** keeps the built-in matcher used by default.
-- **Custom pattern** accepts a case-insensitive regular expression matched
+- **Automatic** keeps the built-in ChatGPT/Codex matcher.
+- **Application** lists current playback streams on Linux and running
+  applications on macOS and Windows, then persists a stable identity rather
+  than a temporary PID or PipeWire serial.
+- **Advanced** accepts a case-insensitive regular expression matched
   against process names and command lines on macOS and Windows, and against
   PipeWire application identity (plus process ancestry) on Linux.
+- **External** disables automatic capture and waits for normalized state and
+  level events through the loopback API.
 
 Persona still calculates only an in-memory output level. It does not capture the
 microphone, run language models, transcribe speech, or send audio over the

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -48,7 +48,8 @@ Treat signed and notarized artifacts as the production release path.
      starting the listener;
    - selecting the first model activates the avatar and listener;
    - first-run system audio permission where applicable;
-   - supported voice process discovery;
+   - automatic, selected-application, advanced-pattern, and external voice modes;
+   - selected Linux playback-stream and macOS/Windows process discovery;
    - idle, short pause, long pause, and resumed speech;
    - immediate lip response to output;
    - no microphone capture, duplicate sound, or saved audio;

--- a/electron/audio-listener.cjs
+++ b/electron/audio-listener.cjs
@@ -2,8 +2,10 @@
 
 const { LinuxPipeWireListener } = require("./linux-pipewire-listener.cjs");
 const { NativeProcessAudioListener } = require("./native-process-audio-listener.cjs");
+const { normalizeVoiceSource } = require("./voice-source.cjs");
 
 function createAudioListener({ platform = process.platform, ...options } = {}) {
+  if (normalizeVoiceSource(options.voiceSource).mode === "external") return null;
   if (platform === "linux") return new LinuxPipeWireListener(options);
   if (platform === "darwin" || platform === "win32") {
     return new NativeProcessAudioListener({ platform, ...options });

--- a/electron/audio-listener.test.cjs
+++ b/electron/audio-listener.test.cjs
@@ -11,4 +11,11 @@ test("selects the native listener implementation for each supported platform", (
   assert.ok(createAudioListener({ platform: "darwin" }) instanceof NativeProcessAudioListener);
   assert.ok(createAudioListener({ platform: "win32" }) instanceof NativeProcessAudioListener);
   assert.equal(createAudioListener({ platform: "freebsd" }), null);
+  assert.equal(
+    createAudioListener({
+      platform: "linux",
+      voiceSource: { mode: "external" },
+    }),
+    null,
+  );
 });

--- a/electron/linux-pipewire-listener.cjs
+++ b/electron/linux-pipewire-listener.cjs
@@ -4,7 +4,11 @@ const { execFile, spawn } = require("node:child_process");
 const fs = require("node:fs");
 const { promisify } = require("node:util");
 const { AudioActivityGate, DEFAULT_SPEECH_RELEASE_MS } = require("./audio-activity-gate.cjs");
-const { DEFAULT_VOICE_APP_PATTERN } = require("./voice-source.cjs");
+const {
+  DEFAULT_VOICE_APP_PATTERN,
+  normalizeVoiceSource,
+  pipeWirePropertiesMatchSource,
+} = require("./voice-source.cjs");
 
 const execFileAsync = promisify(execFile);
 const SPEECH_RELEASE_MS = DEFAULT_SPEECH_RELEASE_MS;
@@ -105,9 +109,23 @@ function isCodexOutputNode(
   processMatcher = null,
   pattern = DEFAULT_VOICE_APP_PATTERN,
 ) {
+  return isVoiceOutputNode(node, null, processMatcher, pattern);
+}
+
+function isVoiceOutputNode(
+  node,
+  voiceSource = null,
+  processMatcher = null,
+  pattern = DEFAULT_VOICE_APP_PATTERN,
+) {
   if (node?.type !== "PipeWire:Interface:Node") return false;
   const properties = nodeProperties(node);
   if (properties["media.class"] !== "Stream/Output/Audio") return false;
+  const selected = normalizeVoiceSource(voiceSource);
+  if (selected.mode === "application") {
+    return pipeWirePropertiesMatchSource(properties, selected.source_id);
+  }
+  if (selected.mode === "external") return false;
   const identity = [
     properties["application.name"],
     properties["application.process.binary"],
@@ -131,6 +149,15 @@ function findCodexOutputNode(
   processMatcher = null,
   pattern = DEFAULT_VOICE_APP_PATTERN,
 ) {
+  return findVoiceOutputNode(nodes, null, processMatcher, pattern);
+}
+
+function findVoiceOutputNode(
+  nodes,
+  voiceSource = null,
+  processMatcher = null,
+  pattern = DEFAULT_VOICE_APP_PATTERN,
+) {
   const processCache = new Map();
   const matcher =
     processMatcher ??
@@ -141,7 +168,7 @@ function findCodexOutputNode(
     return processCache.get(key);
   };
   const matches = nodes.filter((node) =>
-    isCodexOutputNode(node, cachedMatcher, pattern),
+    isVoiceOutputNode(node, voiceSource, cachedMatcher, pattern),
   );
   return (
     matches.find((node) => node.info?.state === "running") ??
@@ -188,6 +215,7 @@ class LinuxPipeWireListener {
     pollIntervalMs = 750,
     speechReleaseMs = SPEECH_RELEASE_MS,
     processPattern = DEFAULT_VOICE_APP_PATTERN,
+    voiceSource = null,
   } = {}) {
     this.onActivity = onActivity;
     this.onDebug = onDebug;
@@ -197,6 +225,7 @@ class LinuxPipeWireListener {
     this.pollIntervalMs = pollIntervalMs;
     this.speechReleaseMs = speechReleaseMs;
     this.processPattern = processPattern ?? DEFAULT_VOICE_APP_PATTERN;
+    this.voiceSource = normalizeVoiceSource(voiceSource);
     this.capture = null;
     this.captureSerial = null;
     this.currentNode = null;
@@ -269,7 +298,12 @@ class LinuxPipeWireListener {
           this.onDebug(outputNodes);
         }
       }
-      const node = findCodexOutputNode(nodes, null, this.processPattern);
+      const node = findVoiceOutputNode(
+        nodes,
+        this.voiceSource,
+        null,
+        this.processPattern,
+      );
       if (node == null) {
         this.detach();
         return;
@@ -393,8 +427,11 @@ module.exports = {
   SPEECH_RELEASE_MS,
   enrichPipeWireNodes,
   findCodexOutputNode,
+  findVoiceOutputNode,
   isCodexOutputNode,
   isCodexProcessTree,
+  isVoiceOutputNode,
+  nodeProperties,
   normalizeRms,
   pcm16Rms,
   readProcessInfo,

--- a/electron/linux-pipewire-listener.test.cjs
+++ b/electron/linux-pipewire-listener.test.cjs
@@ -6,11 +6,14 @@ const {
   LinuxPipeWireListener,
   enrichPipeWireNodes,
   findCodexOutputNode,
+  findVoiceOutputNode,
   isCodexOutputNode,
   isCodexProcessTree,
+  isVoiceOutputNode,
   normalizeRms,
   pcm16Rms,
 } = require("./linux-pipewire-listener.cjs");
+const { pipeWireSourceFromProperties } = require("./voice-source.cjs");
 
 function pipeWireNode(id, properties, state = "idle") {
   return {
@@ -128,6 +131,33 @@ test("matches a custom process pattern for local voice apps", () => {
   assert.equal(isCodexOutputNode(localApp, null, pattern), true);
   assert.equal(isCodexOutputNode(localApp), false);
   assert.equal(findCodexOutputNode([localApp], null, pattern), localApp);
+});
+
+test("selects one configured PipeWire stream even when application names match", () => {
+  const voice = pipeWireNode(60, {
+    "application.name": "Electron",
+    "application.process.binary": "voice-ui",
+    "media.class": "Stream/Output/Audio",
+    "node.name": "voice-output",
+    "object.serial": 160,
+  });
+  const music = pipeWireNode(61, {
+    "application.name": "Electron",
+    "application.process.binary": "music-ui",
+    "media.class": "Stream/Output/Audio",
+    "node.name": "music-output",
+    "object.serial": 161,
+  });
+  const source = pipeWireSourceFromProperties(voice.info.props);
+  const selected = {
+    mode: "application",
+    process_pattern: null,
+    source_id: source.id,
+    source_name: source.name,
+  };
+  assert.equal(isVoiceOutputNode(voice, selected), true);
+  assert.equal(isVoiceOutputNode(music, selected), false);
+  assert.equal(findVoiceOutputNode([music, voice], selected), voice);
 });
 
 test("does not emit duplicate listener status updates", () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -27,6 +27,7 @@ const {
   getHyprlandWindowPlacement,
 } = require("./hyprland-window.cjs");
 const { createAudioListener } = require("./audio-listener.cjs");
+const { listVoiceSources } = require("./voice-source-discovery.cjs");
 const { isAllowedRendererNavigation } = require("./navigation-policy.cjs");
 const { snapshotHasConfiguredModel } = require("./model-readiness.cjs");
 const { parseProtocolUrl, voiceState } = require("./protocol-actions.cjs");
@@ -34,6 +35,7 @@ const {
   createSettingsWindowPresentationGate,
 } = require("./settings-window-presentation.cjs");
 const {
+  normalizeVoiceSource,
   resolveVoiceSourcePattern,
   settingsPatternFromVoiceSource,
 } = require("./voice-source.cjs");
@@ -413,17 +415,21 @@ function publishSettings(snapshot) {
 }
 
 function resolveListenerProcessPattern(snapshot = settingsStore?.getSnapshot()) {
+  const voiceSource = normalizeVoiceSource(snapshot?.voice_source);
+  if (!["default", "custom"].includes(voiceSource.mode)) return null;
   return resolveVoiceSourcePattern({
     environment: process.env,
-    settingsPattern: settingsPatternFromVoiceSource(snapshot?.voice_source),
+    settingsPattern: settingsPatternFromVoiceSource(voiceSource),
   });
 }
 
-function createConfiguredAudioListener() {
+function createConfiguredAudioListener(snapshot = settingsStore?.getSnapshot()) {
+  const voiceSource = normalizeVoiceSource(snapshot?.voice_source);
   return createAudioListener({
     isPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
-    processPattern: resolveListenerProcessPattern(),
+    processPattern: resolveListenerProcessPattern(snapshot),
+    voiceSource,
     onActivity: (activity) => {
       debugLog("listener activity", activity);
       handleBridgeEvent(voiceState(activity));
@@ -441,17 +447,31 @@ function createConfiguredAudioListener() {
   });
 }
 
+function reportInactiveListenerStatus(snapshot = settingsStore?.getSnapshot()) {
+  const voiceSource = normalizeVoiceSource(snapshot?.voice_source);
+  handleListenerStatus({
+    available: voiceSource.mode === "external",
+    capturing: false,
+    monitoring: false,
+    source:
+      voiceSource.mode === "external" ? "External integration" : null,
+  });
+}
+
 function restartAudioListener() {
   audioListener?.stop();
   audioListener = createConfiguredAudioListener();
-  if (audioListener && modelConfigured) void audioListener.start();
-  if (!audioListener) {
+  if (audioListener && modelConfigured) {
+    void audioListener.start();
+  } else if (audioListener) {
     handleListenerStatus({
-      available: false,
+      available: true,
       capturing: false,
       monitoring: false,
       source: null,
     });
+  } else {
+    reportInactiveListenerStatus();
   }
 }
 
@@ -767,6 +787,24 @@ if (!app.requestSingleInstanceLock()) {
       restartAudioListener();
       return snapshot;
     });
+    ipcMain.handle("persona:settings-list-voice-sources", async () => {
+      try {
+        return {
+          ...(await listVoiceSources()),
+          error: null,
+          events_url: `http://127.0.0.1:${mcpServerPort}/events`,
+          listener: latestListenerStatus,
+        };
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          events_url: `http://127.0.0.1:${mcpServerPort}/events`,
+          listener: latestListenerStatus,
+          platform: process.platform,
+          sources: [],
+        };
+      }
+    });
     ipcMain.handle(
       "persona:settings-set-model-lighting",
       (_event, modelId, lighting) =>
@@ -838,14 +876,17 @@ if (!app.requestSingleInstanceLock()) {
     handleProtocolArgv(process.argv);
 
     audioListener = createConfiguredAudioListener();
-    if (audioListener && modelConfigured) void audioListener.start();
-    if (!audioListener) {
+    if (audioListener && modelConfigured) {
+      void audioListener.start();
+    } else if (audioListener) {
       handleListenerStatus({
-        available: false,
+        available: true,
         capturing: false,
         monitoring: false,
         source: null,
       });
+    } else {
+      reportInactiveListenerStatus();
     }
 
     if (!modelConfigured || startInSettings) {

--- a/electron/native-process-audio-listener.cjs
+++ b/electron/native-process-audio-listener.cjs
@@ -5,6 +5,7 @@ const path = require("node:path");
 const { spawn } = require("node:child_process");
 const { AudioActivityGate, DEFAULT_SPEECH_RELEASE_MS } = require("./audio-activity-gate.cjs");
 const { discoverVoiceProcesses } = require("./process-discovery.cjs");
+const { normalizeVoiceSource } = require("./voice-source.cjs");
 
 const SESSION_IDLE_MS = 8_000;
 
@@ -59,12 +60,14 @@ class NativeProcessAudioListener {
     sessionIdleMs = SESSION_IDLE_MS,
     speechReleaseMs = DEFAULT_SPEECH_RELEASE_MS,
     processPattern = null,
+    voiceSource = null,
   } = {}) {
     this.platform = platform;
     this.helperPath =
       helperPath ?? resolveNativeHelperPath({ platform, isPackaged, resourcesPath });
     this.processDiscovery = processDiscovery;
     this.processPattern = processPattern;
+    this.voiceSource = normalizeVoiceSource(voiceSource);
     this.spawnProcess = spawnProcess;
     this.onActivity = onActivity;
     this.onDebug = onDebug;
@@ -125,6 +128,7 @@ class NativeProcessAudioListener {
     try {
       const processes = await this.processDiscovery({
         platform: this.platform,
+        voiceSource: this.voiceSource,
         ...(this.processPattern ? { pattern: this.processPattern } : {}),
       });
       if (this.stopped) return;

--- a/electron/native-process-audio-listener.test.cjs
+++ b/electron/native-process-audio-listener.test.cjs
@@ -116,3 +116,27 @@ test("native listener cannot attach after it is stopped during discovery", async
 
   assert.equal(spawnCount, 0);
 });
+
+test("native listener resolves the configured application before capture", async () => {
+  let discoveryOptions = null;
+  const voiceSource = {
+    mode: "application",
+    process_pattern: null,
+    source_id: "process:darwin:Vm9pY2U",
+    source_name: "Voice",
+  };
+  const listener = new NativeProcessAudioListener({
+    platform: "darwin",
+    helperPath: __filename,
+    voiceSource,
+    processDiscovery: async (options) => {
+      discoveryOptions = options;
+      return { pids: [], rootPids: [] };
+    },
+  });
+
+  await listener.start();
+  listener.stop();
+
+  assert.deepEqual(discoveryOptions.voiceSource, voiceSource);
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -44,6 +44,8 @@ contextBridge.exposeInMainWorld("personaSettings", {
     ipcRenderer.invoke("persona:settings-set-character-size", size),
   setVoiceSource: (voiceSource) =>
     ipcRenderer.invoke("persona:settings-set-voice-source", voiceSource),
+  listVoiceSources: () =>
+    ipcRenderer.invoke("persona:settings-list-voice-sources"),
   setModelLighting: (modelId, lighting) =>
     ipcRenderer.invoke(
       "persona:settings-set-model-lighting",

--- a/electron/preload.test.cjs
+++ b/electron/preload.test.cjs
@@ -79,6 +79,7 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
     mode: "custom",
     process_pattern: "local-tts",
   });
+  await settings.listVoiceSources();
   await settings.setModelLighting("model-id", {
     exposure: 1.2,
     environment_intensity: 0.35,
@@ -123,6 +124,7 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
       "persona:settings-set-voice-source",
       { mode: "custom", process_pattern: "local-tts" },
     ],
+    ["persona:settings-list-voice-sources"],
     [
       "persona:settings-set-model-lighting",
       "model-id",

--- a/electron/process-discovery.cjs
+++ b/electron/process-discovery.cjs
@@ -5,6 +5,8 @@ const { promisify } = require("node:util");
 const {
   DEFAULT_VOICE_APP_PATTERN,
   configuredPattern,
+  normalizeVoiceSource,
+  processMatchesSource,
 } = require("./voice-source.cjs");
 
 const execFileAsync = promisify(execFile);
@@ -12,14 +14,32 @@ const execFileAsync = promisify(execFile);
 function parseMacProcessList(output) {
   return output
     .split(/\r?\n/)
-    .map((line) => /^\s*(\d+)\s+(\d+)\s+(\S+)(?:\s+(.*))?$/.exec(line))
+    .map((line) => /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/.exec(line))
     .filter(Boolean)
     .map((match) => ({
       pid: Number(match[1]),
       parentId: Number(match[2]),
       name: match[3],
-      command: match[4] ?? "",
+      executable: match[3],
+      command: "",
     }));
+}
+
+function parseMacCommandList(output) {
+  return new Map(
+    output
+      .split(/\r?\n/)
+      .map((line) => /^\s*(\d+)\s+(.+?)\s*$/.exec(line))
+      .filter(Boolean)
+      .map((match) => [Number(match[1]), match[2]]),
+  );
+}
+
+function mergeMacProcessCommands(processes, commands) {
+  return processes.map((process) => ({
+    ...process,
+    command: commands.get(process.pid) ?? "",
+  }));
 }
 
 function parseWindowsProcessList(output) {
@@ -31,6 +51,7 @@ function parseWindowsProcessList(output) {
       pid: Number(process.ProcessId),
       parentId: Number(process.ParentProcessId),
       name: String(process.Name ?? ""),
+      executable: String(process.ExecutablePath ?? process.Name ?? ""),
       command: String(process.CommandLine ?? ""),
     }))
     .filter((process) => Number.isInteger(process.pid) && process.pid > 0);
@@ -38,17 +59,30 @@ function parseWindowsProcessList(output) {
 
 function identityMatches(process, pattern = DEFAULT_VOICE_APP_PATTERN) {
   pattern.lastIndex = 0;
-  return pattern.test(`${process.name} ${process.command}`);
+  return pattern.test(
+    `${process.name} ${process.executable ?? ""} ${process.command}`,
+  );
 }
 
-function selectVoiceProcessTree(processes, {
-  ownProcessId = process.pid,
-  pattern = DEFAULT_VOICE_APP_PATTERN,
-} = {}) {
+function selectVoiceProcessTree(
+  processes,
+  {
+    ownProcessId = process.pid,
+    pattern = DEFAULT_VOICE_APP_PATTERN,
+    platform = process.platform,
+    sourceId = null,
+  } = {},
+) {
   const byId = new Map(processes.map((entry) => [entry.pid, entry]));
   const directlyMatched = new Set(
     processes
-      .filter((entry) => entry.pid !== ownProcessId && identityMatches(entry, pattern))
+      .filter(
+        (entry) =>
+          entry.pid !== ownProcessId &&
+          (sourceId
+            ? processMatchesSource(entry, platform, sourceId)
+            : identityMatches(entry, pattern)),
+      )
       .map((entry) => entry.pid),
   );
   const matched = new Set();
@@ -76,24 +110,28 @@ function selectVoiceProcessTree(processes, {
   };
 }
 
-async function discoverVoiceProcesses({
+async function listPlatformProcesses({
   platform = process.platform,
   run = execFileAsync,
-  environment = process.env,
-  ownProcessId = process.pid,
-  pattern = null,
 } = {}) {
-  let processes;
   if (platform === "darwin") {
-    const { stdout } = await run("ps", ["-axo", "pid=,ppid=,comm=,args="], {
+    const options = {
       encoding: "utf8",
       maxBuffer: 4 * 1024 * 1024,
       timeout: 3_000,
-    });
-    processes = parseMacProcessList(stdout);
-  } else if (platform === "win32") {
+    };
+    const [identityResult, commandResult] = await Promise.all([
+      run("ps", ["-axo", "pid=,ppid=,comm="], options),
+      run("ps", ["-axo", "pid=,args="], options),
+    ]);
+    return mergeMacProcessCommands(
+      parseMacProcessList(identityResult.stdout),
+      parseMacCommandList(commandResult.stdout),
+    );
+  }
+  if (platform === "win32") {
     const command =
-      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress";
+      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,ExecutablePath,CommandLine | ConvertTo-Json -Compress";
     const { stdout } = await run(
       "powershell.exe",
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
@@ -104,13 +142,26 @@ async function discoverVoiceProcesses({
         windowsHide: true,
       },
     );
-    processes = parseWindowsProcessList(stdout);
-  } else {
-    return { pids: [], rootPids: [] };
+    return parseWindowsProcessList(stdout);
   }
+  return [];
+}
 
+async function discoverVoiceProcesses({
+  platform = process.platform,
+  run = execFileAsync,
+  environment = process.env,
+  ownProcessId = process.pid,
+  pattern = null,
+  voiceSource = null,
+} = {}) {
+  const processes = await listPlatformProcesses({ platform, run });
+  const selected = normalizeVoiceSource(voiceSource);
   return selectVoiceProcessTree(processes, {
     ownProcessId,
+    platform,
+    sourceId:
+      selected.mode === "application" ? selected.source_id : null,
     pattern: pattern ?? configuredPattern(environment),
   });
 }
@@ -120,6 +171,9 @@ module.exports = {
   configuredPattern,
   discoverVoiceProcesses,
   identityMatches,
+  listPlatformProcesses,
+  mergeMacProcessCommands,
+  parseMacCommandList,
   parseMacProcessList,
   parseWindowsProcessList,
   selectVoiceProcessTree,

--- a/electron/process-discovery.test.cjs
+++ b/electron/process-discovery.test.cjs
@@ -4,17 +4,27 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 const {
   configuredPattern,
+  mergeMacProcessCommands,
+  parseMacCommandList,
   parseMacProcessList,
   parseWindowsProcessList,
   selectVoiceProcessTree,
 } = require("./process-discovery.cjs");
+const { sourceFromProcess } = require("./voice-source.cjs");
 
 test("parses macOS ps output and includes a Codex helper process tree", () => {
-  const processes = parseMacProcessList(`
-  10 1 /Applications/Codex.app/Contents/MacOS/Codex /Applications/Codex.app/Contents/MacOS/Codex
-  11 10 /Applications/Codex Helper /Applications/Codex.app/Contents/Frameworks/Codex Helper --type=utility
-  20 1 /Applications/Music.app/MacOS/Music /Applications/Music.app/MacOS/Music
-`);
+  const processes = mergeMacProcessCommands(
+    parseMacProcessList(`
+  10 1 /Applications/Codex.app/Contents/MacOS/Codex
+  11 10 /Applications/Codex Helper.app/Contents/MacOS/Codex Helper
+  20 1 /Applications/Music.app/MacOS/Music
+`),
+    parseMacCommandList(`
+  10 /Applications/Codex.app/Contents/MacOS/Codex
+  11 /Applications/Codex Helper.app/Contents/MacOS/Codex Helper --type=utility
+  20 /Applications/Music.app/MacOS/Music
+`),
+  );
   assert.deepEqual(selectVoiceProcessTree(processes, { ownProcessId: 99 }), {
     pids: [10, 11],
     rootPids: [10],
@@ -28,6 +38,7 @@ test("parses one or many Windows CIM process records", () => {
         ProcessId: 100,
         ParentProcessId: 1,
         Name: "Codex.exe",
+        ExecutablePath: "C:\\Program Files\\Codex\\Codex.exe",
         CommandLine: '"C:\\\\Program Files\\\\Codex\\\\Codex.exe"',
       },
       {
@@ -43,6 +54,34 @@ test("parses one or many Windows CIM process records", () => {
     rootPids: [100],
   });
   assert.equal(parseWindowsProcessList('{"ProcessId":7,"Name":"ChatGPT.exe"}')[0].pid, 7);
+});
+
+test("selects a saved native application by stable executable identity", () => {
+  const processes = [
+    {
+      pid: 70,
+      parentId: 1,
+      name: "Voice Engine",
+      executable: "/Applications/Voice Engine.app/Contents/MacOS/Voice Engine",
+      command: "Voice Engine --server",
+    },
+    {
+      pid: 71,
+      parentId: 70,
+      name: "Voice Helper",
+      executable: "/Applications/Voice Engine.app/Contents/MacOS/Voice Helper",
+      command: "Voice Helper --audio",
+    },
+  ];
+  const source = sourceFromProcess("darwin", processes[0]);
+  assert.deepEqual(
+    selectVoiceProcessTree(processes, {
+      ownProcessId: 999,
+      platform: "darwin",
+      sourceId: source.id,
+    }),
+    { pids: [70, 71], rootPids: [70] },
+  );
 });
 
 test("supports a custom target application pattern without accepting invalid regex", () => {

--- a/electron/settings-store.cjs
+++ b/electron/settings-store.cjs
@@ -12,10 +12,10 @@ const {
 const {
   DEFAULT_VOICE_SOURCE,
   normalizeVoiceSource,
-  sanitizeVoiceSourcePattern,
+  sanitizeVoiceSource,
 } = require("./voice-source.cjs");
 
-const SETTINGS_SCHEMA_VERSION = 4;
+const SETTINGS_SCHEMA_VERSION = 5;
 const DEFAULT_PACKAGED_LIBRARY_PATH = path.join(
   __dirname,
   "..",
@@ -337,7 +337,7 @@ function safeReadState(settingsPath, packagedLibrary) {
   const fallback = defaultState(packagedLibrary);
   try {
     const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
-    if (![1, 2, 3, SETTINGS_SCHEMA_VERSION].includes(parsed?.schema_version)) {
+    if (![1, 2, 3, 4, SETTINGS_SCHEMA_VERSION].includes(parsed?.schema_version)) {
       return { migrated: false, state: fallback };
     }
     const { hidden, overrides } = packagedUserLayers(parsed, packagedLibrary);
@@ -365,7 +365,7 @@ function safeReadState(settingsPath, packagedLibrary) {
     };
 
     if (parsed.schema_version !== SETTINGS_SCHEMA_VERSION) {
-      if (parsed.schema_version === 3) {
+      if ([3, 4].includes(parsed.schema_version)) {
         const animations = sanitizeUserAnimations(parsed.animations);
         const knownAnimationIds = new Set([
           ...packagedLibrary.animations.map((animation) => animation.id),
@@ -830,16 +830,7 @@ function createSettingsStore({
   }
 
   function setVoiceSource(value) {
-    const mode = value?.mode === "custom" ? "custom" : "default";
-    if (mode === "default") {
-      state.voice_source = { ...DEFAULT_VOICE_SOURCE };
-      writeState();
-      return getSnapshot();
-    }
-    state.voice_source = {
-      mode: "custom",
-      process_pattern: sanitizeVoiceSourcePattern(value?.process_pattern),
-    };
+    state.voice_source = sanitizeVoiceSource(value);
     writeState();
     return getSnapshot();
   }

--- a/electron/settings-store.test.cjs
+++ b/electron/settings-store.test.cjs
@@ -213,7 +213,7 @@ test("keeps user library records when migrating the earlier settings schema", (c
   );
 
   const snapshot = createSettingsStore({ userDataPath, packagedLibraryPath }).getSnapshot();
-  assert.equal(snapshot.schema_version, 4);
+  assert.equal(snapshot.schema_version, 5);
   assert.equal(snapshot.default_model_id, modelId);
   assert.equal(snapshot.character_size, 1.15);
   assert.ok(snapshot.models.some((model) => model.id === modelId));
@@ -533,51 +533,86 @@ test("groups multiple uploaded clips under one action and removes them independe
   );
 });
 
-test("persists a custom voice source and migrates older settings to schema 4", (context) => {
+test("persists every voice source mode and migrates schema 4 settings", (context) => {
   const { userDataPath, packagedLibraryPath } = fixture(context);
   const store = createSettingsStore({ userDataPath, packagedLibraryPath });
   assert.deepEqual(store.getSnapshot().voice_source, {
     mode: "default",
     process_pattern: null,
+    source_id: null,
+    source_name: null,
   });
 
   let snapshot = store.setVoiceSource({
     mode: "custom",
     process_pattern: "  local-tts|open-webui  ",
   });
-  assert.equal(snapshot.schema_version, 4);
+  assert.equal(snapshot.schema_version, 5);
   assert.deepEqual(snapshot.voice_source, {
     mode: "custom",
     process_pattern: "local-tts|open-webui",
+    source_id: null,
+    source_name: null,
   });
   assert.throws(
     () => store.setVoiceSource({ mode: "custom", process_pattern: "[" }),
     /valid regular expression/,
   );
 
-  snapshot = store.setVoiceSource({ mode: "default", process_pattern: null });
-  assert.deepEqual(snapshot.voice_source, {
-    mode: "default",
+  snapshot = store.setVoiceSource({
+    mode: "application",
     process_pattern: null,
+    source_id: "process:win32:Vm9pY2U",
+    source_name: "Voice",
   });
+  assert.deepEqual(snapshot.voice_source, {
+    mode: "application",
+    process_pattern: null,
+    source_id: "process:win32:Vm9pY2U",
+    source_name: "Voice",
+  });
+
+  snapshot = store.setVoiceSource({ mode: "external" });
+  assert.deepEqual(snapshot.voice_source, {
+    mode: "external",
+    process_pattern: null,
+    source_id: null,
+    source_name: null,
+  });
+
+  assert.throws(
+    () =>
+      store.setVoiceSource({
+        mode: "application",
+        source_id: "arbitrary",
+        source_name: "Voice",
+      }),
+    /valid application/,
+  );
 
   fs.writeFileSync(
     path.join(userDataPath, "settings.json"),
     JSON.stringify({
-      schema_version: 3,
+      schema_version: 4,
       models: [],
       animations: [],
       animation_clips: {},
       model_lighting: {},
+      voice_source: {
+        mode: "custom",
+        process_pattern: "voice-engine",
+      },
     }),
   );
   const migrated = createSettingsStore({
     userDataPath,
     packagedLibraryPath,
   }).getSnapshot();
-  assert.equal(migrated.schema_version, 4);
+  assert.equal(migrated.schema_version, 5);
   assert.deepEqual(migrated.voice_source, {
-    mode: "default",
-    process_pattern: null,
+    mode: "custom",
+    process_pattern: "voice-engine",
+    source_id: null,
+    source_name: null,
   });
 });

--- a/electron/voice-source-discovery.cjs
+++ b/electron/voice-source-discovery.cjs
@@ -1,0 +1,103 @@
+"use strict";
+
+const { execFile } = require("node:child_process");
+const { promisify } = require("node:util");
+const {
+  pipeWireSourceFromProperties,
+  sourceFromProcess,
+} = require("./voice-source.cjs");
+const {
+  enrichPipeWireNodes,
+  nodeProperties,
+} = require("./linux-pipewire-listener.cjs");
+const { listPlatformProcesses } = require("./process-discovery.cjs");
+
+const execFileAsync = promisify(execFile);
+
+function uniqueSortedSources(sources) {
+  const byId = new Map();
+  for (const source of sources) {
+    if (!source || byId.has(source.id)) continue;
+    byId.set(source.id, source);
+  }
+  return [...byId.values()]
+    .sort(
+      (left, right) =>
+        left.name.localeCompare(right.name, undefined, {
+          sensitivity: "base",
+        }) ||
+        left.detail.localeCompare(right.detail, undefined, {
+          sensitivity: "base",
+        }),
+    )
+    .slice(0, 500);
+}
+
+function pipeWireSources(objects) {
+  return uniqueSortedSources(
+    enrichPipeWireNodes(objects)
+      .filter(
+        (object) =>
+          object?.type === "PipeWire:Interface:Node" &&
+          nodeProperties(object)["media.class"] === "Stream/Output/Audio",
+      )
+      .map((node) => pipeWireSourceFromProperties(nodeProperties(node))),
+  );
+}
+
+function processBelongsToPersona(process, byId, ownProcessId) {
+  let current = process;
+  const visited = new Set();
+  for (let depth = 0; current && depth < 20; depth += 1) {
+    if (current.pid === ownProcessId) return true;
+    if (visited.has(current.pid)) break;
+    visited.add(current.pid);
+    current = byId.get(current.parentId);
+  }
+  return false;
+}
+
+function processSources(platform, processes, ownProcessId = process.pid) {
+  const byId = new Map(processes.map((entry) => [entry.pid, entry]));
+  return uniqueSortedSources(
+    processes
+      .filter(
+        (entry) =>
+          !processBelongsToPersona(entry, byId, ownProcessId),
+      )
+      .map((entry) => sourceFromProcess(platform, entry)),
+  );
+}
+
+async function listVoiceSources({
+  platform = process.platform,
+  run = execFileAsync,
+  ownProcessId = process.pid,
+} = {}) {
+  if (platform === "linux") {
+    const { stdout } = await run("pw-dump", [], {
+      encoding: "utf8",
+      maxBuffer: 8 * 1024 * 1024,
+      timeout: 2_500,
+    });
+    return {
+      platform,
+      sources: pipeWireSources(JSON.parse(stdout)),
+    };
+  }
+  if (platform === "darwin" || platform === "win32") {
+    const processes = await listPlatformProcesses({ platform, run });
+    return {
+      platform,
+      sources: processSources(platform, processes, ownProcessId),
+    };
+  }
+  return { platform, sources: [] };
+}
+
+module.exports = {
+  listVoiceSources,
+  pipeWireSources,
+  processSources,
+  uniqueSortedSources,
+};

--- a/electron/voice-source-discovery.test.cjs
+++ b/electron/voice-source-discovery.test.cjs
@@ -1,0 +1,140 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  listVoiceSources,
+  pipeWireSources,
+  processSources,
+} = require("./voice-source-discovery.cjs");
+
+test("lists distinct PipeWire playback streams and ignores input nodes", () => {
+  const sources = pipeWireSources([
+    {
+      id: 1,
+      type: "PipeWire:Interface:Node",
+      info: {
+        state: "running",
+        props: {
+          "application.name": "Electron",
+          "application.process.binary": "voice-ui",
+          "media.class": "Stream/Output/Audio",
+          "node.name": "voice-output",
+        },
+      },
+    },
+    {
+      id: 2,
+      type: "PipeWire:Interface:Node",
+      info: {
+        state: "running",
+        props: {
+          "application.name": "Electron",
+          "application.process.binary": "music-ui",
+          "media.class": "Stream/Output/Audio",
+          "node.name": "music-output",
+        },
+      },
+    },
+    {
+      id: 3,
+      type: "PipeWire:Interface:Node",
+      info: {
+        props: {
+          "application.name": "Microphone",
+          "media.class": "Stream/Input/Audio",
+        },
+      },
+    },
+  ]);
+  assert.equal(sources.length, 2);
+  assert.notEqual(sources[0].id, sources[1].id);
+});
+
+test("lists unique native applications without exposing arguments or Persona children", () => {
+  const sources = processSources(
+    "darwin",
+    [
+      {
+        pid: 10,
+        parentId: 1,
+        name: "/Applications/Voice.app/Contents/MacOS/Voice",
+        executable: "/Applications/Voice.app/Contents/MacOS/Voice",
+        command: "Voice --api-key secret",
+      },
+      {
+        pid: 11,
+        parentId: 10,
+        name: "/Applications/Voice.app/Contents/MacOS/Voice",
+        executable: "/Applications/Voice.app/Contents/MacOS/Voice",
+        command: "Voice --child",
+      },
+      {
+        pid: 99,
+        parentId: 1,
+        name: "Persona",
+        executable: "/Applications/Persona.app/Contents/MacOS/Persona",
+        command: "Persona",
+      },
+      {
+        pid: 100,
+        parentId: 99,
+        name: "Persona Helper",
+        executable: "/Applications/Persona.app/Contents/MacOS/Persona Helper",
+        command: "Persona Helper --renderer",
+      },
+    ],
+    99,
+  );
+  assert.equal(sources.length, 1);
+  assert.equal(sources[0].name, "Voice");
+  assert.equal(sources[0].detail.includes("secret"), false);
+});
+
+test("routes discovery through each supported platform adapter", async () => {
+  const linux = await listVoiceSources({
+    platform: "linux",
+    run: async () => ({
+      stdout: JSON.stringify([
+        {
+          id: 10,
+          type: "PipeWire:Interface:Node",
+          info: {
+            props: {
+              "application.name": "Voice",
+              "media.class": "Stream/Output/Audio",
+              "node.name": "voice-output",
+            },
+          },
+        },
+      ]),
+    }),
+  });
+  assert.equal(linux.sources[0].name, "Voice");
+
+  const mac = await listVoiceSources({
+    platform: "darwin",
+    ownProcessId: 999,
+    run: async (_command, args) => ({
+      stdout: args[1].includes("ppid")
+        ? "10 1 /Applications/Voice Engine.app/Contents/MacOS/Voice Engine\n"
+        : "10 /Applications/Voice Engine.app/Contents/MacOS/Voice Engine --serve\n",
+    }),
+  });
+  assert.equal(mac.sources[0].name, "Voice Engine");
+
+  const windows = await listVoiceSources({
+    platform: "win32",
+    ownProcessId: 999,
+    run: async () => ({
+      stdout: JSON.stringify({
+        ProcessId: 20,
+        ParentProcessId: 1,
+        Name: "Voice.exe",
+        ExecutablePath: "C:\\Apps\\Voice.exe",
+        CommandLine: "Voice.exe --serve",
+      }),
+    }),
+  });
+  assert.equal(windows.sources[0].name, "Voice");
+});

--- a/electron/voice-source.cjs
+++ b/electron/voice-source.cjs
@@ -1,8 +1,22 @@
 "use strict";
 
+const path = require("node:path");
+
+const VOICE_SOURCE_MODES = new Set([
+  "default",
+  "application",
+  "custom",
+  "external",
+]);
+const VOICE_SOURCE_ID_PATTERN =
+  /^(?:process:(?:darwin|win32)|pipewire:(?:application|binary|node|stream)):[A-Za-z0-9_-]{1,2048}$/;
+const MAX_VOICE_SOURCE_NAME_LENGTH = 120;
+
 const DEFAULT_VOICE_SOURCE = Object.freeze({
   mode: "default",
   process_pattern: null,
+  source_id: null,
+  source_name: null,
 });
 
 const DEFAULT_VOICE_APP_PATTERN_SOURCE =
@@ -14,6 +28,27 @@ const DEFAULT_VOICE_APP_PATTERN = new RegExp(
 );
 
 const MAX_VOICE_SOURCE_PATTERN_LENGTH = 200;
+
+function emptyVoiceSource(mode = "default") {
+  return {
+    mode,
+    process_pattern: null,
+    source_id: null,
+    source_name: null,
+  };
+}
+
+function cleanSourceName(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().replace(/\s+/g, " ");
+  if (
+    !normalized ||
+    normalized.length > MAX_VOICE_SOURCE_NAME_LENGTH
+  ) {
+    return null;
+  }
+  return normalized;
+}
 
 function compileVoiceSourcePattern(source) {
   if (typeof source !== "string" || !source.trim()) {
@@ -40,7 +75,6 @@ function sanitizeVoiceSourcePattern(value) {
     );
   }
   try {
-    // Ensure the pattern compiles before persisting it.
     new RegExp(normalized, "i");
   } catch {
     throw new Error("Process pattern must be a valid regular expression.");
@@ -48,16 +82,68 @@ function sanitizeVoiceSourcePattern(value) {
   return normalized;
 }
 
-function normalizeVoiceSource(value) {
-  const mode = value?.mode === "custom" ? "custom" : "default";
-  if (mode === "default") {
-    return { mode: "default", process_pattern: null };
+function isValidVoiceSourceId(value) {
+  if (typeof value !== "string" || !VOICE_SOURCE_ID_PATTERN.test(value)) {
+    return false;
   }
+  const processMatch = /^process:(?:darwin|win32):([A-Za-z0-9_-]+)$/.exec(
+    value,
+  );
+  if (processMatch) return Boolean(decodeIdentity(processMatch[1])?.trim());
+
+  const legacyMatch =
+    /^pipewire:(?:application|binary|node):([A-Za-z0-9_-]+)$/.exec(value);
+  if (legacyMatch) return Boolean(decodeIdentity(legacyMatch[1])?.trim());
+
+  const streamMatch = /^pipewire:stream:([A-Za-z0-9_-]+)$/.exec(value);
+  if (!streamMatch) return false;
   try {
+    const decoded = decodeIdentity(streamMatch[1]);
+    const identity = decoded == null ? null : JSON.parse(decoded);
+    if (!identity || typeof identity !== "object" || Array.isArray(identity)) {
+      return false;
+    }
+    return ["application", "binary", "node"].some(
+      (field) =>
+        typeof identity[field] === "string" &&
+        cleanSourceName(identity[field]) === identity[field],
+    );
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeVoiceSource(value) {
+  if (!VOICE_SOURCE_MODES.has(value?.mode)) {
+    throw new Error("Voice source mode is invalid.");
+  }
+  if (value.mode === "custom") {
     return {
-      mode: "custom",
-      process_pattern: sanitizeVoiceSourcePattern(value?.process_pattern),
+      ...emptyVoiceSource("custom"),
+      process_pattern: sanitizeVoiceSourcePattern(value.process_pattern),
     };
+  }
+  if (value.mode === "application") {
+    const sourceId =
+      isValidVoiceSourceId(value.source_id)
+        ? value.source_id
+        : null;
+    const sourceName = cleanSourceName(value.source_name);
+    if (!sourceId || !sourceName) {
+      throw new Error("Select a valid application voice source.");
+    }
+    return {
+      ...emptyVoiceSource("application"),
+      source_id: sourceId,
+      source_name: sourceName,
+    };
+  }
+  return emptyVoiceSource(value.mode);
+}
+
+function normalizeVoiceSource(value) {
+  try {
+    return sanitizeVoiceSource(value);
   } catch {
     return { ...DEFAULT_VOICE_SOURCE };
   }
@@ -86,15 +172,142 @@ function configuredPattern(environment = process.env) {
   return resolveVoiceSourcePattern({ environment });
 }
 
+function encodeIdentity(value) {
+  return Buffer.from(String(value), "utf8").toString("base64url");
+}
+
+function decodeIdentity(value) {
+  try {
+    return Buffer.from(value, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+function normalizeProcessIdentity(value, platform) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) return "";
+  return platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function processIdentity(process, platform) {
+  return normalizeProcessIdentity(
+    process?.executable || process?.name,
+    platform,
+  );
+}
+
+function processSourceId(platform, process) {
+  if (!["darwin", "win32"].includes(platform)) return null;
+  const identity = processIdentity(process, platform);
+  return identity ? `process:${platform}:${encodeIdentity(identity)}` : null;
+}
+
+function processSourceLabel(platform, process) {
+  const executable = String(process?.executable || process?.name || "").trim();
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  const filename = pathApi.basename(executable) || String(process?.name || "");
+  return filename.replace(/\.exe$/i, "") || "Application";
+}
+
+function sourceFromProcess(platform, process) {
+  const id = processSourceId(platform, process);
+  if (!id) return null;
+  const executable = String(process?.executable || process?.name || "").trim();
+  return {
+    id,
+    name: processSourceLabel(platform, process),
+    detail: executable,
+    platform,
+  };
+}
+
+function processMatchesSource(process, platform, sourceId) {
+  return processSourceId(platform, process) === sourceId;
+}
+
+function cleanPipeWireIdentity(properties) {
+  const identity = {
+    application: cleanSourceName(properties?.["application.name"]),
+    binary: cleanSourceName(properties?.["application.process.binary"]),
+    node: cleanSourceName(properties?.["node.name"]),
+  };
+  return Object.values(identity).some(Boolean) ? identity : null;
+}
+
+function pipeWireSourceFromProperties(properties) {
+  const identity = cleanPipeWireIdentity(properties);
+  if (!identity) return null;
+  const detailParts = [identity.binary, identity.node].filter(
+    (value, index, values) => value && values.indexOf(value) === index,
+  );
+  return {
+    id: `pipewire:stream:${encodeIdentity(JSON.stringify(identity))}`,
+    name:
+      identity.application ??
+      cleanSourceName(properties?.["node.description"]) ??
+      identity.binary ??
+      identity.node ??
+      "Audio stream",
+    detail: detailParts.join(" · ") || identity.application || "Playback stream",
+    platform: "linux",
+  };
+}
+
+function matchesLegacyPipeWireSource(properties, kind, encodedValue) {
+  const value = decodeIdentity(encodedValue);
+  if (value == null) return false;
+  const property =
+    kind === "application"
+      ? "application.name"
+      : kind === "binary"
+        ? "application.process.binary"
+        : "node.name";
+  return properties?.[property] === value;
+}
+
+function pipeWirePropertiesMatchSource(properties, sourceId) {
+  const legacy = /^pipewire:(application|binary|node):([A-Za-z0-9_-]+)$/.exec(
+    String(sourceId),
+  );
+  if (legacy) return matchesLegacyPipeWireSource(properties, legacy[1], legacy[2]);
+
+  const match = /^pipewire:stream:([A-Za-z0-9_-]+)$/.exec(String(sourceId));
+  if (!match) return false;
+  try {
+    const decoded = decodeIdentity(match[1]);
+    const expected = decoded == null ? null : JSON.parse(decoded);
+    const actual = cleanPipeWireIdentity(properties);
+    if (!expected || !actual) return false;
+    return ["application", "binary", "node"].every(
+      (field) => expected[field] == null || expected[field] === actual[field],
+    );
+  } catch {
+    return false;
+  }
+}
+
 module.exports = {
   DEFAULT_VOICE_APP_PATTERN,
   DEFAULT_VOICE_APP_PATTERN_SOURCE,
   DEFAULT_VOICE_SOURCE,
+  MAX_VOICE_SOURCE_NAME_LENGTH,
   MAX_VOICE_SOURCE_PATTERN_LENGTH,
+  VOICE_SOURCE_ID_PATTERN,
+  VOICE_SOURCE_MODES,
+  cleanSourceName,
   compileVoiceSourcePattern,
   configuredPattern,
+  emptyVoiceSource,
+  isValidVoiceSourceId,
   normalizeVoiceSource,
+  pipeWirePropertiesMatchSource,
+  pipeWireSourceFromProperties,
+  processMatchesSource,
+  processSourceId,
   resolveVoiceSourcePattern,
+  sanitizeVoiceSource,
   sanitizeVoiceSourcePattern,
   settingsPatternFromVoiceSource,
+  sourceFromProcess,
 };

--- a/electron/voice-source.test.cjs
+++ b/electron/voice-source.test.cjs
@@ -8,9 +8,14 @@ const {
   compileVoiceSourcePattern,
   configuredPattern,
   normalizeVoiceSource,
+  pipeWirePropertiesMatchSource,
+  pipeWireSourceFromProperties,
+  processMatchesSource,
   resolveVoiceSourcePattern,
+  sanitizeVoiceSource,
   sanitizeVoiceSourcePattern,
   settingsPatternFromVoiceSource,
+  sourceFromProcess,
 } = require("./voice-source.cjs");
 
 test("compiles the shared default ChatGPT and Codex pattern", () => {
@@ -54,7 +59,12 @@ test("sanitizes and normalizes persisted voice source values", () => {
   assert.deepEqual(normalizeVoiceSource(null), DEFAULT_VOICE_SOURCE);
   assert.deepEqual(
     normalizeVoiceSource({ mode: "custom", process_pattern: "local-tts" }),
-    { mode: "custom", process_pattern: "local-tts" },
+    {
+      mode: "custom",
+      process_pattern: "local-tts",
+      source_id: null,
+      source_name: null,
+    },
   );
   assert.deepEqual(
     normalizeVoiceSource({ mode: "custom", process_pattern: "[" }),
@@ -68,7 +78,85 @@ test("sanitizes and normalizes persisted voice source values", () => {
     "local-tts",
   );
   assert.equal(
-    settingsPatternFromVoiceSource({ mode: "default", process_pattern: null }),
+    settingsPatternFromVoiceSource(DEFAULT_VOICE_SOURCE),
     null,
   );
+});
+
+test("normalizes all voice modes and rejects arbitrary application IDs", () => {
+  assert.deepEqual(
+    sanitizeVoiceSource({
+      mode: "external",
+      process_pattern: "ignored",
+      source_id: "ignored",
+      source_name: "Ignored",
+    }),
+    {
+      mode: "external",
+      process_pattern: null,
+      source_id: null,
+      source_name: null,
+    },
+  );
+  assert.deepEqual(
+    normalizeVoiceSource({
+      mode: "application",
+      source_id: "arbitrary",
+      source_name: "Voice",
+    }),
+    DEFAULT_VOICE_SOURCE,
+  );
+  assert.throws(
+    () =>
+      sanitizeVoiceSource({
+        mode: "application",
+        source_id: "arbitrary",
+        source_name: "Voice",
+      }),
+    /valid application/,
+  );
+  assert.deepEqual(
+    normalizeVoiceSource({
+      mode: "application",
+      source_id: "pipewire:stream:e30",
+      source_name: "Everything",
+    }),
+    DEFAULT_VOICE_SOURCE,
+  );
+});
+
+test("creates stable native process sources and matches Windows paths case-insensitively", () => {
+  const source = sourceFromProcess("win32", {
+    name: "Voice.exe",
+    executable: "C:\\Apps\\Voice\\Voice.exe",
+  });
+  assert.equal(source.name, "Voice");
+  assert.equal(
+    processMatchesSource(
+      {
+        name: "voice.exe",
+        executable: "c:\\apps\\voice\\voice.exe",
+      },
+      "win32",
+      source.id,
+    ),
+    true,
+  );
+});
+
+test("creates exact PipeWire stream sources without collapsing generic Electron apps", () => {
+  const voiceProperties = {
+    "application.name": "Electron",
+    "application.process.binary": "voice-ui",
+    "node.name": "voice-output",
+  };
+  const musicProperties = {
+    "application.name": "Electron",
+    "application.process.binary": "music-ui",
+    "node.name": "music-output",
+  };
+  const source = pipeWireSourceFromProperties(voiceProperties);
+  assert.equal(source.name, "Electron");
+  assert.equal(pipeWirePropertiesMatchSource(voiceProperties, source.id), true);
+  assert.equal(pipeWirePropertiesMatchSource(musicProperties, source.id), false);
 });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -184,12 +184,18 @@ export function SettingsPage() {
   const [notice, setNotice] = useState<string | null>(null);
   const [mcpStatus, setMcpStatus] = useState<PersonaMcpStatus | null>(null);
   const [mcpLoading, setMcpLoading] = useState(false);
-  const [voiceMode, setVoiceMode] = useState<'default' | 'custom'>(
+  const [voiceMode, setVoiceMode] = useState<
+    PersonaVoiceSourceSettings['mode']
+  >(
     SETTINGS_FALLBACK.voice_source.mode,
   );
   const [voicePattern, setVoicePattern] = useState(
     SETTINGS_FALLBACK.voice_source.process_pattern ?? '',
   );
+  const [voiceCatalog, setVoiceCatalog] =
+    useState<PersonaVoiceSourceCatalog | null>(null);
+  const [voiceSourcesLoading, setVoiceSourcesLoading] = useState(false);
+  const [voiceSourceSearch, setVoiceSourceSearch] = useState('');
   const [confirmation, setConfirmation] =
     useState<ConfirmationRequest | null>(null);
   const [confirming, setConfirming] = useState(false);
@@ -310,26 +316,6 @@ export function SettingsPage() {
     [updateSnapshot],
   );
 
-  const saveVoiceSource = async () => {
-    if (!bridge) return;
-    await run(
-      () =>
-        bridge.setVoiceSource({
-          mode: voiceMode,
-          process_pattern: voiceMode === 'custom' ? voicePattern : null,
-        }),
-      voiceMode === 'custom'
-        ? 'Custom voice source saved. Persona will listen for matching playback.'
-        : 'Voice source reset to ChatGPT and Codex.',
-    );
-  };
-
-  const voiceSourceDirty =
-    voiceMode !== settings.voice_source.mode ||
-    (voiceMode === 'custom'
-      ? voicePattern.trim() !== (settings.voice_source.process_pattern ?? '')
-      : false);
-
   const refreshMcpStatus = useCallback(async () => {
     setMcpLoading(true);
     try {
@@ -345,10 +331,30 @@ export function SettingsPage() {
     }
   }, [bridge]);
 
+  const refreshVoiceSources = useCallback(async () => {
+    setVoiceSourcesLoading(true);
+    try {
+      if (!bridge) {
+        setVoiceCatalog(null);
+        return;
+      }
+      setVoiceCatalog(await bridge.listVoiceSources());
+    } catch (error) {
+      setNotice(errorMessage(error));
+    } finally {
+      setVoiceSourcesLoading(false);
+    }
+  }, [bridge]);
+
   useEffect(() => {
     if (section !== 'mcp') return;
     void refreshMcpStatus();
   }, [refreshMcpStatus, section, settings.animations]);
+
+  useEffect(() => {
+    if (section !== 'voice') return;
+    void refreshVoiceSources();
+  }, [refreshVoiceSources, section]);
 
   const copyText = useCallback(async (value: string, label: string) => {
     try {
@@ -358,6 +364,67 @@ export function SettingsPage() {
       setNotice(`Unable to copy ${label.toLowerCase()}.`);
     }
   }, []);
+
+  const saveVoiceSource = async (
+    source: PersonaVoiceSourceSettings,
+    success: string,
+  ) => {
+    if (!bridge) return null;
+    const snapshot = await run(
+      () => bridge.setVoiceSource(source),
+      success,
+    );
+    if (!snapshot) {
+      setVoiceMode(settings.voice_source.mode);
+      return null;
+    }
+    setVoiceMode(snapshot.voice_source.mode);
+    void refreshVoiceSources();
+    return snapshot;
+  };
+
+  const chooseVoiceMode = (
+    mode: PersonaVoiceSourceSettings['mode'],
+  ) => {
+    setVoiceMode(mode);
+    if (mode === 'default' || mode === 'external') {
+      void saveVoiceSource(
+        {
+          mode,
+          process_pattern: null,
+          source_id: null,
+          source_name: null,
+        },
+        mode === 'default'
+          ? 'Automatic ChatGPT and Codex detection enabled.'
+          : 'External voice integration enabled.',
+      );
+    }
+  };
+
+  const chooseApplicationSource = (source: PersonaVoiceSource) => {
+    void saveVoiceSource(
+      {
+        mode: 'application',
+        process_pattern: null,
+        source_id: source.id,
+        source_name: source.name,
+      },
+      `Voice output source set to ${source.name}.`,
+    );
+  };
+
+  const saveCustomVoiceSource = () => {
+    void saveVoiceSource(
+      {
+        mode: 'custom',
+        process_pattern: voicePattern,
+        source_id: null,
+        source_name: null,
+      },
+      'Advanced process pattern saved.',
+    );
+  };
 
   const openConfirmation = useCallback((request: ConfirmationRequest) => {
     previousFocusRef.current =
@@ -689,15 +756,39 @@ export function SettingsPage() {
     setPreviewRequest((request) => request + 1);
   };
 
+  const normalizedVoiceSearch = voiceSourceSearch.trim().toLowerCase();
+  const visibleVoiceSources = (voiceCatalog?.sources ?? []).filter(
+    (source) =>
+      !normalizedVoiceSearch ||
+      `${source.name} ${source.detail}`
+        .toLowerCase()
+        .includes(normalizedVoiceSearch),
+  );
+  const selectedVoiceSourceAvailable = (voiceCatalog?.sources ?? []).some(
+    (source) => source.id === settings.voice_source.source_id,
+  );
+  const listenerStatus = voiceCatalog?.listener;
+  const voiceSourceDirty =
+    voiceMode !== settings.voice_source.mode ||
+    (voiceMode === 'custom' &&
+      voicePattern.trim() !==
+        (settings.voice_source.process_pattern ?? ''));
+  const voiceHeading =
+    settings.voice_source.mode === 'application'
+      ? settings.voice_source.source_name ?? 'Selected application'
+      : settings.voice_source.mode === 'custom'
+        ? 'Advanced process pattern'
+        : settings.voice_source.mode === 'external'
+          ? 'External events'
+          : 'Automatic detection';
+
   const headingSummary =
     section === 'mcp'
       ? mcpStatus
         ? `${mcpStatus.tools.length} tools · ${mcpStatus.playable_actions.length} playable actions`
         : 'Local agent connection'
       : section === 'voice'
-        ? settings.voice_source.mode === 'custom'
-          ? 'Custom process pattern'
-          : 'ChatGPT / Codex'
+        ? voiceHeading
         : `${customModelCount} custom models · ${customAnimationCount} custom actions`;
   const mcpHealth = mcpStatus?.health ?? (mcpLoading ? 'starting' : 'unavailable');
   const mcpServerUrl =
@@ -1619,28 +1710,44 @@ export function SettingsPage() {
               <section className="settings-panel voice-source-panel">
                 <div className="panel-heading">
                   <div>
-                    <h2>Automatic audio source</h2>
+                    <h2>Choose a voice source</h2>
                     <p>
-                      Persona listens only to playback from the selected
-                      application and turns its volume into lip sync. It does not
-                      capture the microphone, run models, or send audio anywhere.
+                      Persona observes output from one voice application and
+                      turns its volume into animation and lip sync.
                     </p>
                   </div>
                 </div>
 
                 <div
-                  aria-label="Voice source"
-                  className="theme-segmented"
+                  aria-label="Voice source mode"
+                  className="voice-mode-grid"
                   role="group"
                 >
                   <button
                     aria-pressed={voiceMode === 'default'}
                     data-testid="voice-mode-default"
                     disabled={busy || !bridge}
-                    onClick={() => setVoiceMode('default')}
+                    onClick={() => chooseVoiceMode('default')}
                     type="button"
                   >
-                    ChatGPT / Codex
+                    <span className="voice-mode-icon" aria-hidden="true">
+                      A
+                    </span>
+                    <strong>Automatic</strong>
+                    <small>Detect ChatGPT or Codex output.</small>
+                  </button>
+                  <button
+                    aria-pressed={voiceMode === 'application'}
+                    data-testid="voice-mode-application"
+                    disabled={busy || !bridge}
+                    onClick={() => setVoiceMode('application')}
+                    type="button"
+                  >
+                    <span className="voice-mode-icon" aria-hidden="true">
+                      ◎
+                    </span>
+                    <strong>Application</strong>
+                    <small>Pick a running app or playback stream.</small>
                   </button>
                   <button
                     aria-pressed={voiceMode === 'custom'}
@@ -1649,11 +1756,144 @@ export function SettingsPage() {
                     onClick={() => setVoiceMode('custom')}
                     type="button"
                   >
-                    Custom pattern
+                    <span className="voice-mode-icon" aria-hidden="true">
+                      .*
+                    </span>
+                    <strong>Advanced</strong>
+                    <small>Match processes with a regular expression.</small>
+                  </button>
+                  <button
+                    aria-pressed={voiceMode === 'external'}
+                    data-testid="voice-mode-external"
+                    disabled={busy || !bridge}
+                    onClick={() => chooseVoiceMode('external')}
+                    type="button"
+                  >
+                    <span className="voice-mode-icon" aria-hidden="true">
+                      ↗
+                    </span>
+                    <strong>External</strong>
+                    <small>Receive levels directly from a pipeline.</small>
                   </button>
                 </div>
+              </section>
 
-                {voiceMode === 'custom' && (
+              {voiceMode === 'application' && (
+                <section className="settings-panel voice-application-panel">
+                  <div className="panel-heading">
+                    <div>
+                      <h2>Application output</h2>
+                      <p>
+                        {voiceCatalog?.platform === 'linux'
+                          ? 'Play audio in the target app, then select its PipeWire playback stream.'
+                          : 'Start the target voice app, then select its running process.'}
+                      </p>
+                    </div>
+                    <button
+                      className="secondary-button"
+                      disabled={voiceSourcesLoading || !bridge}
+                      onClick={() => void refreshVoiceSources()}
+                      type="button"
+                    >
+                      {voiceSourcesLoading ? 'Refreshing…' : 'Refresh'}
+                    </button>
+                  </div>
+
+                  <label className="voice-source-search">
+                    <span>Filter applications</span>
+                    <input
+                      onChange={(event) =>
+                        setVoiceSourceSearch(event.currentTarget.value)
+                      }
+                      placeholder="Search by application, executable, or stream"
+                      type="search"
+                      value={voiceSourceSearch}
+                    />
+                  </label>
+
+                  {!voiceSourcesLoading &&
+                    voiceCatalog &&
+                    settings.voice_source.mode === 'application' &&
+                    !selectedVoiceSourceAvailable && (
+                      <div className="voice-saved-source">
+                        <div>
+                          <strong>
+                            {settings.voice_source.source_name ??
+                              'Saved application'}
+                          </strong>
+                          <small>Not currently running</small>
+                        </div>
+                        <span className="source-state unavailable">
+                          Unavailable
+                        </span>
+                      </div>
+                    )}
+
+                  <div className="voice-source-list">
+                    {visibleVoiceSources.map((source) => {
+                      const selected =
+                        settings.voice_source.mode === 'application' &&
+                        settings.voice_source.source_id === source.id;
+                      return (
+                        <button
+                          aria-pressed={selected}
+                          disabled={busy || !bridge}
+                          key={source.id}
+                          onClick={() => chooseApplicationSource(source)}
+                          type="button"
+                        >
+                          <span className="source-app-mark" aria-hidden="true">
+                            {source.name.slice(0, 1).toUpperCase()}
+                          </span>
+                          <span className="source-copy">
+                            <strong>{source.name}</strong>
+                            <small>{source.detail}</small>
+                          </span>
+                          <span
+                            className={`source-state ${
+                              selected ? 'selected' : ''
+                            }`}
+                          >
+                            {selected ? 'Selected' : 'Available'}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {voiceCatalog?.error && (
+                    <p className="mcp-error-message" role="alert">
+                      {voiceCatalog.error}
+                    </p>
+                  )}
+
+                  {!voiceSourcesLoading &&
+                    voiceCatalog &&
+                    !voiceCatalog?.error &&
+                    visibleVoiceSources.length === 0 && (
+                      <div className="empty-library">
+                        <strong>No matching voice sources</strong>
+                        <p>
+                          {voiceCatalog?.platform === 'linux'
+                            ? 'Start playback in the target application and refresh the list.'
+                            : 'Start the target application and refresh the list.'}
+                        </p>
+                      </div>
+                    )}
+                </section>
+              )}
+
+              {voiceMode === 'custom' && (
+                <section className="settings-panel voice-pattern-panel">
+                  <div className="panel-heading">
+                    <div>
+                      <h2>Advanced process pattern</h2>
+                      <p>
+                        Match output applications that are unavailable or
+                        ambiguous in the application picker.
+                      </p>
+                    </div>
+                  </div>
                   <label className="voice-pattern-field">
                     <span>Process pattern</span>
                     <input
@@ -1669,32 +1909,126 @@ export function SettingsPage() {
                       value={voicePattern}
                     />
                   </label>
-                )}
+                  <p className="theme-note">
+                    The expression is case-insensitive and works across Linux,
+                    macOS, and Windows.{' '}
+                    <code>PERSONA_TARGET_PROCESS_PATTERN</code> overrides
+                    automatic and advanced matching when set.
+                  </p>
+                  <div className="panel-actions">
+                    <button
+                      className="primary-button"
+                      data-testid="voice-source-save"
+                      disabled={
+                        busy ||
+                        !bridge ||
+                        !voiceSourceDirty ||
+                        !voicePattern.trim()
+                      }
+                      onClick={saveCustomVoiceSource}
+                      type="button"
+                    >
+                      Save pattern
+                    </button>
+                  </div>
+                </section>
+              )}
 
-                <p className="theme-note">
-                  Use a case-insensitive regular expression that matches the
-                  desktop app playing assistant audio. For fully custom local
-                  pipelines you can also drive Persona through its loopback HTTP
-                  API or <code>persona://</code> URLs. Setting{' '}
-                  <code>PERSONA_TARGET_PROCESS_PATTERN</code> overrides this
-                  setting.
-                </p>
+              {voiceMode === 'external' && (
+                <section className="settings-panel voice-external-panel">
+                  <div className="panel-heading">
+                    <div>
+                      <h2>External voice pipeline</h2>
+                      <p>
+                        Send normalized state and output levels directly from
+                        the component that plays generated speech.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="mcp-copy-field">
+                    <div>
+                      <span>Events endpoint</span>
+                      <code>
+                        {voiceCatalog?.events_url ??
+                          'http://127.0.0.1:47831/events'}
+                      </code>
+                    </div>
+                    <button
+                      className="secondary-button"
+                      onClick={() =>
+                        void copyText(
+                          voiceCatalog?.events_url ??
+                            'http://127.0.0.1:47831/events',
+                          'Events endpoint',
+                        )
+                      }
+                      type="button"
+                    >
+                      Copy
+                    </button>
+                  </div>
+                  <p className="desktop-note">
+                    External mode disables automatic capture. Persona receives
+                    only speaking state and a normalized level; raw audio and
+                    transcripts remain in your pipeline.
+                  </p>
+                </section>
+              )}
 
-                <div className="panel-actions">
+              <section className="settings-panel voice-status-panel">
+                <div className="panel-heading">
+                  <div>
+                    <h2>Listener status</h2>
+                    <p>Current state of the local voice integration.</p>
+                  </div>
                   <button
-                    className="primary-button"
-                    data-testid="voice-source-save"
-                    disabled={
-                      busy ||
-                      !bridge ||
-                      !voiceSourceDirty ||
-                      (voiceMode === 'custom' && !voicePattern.trim())
-                    }
-                    onClick={() => void saveVoiceSource()}
+                    className="secondary-button"
+                    disabled={voiceSourcesLoading || !bridge}
+                    onClick={() => void refreshVoiceSources()}
                     type="button"
                   >
-                    Save voice source
+                    Check status
                   </button>
+                </div>
+                <div className="voice-status-grid">
+                  <article>
+                    <span>Mode</span>
+                    <strong>{voiceHeading}</strong>
+                    <small>
+                      {settings.voice_source.mode === 'custom'
+                        ? settings.voice_source.process_pattern
+                        : settings.voice_source.mode === 'external'
+                          ? 'Loopback event API'
+                          : settings.voice_source.source_name ??
+                            'ChatGPT and Codex'}
+                    </small>
+                  </article>
+                  <article>
+                    <span>Status</span>
+                    <strong>
+                      {settings.voice_source.mode === 'external'
+                        ? 'Waiting for events'
+                        : listenerStatus?.capturing
+                          ? 'Receiving audio'
+                          : listenerStatus?.monitoring
+                            ? 'Monitoring'
+                            : 'Not active'}
+                    </strong>
+                    <small>
+                      {listenerStatus?.error ??
+                        listenerStatus?.source ??
+                        'No active output stream'}
+                    </small>
+                  </article>
+                  <article>
+                    <span>Available</span>
+                    <strong>{voiceCatalog?.sources.length ?? 0}</strong>
+                    <small>
+                      {voiceCatalog?.platform === 'linux'
+                        ? 'PipeWire playback streams'
+                        : 'Running applications'}
+                    </small>
+                  </article>
                 </div>
               </section>
             </>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -251,7 +251,7 @@ export function SettingsPage() {
 
   useEffect(() => {
     if (!notice) return;
-    const timer = window.setTimeout(() => setNotice(null), 4000);
+    const timer = window.setTimeout(() => setNotice(null), 2000);
     return () => window.clearTimeout(timer);
   }, [notice]);
 
@@ -311,6 +311,25 @@ export function SettingsPage() {
         return null;
       } finally {
         setBusy(false);
+      }
+    },
+    [updateSnapshot],
+  );
+
+  const persistAppearance = useCallback(
+    async (
+      operation: () => Promise<PersonaSettingsSnapshot>,
+      success: string,
+    ) => {
+      setNotice(null);
+      try {
+        const snapshot = await operation();
+        updateSnapshot(snapshot);
+        setNotice(success);
+        return snapshot;
+      } catch (error) {
+        setNotice(errorMessage(error));
+        return null;
       }
     },
     [updateSnapshot],
@@ -654,7 +673,7 @@ export function SettingsPage() {
 
   const saveCharacterSize = async (size: number) => {
     if (!bridge) return;
-    await run(
+    await persistAppearance(
       () => bridge.setCharacterSize(size),
       `Default character size set to ${Math.round(size * 100)}%.`,
     );
@@ -692,7 +711,7 @@ export function SettingsPage() {
     value: PersonaLightingSettings[Field],
   ) => {
     if (!bridge || !selectedModel) return;
-    const snapshot = await run(
+    const snapshot = await persistAppearance(
       () =>
         bridge.setModelLighting(selectedModel.id, {
           ...previewLighting,

--- a/src/settings-defaults.ts
+++ b/src/settings-defaults.ts
@@ -82,7 +82,7 @@ export function resolveLightingSettings(
 }
 
 export const SETTINGS_FALLBACK: PersonaSettingsSnapshot = {
-  schema_version: 4,
+  schema_version: 5,
   default_model_id: null,
   character_size: 1,
   packaged_animation_change_count: 0,
@@ -92,6 +92,8 @@ export const SETTINGS_FALLBACK: PersonaSettingsSnapshot = {
   voice_source: {
     mode: 'default',
     process_pattern: null,
+    source_id: null,
+    source_name: null,
   },
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -539,11 +539,16 @@ button {
 }
 
 .settings-notice {
+  position: fixed;
+  z-index: 90;
+  bottom: 20px;
+  left: 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin: 16px 28px 0;
+  width: max-content;
+  max-width: min(380px, calc(100vw - 40px));
   padding: 10px 10px 10px 14px;
   border: 1px solid var(--border);
   border-left: 2px solid var(--accent);
@@ -551,19 +556,20 @@ button {
   color: var(--text-primary);
   background: var(--bg-card);
   font-size: var(--fs-md);
-  box-shadow: var(--shadow-card);
+  box-shadow: var(--shadow-overlay);
   animation: notice-in 180ms var(--ease);
 }
 
 @keyframes notice-in {
   from {
     opacity: 0;
-    transform: translateY(-4px);
+    transform: translateY(8px);
   }
 }
 
 .settings-notice span {
   min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .settings-notice button {
@@ -2332,11 +2338,6 @@ button {
   .settings-scroll {
     padding-right: 22px;
     padding-left: 22px;
-  }
-
-  .settings-notice {
-    margin-right: 22px;
-    margin-left: 22px;
   }
 
   .asset-grid,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1244,6 +1244,250 @@ button {
   border-left: 2px solid var(--accent);
 }
 
+/* --- Voice source ------------------------------------------------------- */
+
+.voice-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.voice-mode-grid button {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 2px 10px;
+  min-width: 0;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  color: var(--text-secondary);
+  text-align: left;
+  background: var(--bg-card);
+  transition:
+    border-color var(--dur) var(--ease),
+    background var(--dur) var(--ease),
+    color var(--dur) var(--ease);
+}
+
+.voice-mode-grid button:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-raised);
+}
+
+.voice-mode-grid button[aria-pressed="true"] {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+  background: var(--accent-soft);
+}
+
+.voice-mode-grid button:disabled {
+  opacity: 0.45;
+}
+
+.voice-mode-icon {
+  display: inline-flex;
+  grid-row: 1 / span 2;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  color: var(--accent-text);
+  background: var(--bg-raised);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.voice-mode-grid strong {
+  overflow: hidden;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-mode-grid small {
+  color: var(--text-tertiary);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+
+.voice-source-search {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+}
+
+.voice-source-search input {
+  width: 100%;
+  height: 34px;
+  padding: 0 11px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  outline: none;
+  color: var(--text-primary);
+  background: var(--bg-inset);
+  font-size: var(--fs-md);
+}
+
+.voice-source-search input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.voice-source-list {
+  display: flex;
+  max-height: 300px;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.voice-source-list > button,
+.voice-saved-source {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  min-width: 0;
+  min-height: 54px;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--text-primary);
+  text-align: left;
+  background: var(--bg-card);
+}
+
+.voice-source-list > button {
+  transition:
+    border-color var(--dur) var(--ease),
+    background var(--dur) var(--ease);
+}
+
+.voice-source-list > button:hover:not(:disabled) {
+  background: var(--bg-raised);
+}
+
+.voice-source-list > button[aria-pressed="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+}
+
+.source-app-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border-radius: var(--r-md);
+  color: var(--accent-text);
+  background: var(--bg-raised);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.source-copy,
+.voice-saved-source > div {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.source-copy strong,
+.voice-saved-source strong {
+  overflow: hidden;
+  font-size: var(--fs-md);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-copy small,
+.voice-saved-source small {
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: var(--fs-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-saved-source {
+  margin-bottom: 8px;
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+}
+
+.source-state {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border-radius: var(--r-full);
+  color: var(--text-tertiary);
+  background: var(--bg-raised);
+  font-size: var(--fs-xs);
+}
+
+.source-state.selected {
+  color: var(--accent-text);
+  background: var(--accent-soft-hover);
+}
+
+.source-state.unavailable {
+  color: var(--danger-text);
+  background: var(--danger-soft);
+}
+
+.voice-status-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.voice-status-grid article {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: 13px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+}
+
+.voice-status-grid span {
+  color: var(--text-tertiary);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.voice-status-grid strong {
+  overflow: hidden;
+  margin-top: 8px;
+  font-size: var(--fs-lg);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-status-grid small {
+  overflow: hidden;
+  margin-top: 3px;
+  color: var(--text-tertiary);
+  font-size: var(--fs-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* --- Appearance --------------------------------------------------------- */
 
 /* --- Theme segmented control -------------------------------------------- */
@@ -1323,10 +1567,6 @@ button {
   font-size: var(--fs-xs);
 }
 
-.voice-source-panel .theme-segmented {
-  margin-top: 4px;
-}
-
 .voice-pattern-field {
   display: flex;
   flex-direction: column;
@@ -1356,7 +1596,7 @@ button {
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
-.voice-source-panel .panel-actions {
+.voice-pattern-panel .panel-actions {
   display: flex;
   justify-content: flex-start;
   margin-top: 16px;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -70,8 +70,25 @@ interface PersonaAnimationClipSettings {
 }
 
 interface PersonaVoiceSourceSettings {
-  mode: 'default' | 'custom';
+  mode: 'default' | 'application' | 'custom' | 'external';
   process_pattern: string | null;
+  source_id: string | null;
+  source_name: string | null;
+}
+
+interface PersonaVoiceSource {
+  id: string;
+  name: string;
+  detail: string;
+  platform: 'linux' | 'darwin' | 'win32';
+}
+
+interface PersonaVoiceSourceCatalog {
+  error: string | null;
+  events_url: string;
+  listener: AudioListenerStatus | null;
+  platform: string;
+  sources: PersonaVoiceSource[];
 }
 
 interface PersonaSettingsSnapshot {
@@ -152,6 +169,7 @@ interface Window {
     setVoiceSource(
       voiceSource: PersonaVoiceSourceSettings,
     ): Promise<PersonaSettingsSnapshot>;
+    listVoiceSources(): Promise<PersonaVoiceSourceCatalog>;
     setModelLighting(
       modelId: string,
       lighting: Partial<PersonaLightingSettings>,


### PR DESCRIPTION
## Summary

Expand Persona’s voice-source configuration into a complete cross-platform system for Codex, ChatGPT, other voice applications, and custom voice pipelines.

## Changes

- Keep automatic Codex and ChatGPT voice-output detection.
- Add selection from currently running applications on macOS and Windows.
- Add exact PipeWire playback-stream selection on Linux.
- Support advanced process-regex matching across all platforms.
- Add an external-events mode for custom voice-to-voice pipelines.
- Persist stable application and stream identities instead of temporary process IDs.
- Restart voice monitoring immediately when the selected source changes.
- Preserve unavailable saved sources so they can reconnect when the application returns.
- Add source search, refresh controls, listener status, and integration details to Settings.
- Migrate existing voice-source settings to the new schema.
- Update development, integration, release, and security documentation.
- Replace layout-shifting status notices with two-second bottom-left toasts.
- Prevent Appearance controls from flickering while character size and lighting changes are saved.

## Platform behavior

- **Linux:** discovers and selects individual PipeWire playback streams.
- **macOS:** discovers running applications and follows their current process trees.
- **Windows:** discovers running applications using stable executable identities.
- **All platforms:** support automatic detection, custom process patterns, and direct external events.

## Validation

- `npm run check`
- `npm run native:build`
- `npm run native:test`
- 88 Node tests
- 15 renderer tests
- Production dependency audit: 0 vulnerabilities
- Live PipeWire discovery and exact-stream matching
- Isolated Electron verification of all four voice-source modes
- `git diff --check` after the final Settings UI fixes