### PR TITLE
fix: re-randomize looping animation clips on every loop

### DIFF
--- a/src/hooks/useVrmAnimation.ts
+++ b/src/hooks/useVrmAnimation.ts
@@ -26,6 +26,7 @@ import {
   speakingChunkTransitionDurations,
   shouldAdvanceSpeakingSequence,
 } from '../speaking-chunks';
+import { createLoopSwapHandler } from '../loop-swap';
 
 interface PlayOptions {
   animationUrls?: readonly string[];
@@ -82,6 +83,7 @@ export function useVrmAnimation(
     type: PlayableAnimationType;
     urls: readonly string[];
     generation: number;
+    swapping: boolean;
   } | null>(null);
   const fadingActions = useRef(new Set<THREE.AnimationAction>());
   const pendingTransitionActions = useRef<THREE.AnimationAction[]>([]);
@@ -157,41 +159,18 @@ export function useVrmAnimation(
       pendingCompletion.current = null;
       pending.callback();
     };
-    const handleLoop = ({ action }: { action: THREE.AnimationAction }) => {
-      const selection = activeLoopSelection.current;
-      if (
-        !selection ||
-        action !== current.current ||
-        selection.generation !== requestGeneration.current ||
-        selection.urls.length < 2
-      ) {
-        return;
-      }
-      const nextUrl = randomAnimationUrl(
-        selection.urls,
-        previousAnimation.current.get(selection.type) ?? null,
-      );
-      if (!nextUrl) return;
-      previousAnimation.current.set(selection.type, nextUrl);
-      void loadClip(nextUrl)
-        .then((clip) => {
-          if (
-            selection.generation !== requestGeneration.current ||
-            !mixer.current ||
-            current.current !== action
-          ) {
-            return;
-          }
-          const nextAction = mixer.current.clipAction(clip);
-          nextAction.reset();
-          configureAnimationAction(nextAction, 'loop');
-          fadeTo(nextAction, bodyTransitionSecondsRef.current);
-          current.current = nextAction;
-        })
-        .catch((error: unknown) => {
-          console.warn('[persona] animation load failed', error);
-        });
-    };
+    const handleLoop = createLoopSwapHandler({
+      activeLoopSelection,
+      current,
+      requestGeneration,
+      mixer,
+      previousAnimation: previousAnimation.current,
+      bodyTransitionSeconds: bodyTransitionSecondsRef,
+      loadClip,
+      fadeTo,
+      onLoadError: (error) =>
+        console.warn('[persona] animation load failed', error),
+    });
     animationMixer.addEventListener('finished', handleFinished);
     animationMixer.addEventListener('loop', handleLoop);
     mixer.current = animationMixer;
@@ -382,6 +361,7 @@ export function useVrmAnimation(
             type,
             urls: uniqueAnimationUrls,
             generation,
+            swapping: false,
           };
         }
         if (playback === 'once') {

--- a/src/hooks/useVrmAnimation.ts
+++ b/src/hooks/useVrmAnimation.ts
@@ -78,6 +78,11 @@ export function useVrmAnimation(
   const pendingCompletion = useRef<PendingCompletion | null>(null);
   const speakingSequence = useRef<SpeakingSequence | null>(null);
   const speakingBlend = useRef<SpeakingBlend | null>(null);
+  const activeLoopSelection = useRef<{
+    type: PlayableAnimationType;
+    urls: readonly string[];
+    generation: number;
+  } | null>(null);
   const fadingActions = useRef(new Set<THREE.AnimationAction>());
   const pendingTransitionActions = useRef<THREE.AnimationAction[]>([]);
   const speakingTransitionRef = useRef(speakingTransition);
@@ -87,40 +92,6 @@ export function useVrmAnimation(
   speakingTransitionRef.current = speakingTransition;
   bodyTransitionSecondsRef.current = bodyTransitionSeconds;
   speakingActiveRef.current = speakingActive;
-
-  useEffect(() => {
-    if (!vrm) return;
-    const animationHistory = previousAnimation.current;
-    const fadingActionSet = fadingActions.current;
-    const animationMixer = new THREE.AnimationMixer(vrm.scene);
-    const handleFinished = ({ action }: { action: THREE.AnimationAction }) => {
-      const pending = pendingCompletion.current;
-      if (
-        pending?.action !== action ||
-        pending.generation !== requestGeneration.current
-      ) {
-        return;
-      }
-      pendingCompletion.current = null;
-      pending.callback();
-    };
-    animationMixer.addEventListener('finished', handleFinished);
-    mixer.current = animationMixer;
-    return () => {
-      animationMixer.removeEventListener('finished', handleFinished);
-      animationMixer.stopAllAction();
-      mixer.current = null;
-      current.current = null;
-      currentType.current = null;
-      pendingCompletion.current = null;
-      speakingSequence.current = null;
-      speakingBlend.current = null;
-      fadingActionSet.clear();
-      pendingTransitionActions.current = [];
-      speakingWasActive.current = speakingActiveRef.current;
-      animationHistory.clear();
-    };
-  }, [vrm]);
 
   const load = useCallback(async (url: string) => {
     const cached = cache.current.get(url);
@@ -169,6 +140,78 @@ export function useVrmAnimation(
     },
     [],
   );
+
+  useEffect(() => {
+    if (!vrm) return;
+    const animationHistory = previousAnimation.current;
+    const fadingActionSet = fadingActions.current;
+    const animationMixer = new THREE.AnimationMixer(vrm.scene);
+    const handleFinished = ({ action }: { action: THREE.AnimationAction }) => {
+      const pending = pendingCompletion.current;
+      if (
+        pending?.action !== action ||
+        pending.generation !== requestGeneration.current
+      ) {
+        return;
+      }
+      pendingCompletion.current = null;
+      pending.callback();
+    };
+    const handleLoop = ({ action }: { action: THREE.AnimationAction }) => {
+      const selection = activeLoopSelection.current;
+      if (
+        !selection ||
+        action !== current.current ||
+        selection.generation !== requestGeneration.current ||
+        selection.urls.length < 2
+      ) {
+        return;
+      }
+      const nextUrl = randomAnimationUrl(
+        selection.urls,
+        previousAnimation.current.get(selection.type) ?? null,
+      );
+      if (!nextUrl) return;
+      previousAnimation.current.set(selection.type, nextUrl);
+      void loadClip(nextUrl)
+        .then((clip) => {
+          if (
+            selection.generation !== requestGeneration.current ||
+            !mixer.current ||
+            current.current !== action
+          ) {
+            return;
+          }
+          const nextAction = mixer.current.clipAction(clip);
+          nextAction.reset();
+          configureAnimationAction(nextAction, 'loop');
+          fadeTo(nextAction, bodyTransitionSecondsRef.current);
+          current.current = nextAction;
+        })
+        .catch((error: unknown) => {
+          console.warn('[persona] animation load failed', error);
+        });
+    };
+    animationMixer.addEventListener('finished', handleFinished);
+    animationMixer.addEventListener('loop', handleLoop);
+    mixer.current = animationMixer;
+    return () => {
+      animationMixer.removeEventListener('finished', handleFinished);
+      animationMixer.removeEventListener('loop', handleLoop);
+      animationMixer.stopAllAction();
+      mixer.current = null;
+      current.current = null;
+      currentType.current = null;
+      pendingCompletion.current = null;
+      speakingSequence.current = null;
+      speakingBlend.current = null;
+      activeLoopSelection.current = null;
+      fadingActionSet.clear();
+      pendingTransitionActions.current = [];
+      speakingWasActive.current = speakingActiveRef.current;
+      animationHistory.clear();
+    };
+  }, [vrm, loadClip, fadeTo]);
 
   const advanceSpeakingSequence = useCallback(
     async function advance(generation: number): Promise<void> {
@@ -274,6 +317,7 @@ export function useVrmAnimation(
       const generation = ++requestGeneration.current;
       pendingCompletion.current = null;
       speakingSequence.current = null;
+      activeLoopSelection.current = null;
       const interruptedBlend = speakingBlend.current;
       if (interruptedBlend) {
         pendingTransitionActions.current = [
@@ -333,6 +377,13 @@ export function useVrmAnimation(
         const fadeSeconds = bodyTransitionSecondsRef.current;
         action.reset();
         configureAnimationAction(action, playback);
+        if (playback === 'loop') {
+          activeLoopSelection.current = {
+            type,
+            urls: uniqueAnimationUrls,
+            generation,
+          };
+        }
         if (playback === 'once') {
           if (onComplete) {
             pendingCompletion.current = {

--- a/src/loop-swap.test.ts
+++ b/src/loop-swap.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createLoopSwapHandler, type LoopSelection } from './loop-swap';
+
+function createHarness() {
+  const mixer = new THREE.AnimationMixer(new THREE.Object3D());
+  const initialAction = mixer.clipAction(new THREE.AnimationClip('a', 1));
+  const current = { current: initialAction as THREE.AnimationAction | null };
+  const requestGeneration = { current: 0 };
+  const bodyTransitionSeconds = { current: 0.5 };
+  const previousAnimation = new Map<string, string>();
+  const activeLoopSelection: { current: LoopSelection | null } = {
+    current: {
+      type: 'IDLE',
+      urls: ['a.vrma', 'b.vrma'],
+      generation: 0,
+      swapping: false,
+    },
+  };
+  const fadeTo = vi.fn((next: THREE.AnimationAction) => {
+    current.current = next;
+  });
+
+  return {
+    mixer,
+    initialAction,
+    current,
+    requestGeneration,
+    bodyTransitionSeconds,
+    previousAnimation,
+    activeLoopSelection,
+    fadeTo,
+  };
+}
+
+describe('createLoopSwapHandler', () => {
+  it('ignores re-entrant loop events while a swap is already loading', async () => {
+    const harness = createHarness();
+    let resolveLoad: (clip: THREE.AnimationClip) => void = () => {};
+    const loadClip = vi.fn(
+      () =>
+        new Promise<THREE.AnimationClip>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const onLoadError = vi.fn();
+    const handleLoop = createLoopSwapHandler({
+      activeLoopSelection: harness.activeLoopSelection,
+      current: harness.current,
+      requestGeneration: harness.requestGeneration,
+      mixer: { current: harness.mixer },
+      previousAnimation: harness.previousAnimation,
+      bodyTransitionSeconds: harness.bodyTransitionSeconds,
+      loadClip,
+      fadeTo: harness.fadeTo,
+      onLoadError,
+    });
+
+    handleLoop({ action: harness.initialAction });
+    handleLoop({ action: harness.initialAction });
+
+    expect(loadClip).toHaveBeenCalledTimes(1);
+    expect(harness.activeLoopSelection.current?.swapping).toBe(true);
+
+    resolveLoad(new THREE.AnimationClip('b', 1));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.fadeTo).toHaveBeenCalledTimes(1);
+    expect(harness.activeLoopSelection.current?.swapping).toBe(false);
+    expect(onLoadError).not.toHaveBeenCalled();
+  });
+
+  it('swaps to a different clip than the one currently playing', async () => {
+    const harness = createHarness();
+    harness.previousAnimation.set('IDLE', 'a.vrma');
+    const nextClip = new THREE.AnimationClip('b', 1);
+    const loadClip = vi.fn(async (url: string) => {
+      expect(url).toBe('b.vrma');
+      return nextClip;
+    });
+
+    const handleLoop = createLoopSwapHandler({
+      activeLoopSelection: harness.activeLoopSelection,
+      current: harness.current,
+      requestGeneration: harness.requestGeneration,
+      mixer: { current: harness.mixer },
+      previousAnimation: harness.previousAnimation,
+      bodyTransitionSeconds: harness.bodyTransitionSeconds,
+      loadClip,
+      fadeTo: harness.fadeTo,
+      onLoadError: vi.fn(),
+    });
+
+    handleLoop({ action: harness.initialAction });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(loadClip).toHaveBeenCalledWith('b.vrma');
+    expect(harness.previousAnimation.get('IDLE')).toBe('b.vrma');
+    expect(harness.current.current).not.toBe(harness.initialAction);
+  });
+
+  it('discards a swap that resolves after the action was interrupted', async () => {
+    const harness = createHarness();
+    let resolveLoad: (clip: THREE.AnimationClip) => void = () => {};
+    const loadClip = vi.fn(
+      () =>
+        new Promise<THREE.AnimationClip>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+
+    const handleLoop = createLoopSwapHandler({
+      activeLoopSelection: harness.activeLoopSelection,
+      current: harness.current,
+      requestGeneration: harness.requestGeneration,
+      mixer: { current: harness.mixer },
+      previousAnimation: harness.previousAnimation,
+      bodyTransitionSeconds: harness.bodyTransitionSeconds,
+      loadClip,
+      fadeTo: harness.fadeTo,
+      onLoadError: vi.fn(),
+    });
+
+    handleLoop({ action: harness.initialAction });
+
+    // A new play() call interrupts the loop before the swap's clip loads.
+    const interruptingAction = harness.mixer.clipAction(
+      new THREE.AnimationClip('c', 1),
+    );
+    harness.current.current = interruptingAction;
+    harness.requestGeneration.current += 1;
+
+    resolveLoad(new THREE.AnimationClip('b', 1));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.fadeTo).not.toHaveBeenCalled();
+    expect(harness.current.current).toBe(interruptingAction);
+    expect(harness.activeLoopSelection.current?.swapping).toBe(false);
+  });
+
+  it('resets swapping after a load failure so the next loop can retry', async () => {
+    const harness = createHarness();
+    const failure = new Error('missing file');
+    const loadClip = vi
+      .fn<() => Promise<THREE.AnimationClip>>()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(new THREE.AnimationClip('b', 1));
+    const onLoadError = vi.fn();
+
+    const handleLoop = createLoopSwapHandler({
+      activeLoopSelection: harness.activeLoopSelection,
+      current: harness.current,
+      requestGeneration: harness.requestGeneration,
+      mixer: { current: harness.mixer },
+      previousAnimation: harness.previousAnimation,
+      bodyTransitionSeconds: harness.bodyTransitionSeconds,
+      loadClip,
+      fadeTo: harness.fadeTo,
+      onLoadError,
+    });
+
+    handleLoop({ action: harness.initialAction });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onLoadError).toHaveBeenCalledWith(failure);
+    expect(harness.activeLoopSelection.current?.swapping).toBe(false);
+
+    handleLoop({ action: harness.initialAction });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(loadClip).toHaveBeenCalledTimes(2);
+    expect(harness.fadeTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when only one animation url is available', () => {
+    const harness = createHarness();
+    if (harness.activeLoopSelection.current) {
+      harness.activeLoopSelection.current.urls = ['a.vrma'];
+    }
+    const loadClip = vi.fn();
+
+    const handleLoop = createLoopSwapHandler({
+      activeLoopSelection: harness.activeLoopSelection,
+      current: harness.current,
+      requestGeneration: harness.requestGeneration,
+      mixer: { current: harness.mixer },
+      previousAnimation: harness.previousAnimation,
+      bodyTransitionSeconds: harness.bodyTransitionSeconds,
+      loadClip,
+      fadeTo: harness.fadeTo,
+      onLoadError: vi.fn(),
+    });
+
+    handleLoop({ action: harness.initialAction });
+
+    expect(loadClip).not.toHaveBeenCalled();
+  });
+});

--- a/src/loop-swap.test.ts
+++ b/src/loop-swap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as THREE from 'three';
+import type { PlayableAnimationType } from './animation-catalog';
 import { createLoopSwapHandler, type LoopSelection } from './loop-swap';
 
 function createHarness() {
@@ -8,7 +9,7 @@ function createHarness() {
   const current = { current: initialAction as THREE.AnimationAction | null };
   const requestGeneration = { current: 0 };
   const bodyTransitionSeconds = { current: 0.5 };
-  const previousAnimation = new Map<string, string>();
+  const previousAnimation = new Map<PlayableAnimationType, string>();
   const activeLoopSelection: { current: LoopSelection | null } = {
     current: {
       type: 'IDLE',

--- a/src/loop-swap.ts
+++ b/src/loop-swap.ts
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+import { randomAnimationUrl, type PlayableAnimationType } from './animation-catalog';
+import { configureAnimationAction } from './animation-action';
+
+export interface LoopSelection {
+  type: PlayableAnimationType;
+  urls: readonly string[];
+  generation: number;
+  swapping: boolean;
+}
+
+export interface CreateLoopSwapHandlerOptions {
+  activeLoopSelection: { current: LoopSelection | null };
+  current: { current: THREE.AnimationAction | null };
+  requestGeneration: { current: number };
+  mixer: { current: THREE.AnimationMixer | null };
+  previousAnimation: Map<PlayableAnimationType, string>;
+  bodyTransitionSeconds: { current: number };
+  loadClip: (url: string) => Promise<THREE.AnimationClip>;
+  fadeTo: (next: THREE.AnimationAction, duration: number) => void;
+  onLoadError: (error: unknown) => void;
+}
+
+// Re-randomizes a looping action's clip every time the mixer wraps it, so a
+// body-idle loop doesn't visibly repeat the same clip forever. `swapping`
+// guards against the mixer firing 'loop' again for the same action while a
+// previous pick's clip is still loading.
+export function createLoopSwapHandler(
+  options: CreateLoopSwapHandlerOptions,
+): (event: { action: THREE.AnimationAction }) => void {
+  return ({ action }) => {
+    const selection = options.activeLoopSelection.current;
+    if (
+      !selection ||
+      action !== options.current.current ||
+      selection.generation !== options.requestGeneration.current ||
+      selection.urls.length < 2 ||
+      selection.swapping
+    ) {
+      return;
+    }
+    const nextUrl = randomAnimationUrl(
+      selection.urls,
+      options.previousAnimation.get(selection.type) ?? null,
+    );
+    if (!nextUrl) return;
+    selection.swapping = true;
+    options.previousAnimation.set(selection.type, nextUrl);
+    void options
+      .loadClip(nextUrl)
+      .then((clip) => {
+        selection.swapping = false;
+        if (
+          selection.generation !== options.requestGeneration.current ||
+          !options.mixer.current ||
+          options.current.current !== action
+        ) {
+          return;
+        }
+        const nextAction = options.mixer.current.clipAction(clip);
+        nextAction.reset();
+        configureAnimationAction(nextAction, 'loop');
+        options.fadeTo(nextAction, options.bodyTransitionSeconds.current);
+        options.current.current = nextAction;
+      })
+      .catch((error: unknown) => {
+        selection.swapping = false;
+        options.onLoadError(error);
+      });
+  };
+}


### PR DESCRIPTION
- Re-randomize looping animation clips on every loop
- Guard loop re-randomize swap against re-entrant loop events
- Type the loop-swap test harness's previousAnimation map correctly