### PR TITLE
fix: stabilize Core Audio tap lifecycle against ChatGPT worker churn

### DIFF
--- a/electron/native-process-audio-listener.cjs
+++ b/electron/native-process-audio-listener.cjs
@@ -77,6 +77,7 @@ class NativeProcessAudioListener {
     this.sessionIdleMs = sessionIdleMs;
     this.capture = null;
     this.captureKey = null;
+    this.resolvedPids = new Set();
     this.pollTimer = null;
     this.sessionTimer = null;
     this.sessionActive = false;
@@ -132,16 +133,21 @@ class NativeProcessAudioListener {
         ...(this.processPattern ? { pattern: this.processPattern } : {}),
       });
       if (this.stopped) return;
-      const selectedPids =
-        this.platform === "win32" ? processes.rootPids.slice(0, 1) : processes.pids;
-      const key = selectedPids.join(",");
-      if (!key) {
+      const spawnPids =
+        this.platform === "win32"
+          ? processes.rootPids.slice(0, 1)
+          : processes.pids;
+      if (spawnPids.length === 0) {
         this.detach();
         return;
       }
+      // Key the tap lifecycle on matched roots + the PIDs the native tap
+      // resolved to audio objects, not the full tree — worker churn (#13).
+      const stablePids = this.stableCapturePids(processes);
+      const key = stablePids.join(",");
       if (this.capture && this.captureKey === key) return;
       this.detach({ sessionEnded: false });
-      this.startCapture(selectedPids, key);
+      this.startCapture(spawnPids, key);
     } catch (error) {
       this.reportStatus({
         available: true,
@@ -153,6 +159,18 @@ class NativeProcessAudioListener {
     } finally {
       this.pollInFlight = false;
     }
+  }
+
+  stableCapturePids(processes) {
+    if (this.platform === "win32") {
+      return processes.rootPids.slice(0, 1);
+    }
+    const matched = new Set(processes.pids ?? []);
+    const stable = new Set(processes.rootPids ?? []);
+    for (const pid of this.resolvedPids) {
+      if (matched.has(pid)) stable.add(pid);
+    }
+    return [...stable].sort((left, right) => left - right);
   }
 
   startCapture(processIds, key) {
@@ -173,6 +191,7 @@ class NativeProcessAudioListener {
       if (this.capture !== child) return;
       this.capture = null;
       this.captureKey = null;
+      this.resolvedPids = new Set();
       this.reportStatus({
         available: false,
         capturing: false,
@@ -185,6 +204,7 @@ class NativeProcessAudioListener {
       if (this.capture !== child) return;
       this.capture = null;
       this.captureKey = null;
+      this.resolvedPids = new Set();
       this.gate.reset();
       this.reportStatus({
         available: true,
@@ -201,6 +221,10 @@ class NativeProcessAudioListener {
   handleHelperMessage(child, message) {
     if (this.capture !== child || message == null || typeof message !== "object") return;
     if (message.type === "ready") {
+      const resolved = Array.isArray(message.pids)
+        ? message.pids.filter((pid) => Number.isInteger(pid) && pid > 0)
+        : [];
+      this.resolvedPids = new Set(resolved);
       this.reportStatus({
         available: true,
         capturing: true,
@@ -251,6 +275,7 @@ class NativeProcessAudioListener {
       this.captureKey = null;
       child.kill();
     }
+    if (sessionEnded) this.resolvedPids = new Set();
     this.gate.reset();
     if (sessionEnded) this.endSession();
     this.reportStatus({

--- a/electron/native-process-audio-listener.cjs
+++ b/electron/native-process-audio-listener.cjs
@@ -77,6 +77,7 @@ class NativeProcessAudioListener {
     this.sessionIdleMs = sessionIdleMs;
     this.capture = null;
     this.captureKey = null;
+    this.captureRootPids = new Set();
     this.resolvedPids = new Set();
     this.pollTimer = null;
     this.sessionTimer = null;
@@ -147,7 +148,7 @@ class NativeProcessAudioListener {
       const key = stablePids.join(",");
       if (this.capture && this.captureKey === key) return;
       this.detach({ sessionEnded: false });
-      this.startCapture(spawnPids, key);
+      this.startCapture(spawnPids, key, processes.rootPids);
     } catch (error) {
       this.reportStatus({
         available: true,
@@ -173,7 +174,7 @@ class NativeProcessAudioListener {
     return [...stable].sort((left, right) => left - right);
   }
 
-  startCapture(processIds, key) {
+  startCapture(processIds, key, rootPids = []) {
     const args = processIds.flatMap((processId) => ["--pid", String(processId)]);
     const child = this.spawnProcess(this.helperPath, args, {
       stdio: ["ignore", "pipe", "pipe"],
@@ -181,6 +182,7 @@ class NativeProcessAudioListener {
     });
     this.capture = child;
     this.captureKey = key;
+    this.captureRootPids = new Set(rootPids);
     const parse = createNdjsonParser(
       (message) => this.handleHelperMessage(child, message),
       (line) => this.onDebug?.("native listener emitted invalid JSON", line),
@@ -191,6 +193,7 @@ class NativeProcessAudioListener {
       if (this.capture !== child) return;
       this.capture = null;
       this.captureKey = null;
+      this.captureRootPids = new Set();
       this.resolvedPids = new Set();
       this.reportStatus({
         available: false,
@@ -204,6 +207,7 @@ class NativeProcessAudioListener {
       if (this.capture !== child) return;
       this.capture = null;
       this.captureKey = null;
+      this.captureRootPids = new Set();
       this.resolvedPids = new Set();
       this.gate.reset();
       this.reportStatus({
@@ -225,6 +229,11 @@ class NativeProcessAudioListener {
         ? message.pids.filter((pid) => Number.isInteger(pid) && pid > 0)
         : [];
       this.resolvedPids = new Set(resolved);
+      if (this.platform === "darwin") {
+        this.captureKey = [...new Set([...this.captureRootPids, ...resolved])]
+          .sort((left, right) => left - right)
+          .join(",");
+      }
       this.reportStatus({
         available: true,
         capturing: true,
@@ -273,6 +282,7 @@ class NativeProcessAudioListener {
       const child = this.capture;
       this.capture = null;
       this.captureKey = null;
+      this.captureRootPids = new Set();
       child.kill();
     }
     if (sessionEnded) this.resolvedPids = new Set();

--- a/electron/native-process-audio-listener.test.cjs
+++ b/electron/native-process-audio-listener.test.cjs
@@ -140,3 +140,51 @@ test("native listener resolves the configured application before capture", async
 
   assert.deepEqual(discoveryOptions.voiceSource, voiceSource);
 });
+
+test("keeps the capture target stable while dynamic worker PIDs churn", async () => {
+  const spawns = [];
+  const children = [];
+  let discovery = { pids: [10, 11], rootPids: [10] };
+  const listener = new NativeProcessAudioListener({
+    platform: "darwin",
+    helperPath: __filename,
+    processDiscovery: async () => discovery,
+    spawnProcess: (_path, args) => {
+      spawns.push(args);
+      const child = fakeChild();
+      children.push(child);
+      return child;
+    },
+  });
+
+  await listener.start();
+  // First spawn uses the full matched tree so the audio service is tapped.
+  assert.deepEqual(spawns[0], ["--pid", "10", "--pid", "11"]);
+
+  // The native tap resolves only the audio-service PID to a Core Audio object.
+  children[0].stdout.emit(
+    "data",
+    '{"type":"ready","source":"macOS process audio","pids":[11]}\n',
+  );
+
+  // Learning the resolved set re-keys once to the stable target [root + resolved].
+  await listener.poll();
+  assert.equal(spawns.length, 2);
+  const stabilized = spawns.length;
+
+  // A dynamic tool worker joining/leaving the matched tree must NOT recreate
+  // the tap once the target has stabilized.
+  discovery = { pids: [10, 11, 12], rootPids: [10] };
+  await listener.poll();
+  discovery = { pids: [10, 11], rootPids: [10] };
+  await listener.poll();
+  assert.equal(spawns.length, stabilized);
+
+  // A real audio-source change (resolved PID leaves the tree) DOES re-attach.
+  discovery = { pids: [10, 13], rootPids: [10] };
+  await listener.poll();
+  assert.equal(spawns.length, stabilized + 1);
+  assert.deepEqual(spawns.at(-1), ["--pid", "10", "--pid", "13"]);
+
+  listener.stop();
+});

--- a/electron/native-process-audio-listener.test.cjs
+++ b/electron/native-process-audio-listener.test.cjs
@@ -167,9 +167,9 @@ test("keeps the capture target stable while dynamic worker PIDs churn", async ()
     '{"type":"ready","source":"macOS process audio","pids":[11]}\n',
   );
 
-  // Learning the resolved set re-keys once to the stable target [root + resolved].
+  // Learning the resolved set re-keys the existing capture in place.
   await listener.poll();
-  assert.equal(spawns.length, 2);
+  assert.equal(spawns.length, 1);
   const stabilized = spawns.length;
 
   // A dynamic tool worker joining/leaving the matched tree must NOT recreate
@@ -185,6 +185,14 @@ test("keeps the capture target stable while dynamic worker PIDs churn", async ()
   await listener.poll();
   assert.equal(spawns.length, stabilized + 1);
   assert.deepEqual(spawns.at(-1), ["--pid", "10", "--pid", "13"]);
+
+  // Learning the replacement audio-service PID must not recreate that tap.
+  children.at(-1).stdout.emit(
+    "data",
+    '{"type":"ready","source":"macOS process audio","pids":[13]}\n',
+  );
+  await listener.poll();
+  assert.equal(spawns.length, stabilized + 1);
 
   listener.stop();
 });

--- a/native/macos/PersonaAudioListener.mm
+++ b/native/macos/PersonaAudioListener.mm
@@ -48,7 +48,9 @@ void handleSignal(int) {
   running.store(false, std::memory_order_relaxed);
 }
 
-std::vector<AudioObjectID> audioProcessObjects(const std::vector<pid_t>& requestedPids) {
+std::vector<AudioObjectID> audioProcessObjects(
+    const std::vector<pid_t>& requestedPids,
+    std::vector<pid_t>* resolvedPids = nullptr) {
   auto address = propertyAddress(kAudioHardwarePropertyProcessObjectList);
   UInt32 size = 0;
   if (AudioObjectGetPropertyDataSize(
@@ -73,6 +75,7 @@ std::vector<AudioObjectID> audioProcessObjects(const std::vector<pid_t>& request
     }
     if (std::find(requestedPids.begin(), requestedPids.end(), pid) != requestedPids.end()) {
       matches.push_back(object);
+      if (resolvedPids != nullptr) resolvedPids->push_back(pid);
     }
   }
   return matches;
@@ -172,7 +175,8 @@ int main(int argc, const char *argv[]) {
     }
     if (processIds.empty()) return fail(@"At least one --pid is required.");
 
-    const auto processObjects = audioProcessObjects(processIds);
+    std::vector<pid_t> resolvedPids;
+    const auto processObjects = audioProcessObjects(processIds, &resolvedPids);
     if (processObjects.empty()) {
       return fail(@"No active Core Audio process matches the requested application.");
     }
@@ -283,7 +287,14 @@ int main(int argc, const char *argv[]) {
 
     signal(SIGINT, handleSignal);
     signal(SIGTERM, handleSignal);
-    emitJSON(@{@"type" : @"ready", @"source" : @"macOS process audio"});
+    NSMutableArray<NSNumber *> *resolvedNumbers =
+        [NSMutableArray arrayWithCapacity:resolvedPids.size()];
+    for (pid_t pid : resolvedPids) [resolvedNumbers addObject:@(pid)];
+    emitJSON(@{
+      @"type" : @"ready",
+      @"source" : @"macOS process audio",
+      @"pids" : resolvedNumbers,
+    });
 
     while (running.load(std::memory_order_relaxed)) {
       std::this_thread::sleep_for(std::chrono::milliseconds(33));


### PR DESCRIPTION
Here's what changed.

- `electron/native-process-audio-listener.cjs`: tap lifecycle keyed on matched roots + the PIDs the native tap resolved to audio objects, not the full descendant tree; helper still spawned with the full tree. Added `resolvedPids`, learned from `ready`, cleared on detach/error/exit.
- `native/macos/PersonaAudioListener.mm`: `ready` now includes the resolved PIDs.
- `electron/native-process-audio-listener.test.cjs`: test that worker-PID churn doesn't recreate the tap, a real source change does.
