### PR TITLE
fix: unwrap /api/hearts entries as character models directly

### DIFF
--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -86,9 +86,9 @@ function createVroidHubClient({
     // Only the connected account unconditionally owns its own models; a
     // hearted model created by someone else must be explicitly marked
     // available to other users before Persona is allowed to use it, per
-    // VRoid Hub's third-party integration rules.
+    // VRoid Hub's third-party integration rules. /api/hearts' data entries
+    // are the character models themselves, not a heart record wrapping one.
     const heartedModels = (Array.isArray(hearts?.data) ? hearts.data : [])
-      .map((heart) => heart.character_model)
       .filter((model) => model?.is_other_users_available === true);
 
     const ownIds = new Set(

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -62,24 +62,20 @@ test("lists the account's own models and eligible hearted models, filtering inel
       }
       if (request.url.startsWith("/api/hearts")) {
         heartsUrl = request.url;
+        // /api/hearts' data entries are the character models themselves,
+        // not a heart record wrapping one under a character_model key.
         return json(response, 200, {
           data: [
-            {
-              id: "heart-1",
-              character_model: characterModel({
-                id: "hearted-allowed",
-                name: "Hearted, allowed",
-                is_other_users_available: true,
-              }),
-            },
-            {
-              id: "heart-2",
-              character_model: characterModel({
-                id: "hearted-blocked",
-                name: "Hearted, blocked",
-                is_other_users_available: false,
-              }),
-            },
+            characterModel({
+              id: "hearted-allowed",
+              name: "Hearted, allowed",
+              is_other_users_available: true,
+            }),
+            characterModel({
+              id: "hearted-blocked",
+              name: "Hearted, blocked",
+              is_other_users_available: false,
+            }),
           ],
         });
       }


### PR DESCRIPTION
VRoid Hub's /api/hearts response puts the character model fields directly on each data entry, not nested under a character_model key. The previous .map((heart) => heart.character_model) always produced undefined, so every hearted model was silently filtered out by the is_other_users_available check regardless of the owner's actual third-party-use setting — hearted models a user was fully entitled to use never appeared in Persona's character list.

Confirmed against a real /api/hearts response: the character fields (id, is_downloadable, is_other_users_available, etc.) are top-level on each data entry.

- Removes the incorrect .character_model unwrap.
- Updates the fake-server test fixture to match the real response shape.