### PR TITLE
fix: surface animation load failures as Settings notifications

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -840,6 +840,14 @@ if (!app.requestSingleInstanceLock()) {
       }),
     );
     ipcMain.on("persona:hide", () => void hideOverlay());
+    // Playback failures (e.g. an incompatible VRMA file) happen in the avatar
+    // window, which has no notice UI of its own; forward them to the settings
+    // window so the user actually finds out something went wrong.
+    ipcMain.on("persona:report-error", (_event, message) => {
+      if (typeof message !== "string" || !message.trim()) return;
+      if (!settingsWindow || settingsWindow.isDestroyed()) return;
+      settingsWindow.webContents.send("persona:notice", message);
+    });
     // The resolved theme lives in renderer storage, so the window chrome can
     // only be corrected once the settings renderer reports it. Accepts the two
     // known theme names and never a caller-supplied colour.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -843,7 +843,8 @@ if (!app.requestSingleInstanceLock()) {
     // Playback failures (e.g. an incompatible VRMA file) happen in the avatar
     // window, which has no notice UI of its own; forward them to the settings
     // window so the user actually finds out something went wrong.
-    ipcMain.on("persona:report-error", (_event, message) => {
+    ipcMain.on("persona:report-error", (event, message) => {
+      if (event.sender !== avatarWindow?.webContents) return;
       if (typeof message !== "string" || !message.trim()) return;
       if (!settingsWindow || settingsWindow.isDestroyed()) return;
       settingsWindow.webContents.send("persona:notice", message);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -5,6 +5,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 contextBridge.exposeInMainWorld("personaBridge", {
   getSnapshot: () => ipcRenderer.invoke("persona:get-snapshot"),
   hide: () => ipcRenderer.send("persona:hide"),
+  reportError: (message) => ipcRenderer.send("persona:report-error", message),
   subscribe: (listener) => {
     const handler = (_event, payload) => listener(payload);
     ipcRenderer.on("persona:event", handler);
@@ -73,5 +74,10 @@ contextBridge.exposeInMainWorld("personaSettings", {
     const handler = (_event, snapshot) => listener(snapshot);
     ipcRenderer.on("persona:settings-updated", handler);
     return () => ipcRenderer.off("persona:settings-updated", handler);
+  },
+  subscribeNotice: (listener) => {
+    const handler = (_event, message) => listener(message);
+    ipcRenderer.on("persona:notice", handler);
+    return () => ipcRenderer.off("persona:notice", handler);
   },
 });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -239,6 +239,11 @@ export function SettingsPage() {
   }, [bridge]);
 
   useEffect(() => {
+    if (!bridge) return;
+    return bridge.subscribeNotice(setNotice);
+  }, [bridge]);
+
+  useEffect(() => {
     setVoiceMode(settings.voice_source.mode);
     setVoicePattern(settings.voice_source.process_pattern ?? '');
   }, [settings.voice_source.mode, settings.voice_source.process_pattern]);

--- a/src/hooks/useVrmAnimation.ts
+++ b/src/hooks/useVrmAnimation.ts
@@ -285,6 +285,7 @@ export function useVrmAnimation(
         ];
       }
       speakingBlend.current = null;
+      let url: string | null | undefined;
       try {
         const sequenceUrls = speakingChunkSequenceUrls(
           type,
@@ -305,7 +306,7 @@ export function useVrmAnimation(
           return;
         }
         const uniqueAnimationUrls = [...new Set(animationUrls)];
-        const url = randomAnimationUrl(
+        url = randomAnimationUrl(
           uniqueAnimationUrls,
           previousAnimation.current.get(type) ?? null,
         );
@@ -348,6 +349,12 @@ export function useVrmAnimation(
         currentType.current = type;
       } catch (error) {
         console.warn('[persona] animation load failed', error);
+        const detail = error instanceof Error ? error.message : String(error);
+        const filename = url?.split(/[/\\]/).pop();
+        const source = filename ? ` (${filename})` : '';
+        window.personaBridge?.reportError(
+          `Couldn't play that animation${source}: ${detail}`,
+        );
         if (generation === requestGeneration.current && playback === 'once') {
           onComplete?.();
         }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -148,6 +148,7 @@ interface Window {
   personaBridge?: {
     getSnapshot(): Promise<AvatarBridgeEvent | null>;
     hide(): void;
+    reportError(message: string): void;
     subscribe(listener: (event: AvatarBridgeEvent) => void): () => void;
   };
   personaSettings?: {
@@ -194,5 +195,6 @@ interface Window {
     subscribe(
       listener: (snapshot: PersonaSettingsSnapshot) => void,
     ): () => void;
+    subscribeNotice(listener: (message: string) => void): () => void;
   };
 }


### PR DESCRIPTION
- Surface animation load failures as Settings notifications
- Validate sender on persona:report-error IPC handler