### PR TITLE
fix: extract VRM 1.0 conditions of use from vrm_meta directly

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -151,7 +151,9 @@ They can also be changed from the gated Developer tab in the Settings window.
 The warning must be acknowledged once before its controls are available. Valid
 entry and exit durations range from `45` to `3600` ms. Their two-handle sliders
 select the complete random range; Reset developer settings restores the
-packaged ranges while leaving developer access enabled.
+packaged ranges while leaving developer access enabled. The same Developer tab
+also exposes a Linux-only VRoid Hub plaintext override for machines that do
+not have a secure credential store available during development.
 
 ## MCP contract
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -222,8 +222,9 @@ keychain-backed) in `vroid-hub-credentials.json`, the same mechanism used for
 the resulting session tokens (`vroid-hub-auth.json`). On Linux, a packaged
 build also confirms the OS keyring backend is actually selected rather than
 `safeStorage`'s insecure `basic_text` fallback (used when no GNOME Secret
-Service or KWallet is running). If real OS-backed encryption isn't available,
-the feature stays disabled rather than storing either in plaintext.
+Service or KWallet is running). If you intentionally want to bypass that gate
+while developing, enable the VRoid Hub Linux override in Developer settings.
+Otherwise the feature stays disabled rather than storing either in plaintext.
 
 With no credentials configured, "Connect VRoid Hub account" in Settings stays
 disabled. When configured, Settings opens the VRoid Hub authorization page in

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -483,15 +483,29 @@ function configureVroidHub(clientId, clientSecret) {
 // persona:settings-set-window-theme's existing sender checks below.
 // isEncryptionAvailable() alone is not a reliable secrecy guarantee on
 // Linux: without a running keyring (GNOME Secret Service or KWallet over
-// D-Bus), Electron's safeStorage still reports encryption as "available"
-// but silently selects the basic_text backend, which provides no real
-// protection. A packaged build must not tell the user their VRoid Hub
-// client secret and session tokens are OS-keychain-backed when they are
-// not, so this checks the actual selected backend rather than trusting
-// isEncryptionAvailable() by itself. The dev-only plaintext override above
-// intentionally forces basic_text for local convenience, so this check is
-// skipped there.
-function vroidHubSecureStorageAvailable() {
+// D-Bus), Electron's safeStorage can select the basic_text backend, which
+// provides no real protection. A packaged build must not tell the user their
+// VRoid Hub client secret and session tokens are OS-keychain-backed when they
+// are not, so this checks the actual selected backend rather than trusting
+// isEncryptionAvailable() by itself. Local development still opts into
+// Electron's plaintext backend for convenience. Packaged Linux builds can only
+// do the same when the gated Developer setting explicitly allows it.
+function vroidHubPlaintextStorageAllowed(snapshot = settingsStore?.getSnapshot()) {
+  return (
+    process.platform === "linux" &&
+    snapshot?.vroid_hub_allow_plaintext_storage === true
+  );
+}
+
+function syncVroidHubStorageBackend(snapshot = settingsStore?.getSnapshot()) {
+  if (process.platform !== "linux") return;
+  safeStorage.setUsePlainTextEncryption(
+    !app.isPackaged || vroidHubPlaintextStorageAllowed(snapshot),
+  );
+}
+
+function vroidHubSecureStorageAvailable(snapshot = settingsStore?.getSnapshot()) {
+  if (vroidHubPlaintextStorageAllowed(snapshot)) return true;
   if (!safeStorage.isEncryptionAvailable()) return false;
   if (!app.isPackaged) return true;
   return safeStorage.getSelectedStorageBackend?.() !== "basic_text";
@@ -521,6 +535,29 @@ function broadcastVroidHubStatus() {
     !settingsWindow.webContents.isLoading()
   ) {
     settingsWindow.webContents.send("persona:vroid-status-updated", vroidHubStatus());
+  }
+}
+
+function refreshVroidHubStoragePolicy(snapshot = settingsStore?.getSnapshot()) {
+  syncVroidHubStorageBackend(snapshot);
+  if (!vroidCredentialsFilePath) return;
+  if (!vroidHubSecureStorageAvailable(snapshot)) {
+    vroidHubAuth?.disconnect();
+    vroidHubAuth = null;
+    vroidHubClient = null;
+    publishSettings(settingsStore.clearActiveHubModel());
+    return;
+  }
+  const vroidCredentials = readVroidHubCredentials({
+    credentialsFilePath: vroidCredentialsFilePath,
+    decrypt: (buffer) =>
+      Buffer.from(safeStorage.decryptString(buffer), "utf8"),
+  });
+  if (vroidCredentials) {
+    configureVroidHub(
+      vroidCredentials.clientId,
+      vroidCredentials.clientSecret,
+    );
   }
 }
 
@@ -856,22 +893,12 @@ if (!app.requestSingleInstanceLock()) {
     // session tokens. The redirect URI is served by the local loopback
     // bridge below, not the persona:// deep link, so it works identically in
     // `npm run dev`/`demo` and packaged builds.
-    // Dev-only convenience: safeStorage (used to encrypt both the credentials
-    // and the VRoid Hub token file) needs a real OS keychain backend on
-    // Linux (KWallet or GNOME Secret Service over D-Bus). Machines running
-    // Persona from source without one — e.g. a minimal WSL2 install with no
-    // session D-Bus — would otherwise have the VRoid Hub feature silently
-    // disabled. Packaged builds never call this, so distributed Persona
-    // still requires real OS-backed encryption; this only loosens the
-    // guarantee for local development.
-    if (!app.isPackaged) {
-      safeStorage.setUsePlainTextEncryption(true);
-    }
+    syncVroidHubStorageBackend(initialSettingsSnapshot);
     vroidCredentialsFilePath = path.join(
       app.getPath("userData"),
       "vroid-hub-credentials.json",
     );
-    if (vroidHubSecureStorageAvailable()) {
+    if (vroidHubSecureStorageAvailable(initialSettingsSnapshot)) {
       const vroidCredentials = readVroidHubCredentials({
         credentialsFilePath: vroidCredentialsFilePath,
         decrypt: (buffer) =>
@@ -978,8 +1005,40 @@ if (!app.requestSingleInstanceLock()) {
     ipcMain.handle("persona:settings-enable-developer", () =>
       publishSettings(settingsStore.enableDeveloperSettings()),
     );
-    ipcMain.handle("persona:settings-reset-developer", () =>
-      publishSettings(settingsStore.resetDeveloperSettings()),
+    ipcMain.handle("persona:settings-reset-developer", () => {
+      const snapshot = publishSettings(settingsStore.resetDeveloperSettings());
+      refreshVroidHubStoragePolicy(snapshot);
+      broadcastVroidHubStatus();
+      return settingsStore.getSnapshot();
+    });
+    ipcMain.handle(
+      "persona:settings-set-vroid-plaintext-storage",
+      (_event, allowed) => {
+        const snapshot = publishSettings(
+          settingsStore.setVroidHubPlaintextStorageAllowed(allowed),
+        );
+        syncVroidHubStorageBackend(snapshot);
+        if (!vroidHubSecureStorageAvailable(snapshot)) {
+          vroidHubAuth?.disconnect();
+          vroidHubAuth = null;
+          vroidHubClient = null;
+          publishSettings(settingsStore.clearActiveHubModel());
+        } else if (vroidCredentialsFilePath) {
+          const vroidCredentials = readVroidHubCredentials({
+            credentialsFilePath: vroidCredentialsFilePath,
+            decrypt: (buffer) =>
+              Buffer.from(safeStorage.decryptString(buffer), "utf8"),
+          });
+          if (vroidCredentials) {
+            configureVroidHub(
+              vroidCredentials.clientId,
+              vroidCredentials.clientSecret,
+            );
+          }
+        }
+        broadcastVroidHubStatus();
+        return settingsStore.getSnapshot();
+      },
     );
     ipcMain.handle("persona:settings-set-voice-source", (_event, voiceSource) => {
       const snapshot = publishSettings(settingsStore.setVoiceSource(voiceSource));

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -64,6 +64,11 @@ contextBridge.exposeInMainWorld("personaSettings", {
     ipcRenderer.invoke("persona:settings-enable-developer"),
   resetDeveloperSettings: () =>
     ipcRenderer.invoke("persona:settings-reset-developer"),
+  setVroidHubPlaintextStorageAllowed: (allowed) =>
+    ipcRenderer.invoke(
+      "persona:settings-set-vroid-plaintext-storage",
+      allowed,
+    ),
   setVoiceSource: (voiceSource) =>
     ipcRenderer.invoke("persona:settings-set-voice-source", voiceSource),
   listVoiceSources: () =>

--- a/electron/settings-store.cjs
+++ b/electron/settings-store.cjs
@@ -173,6 +173,7 @@ function defaultState(packagedLibrary) {
     character_size: 1,
     avatar_window: { ...DEFAULT_AVATAR_WINDOW_SIZE },
     developer_settings_enabled: false,
+    vroid_hub_allow_plaintext_storage: false,
     body_transition_ms: DEFAULT_BODY_TRANSITION_MS,
     speaking_debounce_ms: DEFAULT_SPEAKING_DEBOUNCE_MS,
     idle_interim_ms: DEFAULT_IDLE_INTERIM_MS,
@@ -492,6 +493,8 @@ function safeReadState(settingsPath, packagedLibrary) {
       character_size: parsed.character_size,
       avatar_window: sanitizeAvatarWindowSize(parsed.avatar_window),
       developer_settings_enabled: parsed.developer_settings_enabled === true,
+      vroid_hub_allow_plaintext_storage:
+        parsed.vroid_hub_allow_plaintext_storage === true,
       body_transition_ms: sanitizeBodyTransitionMs(
         usesLegacySchedulerUnits
           ? Number(parsed.body_transition_seconds) * 1000
@@ -748,6 +751,8 @@ function createSettingsStore({
           : 1,
       avatar_window: sanitizeAvatarWindowSize(state.avatar_window),
       developer_settings_enabled: state.developer_settings_enabled === true,
+      vroid_hub_allow_plaintext_storage:
+        state.vroid_hub_allow_plaintext_storage === true,
       body_transition_ms: sanitizeBodyTransitionMs(
         state.body_transition_ms,
       ),
@@ -1151,6 +1156,13 @@ function createSettingsStore({
     state.speaking_debounce_ms = DEFAULT_SPEAKING_DEBOUNCE_MS;
     state.idle_interim_ms = DEFAULT_IDLE_INTERIM_MS;
     state.speaking_transition = defaultSpeakingTransition();
+    state.vroid_hub_allow_plaintext_storage = false;
+    writeState();
+    return getSnapshot();
+  }
+
+  function setVroidHubPlaintextStorageAllowed(value) {
+    state.vroid_hub_allow_plaintext_storage = value === true;
     writeState();
     return getSnapshot();
   }
@@ -1297,6 +1309,7 @@ function createSettingsStore({
     enableDeveloperSettings,
     resetPackagedAnimations,
     resetDeveloperSettings,
+    setVroidHubPlaintextStorageAllowed,
     resolveAssetRequest,
     setActiveHubModel,
     setAvatarWindowSize,

--- a/electron/settings-store.test.cjs
+++ b/electron/settings-store.test.cjs
@@ -438,6 +438,15 @@ test("validates custom metadata, files, duplicates, and appearance settings", (c
   assert.equal(store.getSnapshot().speaking_debounce_ms, 350);
   assert.equal(store.getSnapshot().idle_interim_ms, 350);
   assert.equal(store.getSnapshot().developer_settings_enabled, true);
+  assert.equal(
+    store.setVroidHubPlaintextStorageAllowed(true)
+      .vroid_hub_allow_plaintext_storage,
+    true,
+  );
+  assert.equal(
+    store.resetDeveloperSettings().vroid_hub_allow_plaintext_storage,
+    false,
+  );
 
   const invalidModel = path.join(root, "invalid.vrm");
   fs.writeFileSync(invalidModel, "not glTF");

--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -21,16 +21,38 @@ function authorizedHeaders({ accessToken, tokenType = "Bearer" } = {}, extra = {
   };
 }
 
-// VRoid Hub's conditions-of-use fields live at different paths depending on
-// which VRM spec version the model was exported with (VRM 1.0 nests them
-// under the latest version's vrm_meta; VRM 0.0 exposes a top-level license
-// object), per developer.vroid.com's CharacterModelSerializer reference.
+// VRoid Hub's conditions-of-use fields live at different paths *and use
+// different vocabularies* depending on which VRM spec version the model was
+// exported with:
+//   - VRM 1.0: flat fields directly on the latest version's vrm_meta
+//     (VRM1Meta — camelCase, e.g. commercialUsage/modification/
+//     creditNotation), not nested under any `.license` key. See
+//     node_modules/@pixiv/three-vrm-core/types/meta/VRM1Meta.d.ts.
+//   - VRM 0.0: a separate top-level `license` object (snake_case, VRoid
+//     Hub's own vocabulary), per developer.vroid.com's
+//     CharacterModelSerializer reference.
+// The two share no field names or value vocabularies, so this returns each
+// version's native shape tagged with spec_version rather than merging them.
 function characterLicense(model) {
-  return (
-    model.latest_character_model_version?.vrm_meta?.license ??
-    model.license ??
-    null
-  );
+  const specVersion = model.latest_character_model_version?.spec_version;
+  if (specVersion === "1.0") {
+    const vrmMeta = model.latest_character_model_version?.vrm_meta;
+    if (vrmMeta == null || typeof vrmMeta !== "object") return null;
+    return {
+      spec_version: "1.0",
+      avatarPermission: vrmMeta.avatarPermission,
+      allowExcessivelyViolentUsage: vrmMeta.allowExcessivelyViolentUsage,
+      allowExcessivelySexualUsage: vrmMeta.allowExcessivelySexualUsage,
+      commercialUsage: vrmMeta.commercialUsage,
+      allowPoliticalOrReligiousUsage: vrmMeta.allowPoliticalOrReligiousUsage,
+      allowAntisocialOrHateUsage: vrmMeta.allowAntisocialOrHateUsage,
+      creditNotation: vrmMeta.creditNotation,
+      allowRedistribution: vrmMeta.allowRedistribution,
+      modification: vrmMeta.modification,
+    };
+  }
+  if (model.license == null || typeof model.license !== "object") return null;
+  return { spec_version: "0.0", ...model.license };
 }
 
 function toCharacterSummary(model, origin) {

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -104,6 +104,66 @@ test("lists the account's own models and eligible hearted models, filtering inel
   );
 });
 
+test("extracts VRM 0.0 and VRM 1.0 conditions of use in their own native shapes", async (context) => {
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url.startsWith("/api/account/character_models")) {
+        return json(response, 200, {
+          data: [
+            characterModel({
+              id: "vrm0-model",
+              license: { credit: "necessary", personal_commercial_use: "profit" },
+            }),
+            characterModel({
+              id: "vrm1-model",
+              latest_character_model_version: {
+                spec_version: "1.0",
+                vrm_meta: {
+                  commercialUsage: "personalProfit",
+                  creditNotation: "required",
+                  allowRedistribution: false,
+                },
+              },
+            }),
+            characterModel({ id: "no-license-model" }),
+          ],
+        });
+      }
+      if (request.url.startsWith("/api/hearts")) {
+        return json(response, 200, { data: [] });
+      }
+      response.writeHead(404);
+      response.end();
+    },
+  });
+  const client = createVroidHubClient({
+    applicationId: "app-123",
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const characters = await client.listCharacters(TOKEN);
+  const byId = Object.fromEntries(characters.map((c) => [c.id, c.license]));
+
+  assert.deepEqual(byId["vrm0-model"], {
+    spec_version: "0.0",
+    credit: "necessary",
+    personal_commercial_use: "profit",
+  });
+  assert.deepEqual(byId["vrm1-model"], {
+    spec_version: "1.0",
+    avatarPermission: undefined,
+    allowExcessivelyViolentUsage: undefined,
+    allowExcessivelySexualUsage: undefined,
+    commercialUsage: "personalProfit",
+    allowPoliticalOrReligiousUsage: undefined,
+    allowAntisocialOrHateUsage: undefined,
+    creditNotation: "required",
+    allowRedistribution: false,
+    modification: undefined,
+  });
+  assert.equal(byId["no-license-model"], null);
+});
+
 test("downloads a licensed character model through the redirect flow", async (context) => {
   const fileBytes = Buffer.from("glTFmodelbytes");
   const server = await startFakeHub(context, {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -29,6 +29,7 @@ import {
   THEME_OPTIONS,
   type ThemePreference,
 } from '../theme';
+import { vroidLicenseRows } from '../vroid-license-fields';
 
 type SettingsSection =
   | 'models'
@@ -60,73 +61,11 @@ interface ConfirmationRequest {
   title: string;
 }
 
-// Labels mirror VRoid Hub's own conditions-of-use wording, per its developer
-// guidelines for displaying model data conditions of use in a linked app.
-const VROID_LICENSE_FIELDS: Array<{
-  key: keyof PersonaVroidHubCharacterLicense;
-  label: string;
-  values: Record<string, string>;
-}> = [
-  {
-    key: 'characterization_allowed_user',
-    label: 'Who may perform as this character',
-    values: { default: 'Platform default', author: 'Author only', everyone: 'Everyone' },
-  },
-  {
-    key: 'personal_commercial_use',
-    label: 'Personal commercial use',
-    values: {
-      default: 'Platform default',
-      disallow: 'Not allowed',
-      profit: 'Allowed (for-profit)',
-      nonprofit: 'Allowed (non-profit only)',
-    },
-  },
-  {
-    key: 'corporate_commercial_use',
-    label: 'Corporate commercial use',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
-  },
-  {
-    key: 'modification',
-    label: 'Modification',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
-  },
-  {
-    key: 'redistribution',
-    label: 'Redistribution',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
-  },
-  {
-    key: 'credit',
-    label: 'Credit',
-    values: {
-      default: 'Platform default',
-      necessary: 'Required',
-      unnecessary: 'Not required',
-    },
-  },
-  {
-    key: 'violent_expression',
-    label: 'Violent expression',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
-  },
-  {
-    key: 'sexual_expression',
-    label: 'Sexual expression',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
-  },
-];
-
 function vroidConditionsOfUse(
   character: PersonaVroidHubCharacter,
   onOpenHubPage: () => void,
 ): ReactNode {
-  const rows = VROID_LICENSE_FIELDS.map(({ key, label, values }) => {
-    const raw = character.license?.[key];
-    if (raw == null) return null;
-    return { label, value: values[raw] ?? raw };
-  }).filter((row): row is { label: string; value: string } => row != null);
+  const rows = vroidLicenseRows(character.license);
 
   return (
     <>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1072,6 +1072,23 @@ export function SettingsPage() {
     );
   };
 
+  const previewVroidHubPlaintextStorageAllowed = (allowed: boolean) => {
+    setSettings((current) => ({
+      ...current,
+      vroid_hub_allow_plaintext_storage: allowed,
+    }));
+  };
+
+  const saveVroidHubPlaintextStorageAllowed = async (allowed: boolean) => {
+    if (!bridge) return;
+    await persistAppearance(
+      () => bridge.setVroidHubPlaintextStorageAllowed(allowed),
+      allowed
+        ? 'VRoid Hub Linux override enabled.'
+        : 'VRoid Hub Linux override disabled.',
+    );
+  };
+
   const requestDeveloperSettingsAccess = () => {
     if (!bridge || settings.developer_settings_enabled) return;
     openConfirmation({
@@ -1230,6 +1247,8 @@ export function SettingsPage() {
     settings.speaking_debounce_ms !==
       SETTINGS_FALLBACK.speaking_debounce_ms ||
     settings.idle_interim_ms !== SETTINGS_FALLBACK.idle_interim_ms ||
+    settings.vroid_hub_allow_plaintext_storage !==
+      SETTINGS_FALLBACK.vroid_hub_allow_plaintext_storage ||
     (['entry_ms', 'exit_ms'] as const).some((field) =>
       settings.speaking_transition[field].some(
         (milliseconds, index) =>
@@ -2503,6 +2522,29 @@ export function SettingsPage() {
                         </p>
                       </div>
                     </div>
+
+                    <div className="lighting-toggle-row">
+                      <span>VRoid Hub Linux override</span>
+                      <button
+                        aria-checked={settings.vroid_hub_allow_plaintext_storage}
+                        className={`toggle-switch${settings.vroid_hub_allow_plaintext_storage ? ' active' : ''}`}
+                        disabled={busy || !bridge}
+                        onClick={() => {
+                          const next =
+                            !settings.vroid_hub_allow_plaintext_storage;
+                          previewVroidHubPlaintextStorageAllowed(next);
+                          void saveVroidHubPlaintextStorageAllowed(next);
+                        }}
+                        role="switch"
+                        type="button"
+                      />
+                    </div>
+                    <p className="theme-note">
+                      On Linux, this allows VRoid Hub authentication to keep
+                      working even when Electron falls back to plaintext
+                      credential storage. Leave it off to require a secure
+                      keyring backend.
+                    </p>
 
                     {(
                       [

--- a/src/settings-defaults.ts
+++ b/src/settings-defaults.ts
@@ -103,6 +103,7 @@ export const SETTINGS_FALLBACK: PersonaSettingsSnapshot = {
   character_size: 1,
   avatar_window: { ...DEFAULT_AVATAR_WINDOW_SIZE },
   developer_settings_enabled: false,
+  vroid_hub_allow_plaintext_storage: false,
   body_transition_ms: DEFAULT_BODY_TRANSITION_MS,
   speaking_debounce_ms: DEFAULT_SPEAKING_DEBOUNCE_MS,
   idle_interim_ms: DEFAULT_IDLE_INTERIM_MS,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -151,7 +151,10 @@ interface PersonaVroidHubCredentials {
 
 type VroidHubUsagePermission = 'default' | 'disallow' | 'allow';
 
-interface PersonaVroidHubCharacterLicense {
+// VRM 0.0's conditions of use: a top-level `license` object on the character
+// model, snake_case, VRoid-Hub-specific vocabulary.
+interface PersonaVroidHubCharacterLicenseV0 {
+  spec_version: '0.0';
   characterization_allowed_user?: 'default' | 'author' | 'everyone';
   personal_commercial_use?: 'default' | 'disallow' | 'profit' | 'nonprofit';
   corporate_commercial_use?: VroidHubUsagePermission;
@@ -161,6 +164,26 @@ interface PersonaVroidHubCharacterLicense {
   violent_expression?: VroidHubUsagePermission;
   sexual_expression?: VroidHubUsagePermission;
 }
+
+// VRM 1.0's conditions of use: flat fields on vrm_meta (VRM1Meta), camelCase,
+// the VRM spec's own vocabulary — no shared shape with the V0 license above.
+// See node_modules/@pixiv/three-vrm-core/types/meta/VRM1Meta.d.ts.
+interface PersonaVroidHubCharacterLicenseV1 {
+  spec_version: '1.0';
+  avatarPermission?: 'onlyAuthor' | 'onlySeparatelyLicensedPerson' | 'everyone';
+  allowExcessivelyViolentUsage?: boolean;
+  allowExcessivelySexualUsage?: boolean;
+  commercialUsage?: 'personalNonProfit' | 'personalProfit' | 'corporation';
+  allowPoliticalOrReligiousUsage?: boolean;
+  allowAntisocialOrHateUsage?: boolean;
+  creditNotation?: 'required' | 'unnecessary';
+  allowRedistribution?: boolean;
+  modification?: 'prohibited' | 'allowModification' | 'allowModificationRedistribution';
+}
+
+type PersonaVroidHubCharacterLicense =
+  | PersonaVroidHubCharacterLicenseV0
+  | PersonaVroidHubCharacterLicenseV1;
 
 interface PersonaVroidHubCharacter {
   id: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -107,6 +107,7 @@ interface PersonaSettingsSnapshot {
   character_size: number;
   avatar_window: PersonaAvatarWindowSize;
   developer_settings_enabled: boolean;
+  vroid_hub_allow_plaintext_storage: boolean;
   body_transition_ms: number;
   speaking_debounce_ms: number;
   idle_interim_ms: number;
@@ -251,6 +252,9 @@ interface Window {
     setIdleInterimMs(milliseconds: number): Promise<PersonaSettingsSnapshot>;
     enableDeveloperSettings(): Promise<PersonaSettingsSnapshot>;
     resetDeveloperSettings(): Promise<PersonaSettingsSnapshot>;
+    setVroidHubPlaintextStorageAllowed(
+      allowed: boolean,
+    ): Promise<PersonaSettingsSnapshot>;
     setVoiceSource(
       voiceSource: PersonaVoiceSourceSettings,
     ): Promise<PersonaSettingsSnapshot>;

--- a/src/vroid-license-fields.test.ts
+++ b/src/vroid-license-fields.test.ts
@@ -2,32 +2,85 @@ import { describe, expect, it } from 'vitest';
 import { vroidLicenseRows } from './vroid-license-fields';
 
 describe('vroidLicenseRows', () => {
-  it('renders VRM 0.0 fields with their VRoid Hub labels and values', () => {
+  it('renders the complete VRM 0.0 conditions-of-use table', () => {
     const rows = vroidLicenseRows({
       spec_version: '0.0',
+      characterization_allowed_user: 'everyone',
+      violent_expression: 'allow',
+      sexual_expression: 'disallow',
+      corporate_commercial_use: 'disallow',
+      personal_commercial_use: 'nonprofit',
+      redistribution: 'allow',
+      modification: 'disallow',
       credit: 'necessary',
-      personal_commercial_use: 'profit',
     });
 
     expect(rows).toEqual([
-      { label: 'Personal commercial use', value: 'Allowed (for-profit)' },
-      { label: 'Credit', value: 'Required' },
+      { label: 'Avatar use', value: 'Allow' },
+      { label: 'Violent acts', value: 'Allow' },
+      { label: 'Sexual acts', value: 'Do not allow' },
+      { label: 'Corporate use', value: 'Do not allow' },
+      { label: 'Individual commercial use', value: 'Non-profit activities only' },
+      { label: 'Redistribution', value: 'Allow' },
+      { label: 'Alterations', value: 'Do not allow' },
+      { label: 'Attribution', value: 'Required' },
     ]);
   });
 
-  it('renders VRM 1.0 fields, including booleans, with their own labels and values', () => {
+  it('renders the complete VRM 1.0 table and splits shared source fields', () => {
     const rows = vroidLicenseRows({
       spec_version: '1.0',
+      avatarPermission: 'everyone',
+      allowExcessivelyViolentUsage: true,
+      allowExcessivelySexualUsage: false,
+      allowPoliticalOrReligiousUsage: true,
+      allowAntisocialOrHateUsage: false,
       commercialUsage: 'personalProfit',
-      creditNotation: 'required',
       allowRedistribution: false,
+      modification: 'allowModification',
+      creditNotation: 'required',
     });
 
     expect(rows).toEqual([
-      { label: 'Commercial use', value: 'Personal, for-profit allowed' },
-      { label: 'Credit', value: 'Required' },
-      { label: 'Redistribution (unmodified)', value: 'Not allowed' },
+      { label: 'Avatar use', value: 'Allow' },
+      { label: 'Violent acts', value: 'Allow' },
+      { label: 'Sexual acts', value: 'Do not allow' },
+      { label: 'Political/religious acts', value: 'Allow' },
+      { label: 'Antisocial/hateful acts', value: 'Do not allow' },
+      { label: 'Corporate use', value: 'Do not allow' },
+      { label: 'Individual commercial use', value: 'Allow' },
+      { label: 'Redistribution', value: 'Do not allow' },
+      { label: 'Alterations', value: 'Allow' },
+      { label: 'Redistribution of altered model', value: 'Do not allow' },
+      { label: 'Attribution', value: 'Required' },
     ]);
+  });
+
+  it('renders unset source fields as Not set', () => {
+    expect(vroidLicenseRows({ spec_version: '1.0' })).toEqual([
+      { label: 'Avatar use', value: 'Not set' },
+      { label: 'Violent acts', value: 'Not set' },
+      { label: 'Sexual acts', value: 'Not set' },
+      { label: 'Political/religious acts', value: 'Not set' },
+      { label: 'Antisocial/hateful acts', value: 'Not set' },
+      { label: 'Corporate use', value: 'Not set' },
+      { label: 'Individual commercial use', value: 'Not set' },
+      { label: 'Redistribution', value: 'Not set' },
+      { label: 'Alterations', value: 'Not set' },
+      { label: 'Redistribution of altered model', value: 'Not set' },
+      { label: 'Attribution', value: 'Not set' },
+    ]);
+  });
+
+  it('maps VRM 0.0 default values to Not set', () => {
+    const rows = vroidLicenseRows({
+      spec_version: '0.0',
+      characterization_allowed_user: 'default',
+      credit: 'default',
+    });
+
+    expect(rows[0]).toEqual({ label: 'Avatar use', value: 'Not set' });
+    expect(rows[7]).toEqual({ label: 'Attribution', value: 'Not set' });
   });
 
   it('falls back to the raw value when it is not in the known vocabulary', () => {
@@ -36,12 +89,7 @@ describe('vroidLicenseRows', () => {
       credit: 'somethingUnexpected' as never,
     });
 
-    expect(rows).toEqual([{ label: 'Credit', value: 'somethingUnexpected' }]);
-  });
-
-  it('omits fields the model did not set at all', () => {
-    const rows = vroidLicenseRows({ spec_version: '0.0' });
-    expect(rows).toEqual([]);
+    expect(rows[7]).toEqual({ label: 'Attribution', value: 'somethingUnexpected' });
   });
 
   it('returns no rows for a null or missing license', () => {

--- a/src/vroid-license-fields.test.ts
+++ b/src/vroid-license-fields.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { vroidLicenseRows } from './vroid-license-fields';
+
+describe('vroidLicenseRows', () => {
+  it('renders VRM 0.0 fields with their VRoid Hub labels and values', () => {
+    const rows = vroidLicenseRows({
+      spec_version: '0.0',
+      credit: 'necessary',
+      personal_commercial_use: 'profit',
+    });
+
+    expect(rows).toEqual([
+      { label: 'Personal commercial use', value: 'Allowed (for-profit)' },
+      { label: 'Credit', value: 'Required' },
+    ]);
+  });
+
+  it('renders VRM 1.0 fields, including booleans, with their own labels and values', () => {
+    const rows = vroidLicenseRows({
+      spec_version: '1.0',
+      commercialUsage: 'personalProfit',
+      creditNotation: 'required',
+      allowRedistribution: false,
+    });
+
+    expect(rows).toEqual([
+      { label: 'Commercial use', value: 'Personal, for-profit allowed' },
+      { label: 'Credit', value: 'Required' },
+      { label: 'Redistribution (unmodified)', value: 'Not allowed' },
+    ]);
+  });
+
+  it('falls back to the raw value when it is not in the known vocabulary', () => {
+    const rows = vroidLicenseRows({
+      spec_version: '0.0',
+      credit: 'somethingUnexpected' as never,
+    });
+
+    expect(rows).toEqual([{ label: 'Credit', value: 'somethingUnexpected' }]);
+  });
+
+  it('omits fields the model did not set at all', () => {
+    const rows = vroidLicenseRows({ spec_version: '0.0' });
+    expect(rows).toEqual([]);
+  });
+
+  it('returns no rows for a null or missing license', () => {
+    expect(vroidLicenseRows(null)).toEqual([]);
+    expect(vroidLicenseRows(undefined)).toEqual([]);
+  });
+});

--- a/src/vroid-license-fields.ts
+++ b/src/vroid-license-fields.ts
@@ -1,0 +1,149 @@
+export interface VroidLicenseRow {
+  label: string;
+  value: string;
+}
+
+// Labels mirror VRoid Hub's own conditions-of-use wording, per its developer
+// guidelines for displaying model data conditions of use in a linked app.
+// VRM 0.0 models expose these as a top-level `license` object; VRM 1.0
+// models use an entirely different (camelCase, differently-valued) set of
+// fields on vrm_meta directly — see VROID_LICENSE_FIELDS_V1 below. There's
+// no shared vocabulary between the two, so each gets its own table rather
+// than forcing one into the other's shape.
+const VROID_LICENSE_FIELDS_V0: Array<{
+  key: keyof PersonaVroidHubCharacterLicenseV0;
+  label: string;
+  values: Record<string, string>;
+}> = [
+  {
+    key: 'characterization_allowed_user',
+    label: 'Who may perform as this character',
+    values: { default: 'Platform default', author: 'Author only', everyone: 'Everyone' },
+  },
+  {
+    key: 'personal_commercial_use',
+    label: 'Personal commercial use',
+    values: {
+      default: 'Platform default',
+      disallow: 'Not allowed',
+      profit: 'Allowed (for-profit)',
+      nonprofit: 'Allowed (non-profit only)',
+    },
+  },
+  {
+    key: 'corporate_commercial_use',
+    label: 'Corporate commercial use',
+    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+  },
+  {
+    key: 'modification',
+    label: 'Modification',
+    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+  },
+  {
+    key: 'redistribution',
+    label: 'Redistribution',
+    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+  },
+  {
+    key: 'credit',
+    label: 'Credit',
+    values: {
+      default: 'Platform default',
+      necessary: 'Required',
+      unnecessary: 'Not required',
+    },
+  },
+  {
+    key: 'violent_expression',
+    label: 'Violent expression',
+    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+  },
+  {
+    key: 'sexual_expression',
+    label: 'Sexual expression',
+    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+  },
+];
+
+// VRM 1.0's vrm_meta fields (VRM1Meta), mixing enums and booleans — see
+// node_modules/@pixiv/three-vrm-core/types/meta/VRM1Meta.d.ts. Boolean
+// values are looked up via their String() form ("true"/"false").
+const VROID_LICENSE_FIELDS_V1: Array<{
+  key: keyof PersonaVroidHubCharacterLicenseV1;
+  label: string;
+  values: Record<string, string>;
+}> = [
+  {
+    key: 'avatarPermission',
+    label: 'Who may perform as this character',
+    values: {
+      onlyAuthor: 'Author only',
+      onlySeparatelyLicensedPerson: 'Requires a separate license',
+      everyone: 'Everyone',
+    },
+  },
+  {
+    key: 'commercialUsage',
+    label: 'Commercial use',
+    values: {
+      personalNonProfit: 'Personal, non-profit only',
+      personalProfit: 'Personal, for-profit allowed',
+      corporation: 'Corporate use allowed',
+    },
+  },
+  {
+    key: 'modification',
+    label: 'Modification',
+    values: {
+      prohibited: 'Not allowed',
+      allowModification: 'Allowed (no redistribution)',
+      allowModificationRedistribution: 'Allowed, including redistribution',
+    },
+  },
+  {
+    key: 'creditNotation',
+    label: 'Credit',
+    values: { required: 'Required', unnecessary: 'Not required' },
+  },
+  {
+    key: 'allowRedistribution',
+    label: 'Redistribution (unmodified)',
+    values: { true: 'Allowed', false: 'Not allowed' },
+  },
+  {
+    key: 'allowExcessivelyViolentUsage',
+    label: 'Excessively violent expression',
+    values: { true: 'Allowed', false: 'Not allowed' },
+  },
+  {
+    key: 'allowExcessivelySexualUsage',
+    label: 'Excessively sexual expression',
+    values: { true: 'Allowed', false: 'Not allowed' },
+  },
+  {
+    key: 'allowPoliticalOrReligiousUsage',
+    label: 'Political or religious usage',
+    values: { true: 'Allowed', false: 'Not allowed' },
+  },
+  {
+    key: 'allowAntisocialOrHateUsage',
+    label: 'Antisocial or hate speech usage',
+    values: { true: 'Allowed', false: 'Not allowed' },
+  },
+];
+
+export function vroidLicenseRows(
+  license: PersonaVroidHubCharacterLicense | null | undefined,
+): VroidLicenseRow[] {
+  const fields = license?.spec_version === '1.0' ? VROID_LICENSE_FIELDS_V1 : VROID_LICENSE_FIELDS_V0;
+  return fields
+    .map(({ key, label, values }) => {
+      // license's two variants share no keys, so this cast is safe per the
+      // `fields` table already matching license?.spec_version above.
+      const raw = (license as Record<string, unknown> | null | undefined)?.[key as string];
+      if (raw == null) return null;
+      return { label, value: values[String(raw)] ?? String(raw) };
+    })
+    .filter((row): row is VroidLicenseRow => row != null);
+}

--- a/src/vroid-license-fields.ts
+++ b/src/vroid-license-fields.ts
@@ -3,147 +3,172 @@ export interface VroidLicenseRow {
   value: string;
 }
 
-// Labels mirror VRoid Hub's own conditions-of-use wording, per its developer
-// guidelines for displaying model data conditions of use in a linked app.
-// VRM 0.0 models expose these as a top-level `license` object; VRM 1.0
-// models use an entirely different (camelCase, differently-valued) set of
-// fields on vrm_meta directly — see VROID_LICENSE_FIELDS_V1 below. There's
-// no shared vocabulary between the two, so each gets its own table rather
-// than forcing one into the other's shape.
-const VROID_LICENSE_FIELDS_V0: Array<{
-  key: keyof PersonaVroidHubCharacterLicenseV0;
+interface VroidLicenseField<Key extends string = string> {
+  key: Key;
   label: string;
   values: Record<string, string>;
-}> = [
+}
+
+const ALLOW_VALUES = {
+  default: 'Not set',
+  allow: 'Allow',
+  disallow: 'Do not allow',
+};
+
+// Keep the labels, ordering, and value wording aligned with VRoid Hub's
+// conditions-of-use display guidelines. VRM 0.0 and VRM 1.0 expose different
+// source shapes, so each version has its own display table.
+const VROID_LICENSE_FIELDS_V0: VroidLicenseField<
+  keyof PersonaVroidHubCharacterLicenseV0
+>[] = [
   {
     key: 'characterization_allowed_user',
-    label: 'Who may perform as this character',
-    values: { default: 'Platform default', author: 'Author only', everyone: 'Everyone' },
+    label: 'Avatar use',
+    values: { default: 'Not set', author: 'Do not allow', everyone: 'Allow' },
   },
   {
-    key: 'personal_commercial_use',
-    label: 'Personal commercial use',
-    values: {
-      default: 'Platform default',
-      disallow: 'Not allowed',
-      profit: 'Allowed (for-profit)',
-      nonprofit: 'Allowed (non-profit only)',
-    },
+    key: 'violent_expression',
+    label: 'Violent acts',
+    values: ALLOW_VALUES,
+  },
+  {
+    key: 'sexual_expression',
+    label: 'Sexual acts',
+    values: ALLOW_VALUES,
   },
   {
     key: 'corporate_commercial_use',
-    label: 'Corporate commercial use',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+    label: 'Corporate use',
+    values: ALLOW_VALUES,
   },
   {
-    key: 'modification',
-    label: 'Modification',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+    key: 'personal_commercial_use',
+    label: 'Individual commercial use',
+    values: {
+      default: 'Not set',
+      disallow: 'Do not allow',
+      profit: 'Allow',
+      nonprofit: 'Non-profit activities only',
+    },
   },
   {
     key: 'redistribution',
     label: 'Redistribution',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
+    values: ALLOW_VALUES,
+  },
+  {
+    key: 'modification',
+    label: 'Alterations',
+    values: ALLOW_VALUES,
   },
   {
     key: 'credit',
-    label: 'Credit',
+    label: 'Attribution',
     values: {
-      default: 'Platform default',
+      default: 'Not set',
       necessary: 'Required',
       unnecessary: 'Not required',
     },
   },
-  {
-    key: 'violent_expression',
-    label: 'Violent expression',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
-  },
-  {
-    key: 'sexual_expression',
-    label: 'Sexual expression',
-    values: { default: 'Platform default', disallow: 'Not allowed', allow: 'Allowed' },
-  },
 ];
 
-// VRM 1.0's vrm_meta fields (VRM1Meta), mixing enums and booleans — see
-// node_modules/@pixiv/three-vrm-core/types/meta/VRM1Meta.d.ts. Boolean
-// values are looked up via their String() form ("true"/"false").
-const VROID_LICENSE_FIELDS_V1: Array<{
-  key: keyof PersonaVroidHubCharacterLicenseV1;
-  label: string;
-  values: Record<string, string>;
-}> = [
+const BOOLEAN_PERMISSION_VALUES = {
+  true: 'Allow',
+  false: 'Do not allow',
+};
+
+const VROID_LICENSE_FIELDS_V1: VroidLicenseField<
+  keyof PersonaVroidHubCharacterLicenseV1
+>[] = [
   {
     key: 'avatarPermission',
-    label: 'Who may perform as this character',
+    label: 'Avatar use',
     values: {
-      onlyAuthor: 'Author only',
-      onlySeparatelyLicensedPerson: 'Requires a separate license',
-      everyone: 'Everyone',
+      onlyAuthor: 'Do not allow',
+      onlySeparatelyLicensedPerson: 'Do not allow',
+      everyone: 'Allow',
+    },
+  },
+  {
+    key: 'allowExcessivelyViolentUsage',
+    label: 'Violent acts',
+    values: BOOLEAN_PERMISSION_VALUES,
+  },
+  {
+    key: 'allowExcessivelySexualUsage',
+    label: 'Sexual acts',
+    values: BOOLEAN_PERMISSION_VALUES,
+  },
+  {
+    key: 'allowPoliticalOrReligiousUsage',
+    label: 'Political/religious acts',
+    values: BOOLEAN_PERMISSION_VALUES,
+  },
+  {
+    key: 'allowAntisocialOrHateUsage',
+    label: 'Antisocial/hateful acts',
+    values: BOOLEAN_PERMISSION_VALUES,
+  },
+  {
+    key: 'commercialUsage',
+    label: 'Corporate use',
+    values: {
+      personalNonProfit: 'Do not allow',
+      personalProfit: 'Do not allow',
+      corporation: 'Allow',
     },
   },
   {
     key: 'commercialUsage',
-    label: 'Commercial use',
+    label: 'Individual commercial use',
     values: {
-      personalNonProfit: 'Personal, non-profit only',
-      personalProfit: 'Personal, for-profit allowed',
-      corporation: 'Corporate use allowed',
+      personalNonProfit: 'Do not allow',
+      personalProfit: 'Allow',
+      corporation: 'Allow',
+    },
+  },
+  {
+    key: 'allowRedistribution',
+    label: 'Redistribution',
+    values: BOOLEAN_PERMISSION_VALUES,
+  },
+  {
+    key: 'modification',
+    label: 'Alterations',
+    values: {
+      prohibited: 'Do not allow',
+      allowModification: 'Allow',
+      allowModificationRedistribution: 'Allow',
     },
   },
   {
     key: 'modification',
-    label: 'Modification',
+    label: 'Redistribution of altered model',
     values: {
-      prohibited: 'Not allowed',
-      allowModification: 'Allowed (no redistribution)',
-      allowModificationRedistribution: 'Allowed, including redistribution',
+      prohibited: 'Do not allow',
+      allowModification: 'Do not allow',
+      allowModificationRedistribution: 'Allow',
     },
   },
   {
     key: 'creditNotation',
-    label: 'Credit',
+    label: 'Attribution',
     values: { required: 'Required', unnecessary: 'Not required' },
-  },
-  {
-    key: 'allowRedistribution',
-    label: 'Redistribution (unmodified)',
-    values: { true: 'Allowed', false: 'Not allowed' },
-  },
-  {
-    key: 'allowExcessivelyViolentUsage',
-    label: 'Excessively violent expression',
-    values: { true: 'Allowed', false: 'Not allowed' },
-  },
-  {
-    key: 'allowExcessivelySexualUsage',
-    label: 'Excessively sexual expression',
-    values: { true: 'Allowed', false: 'Not allowed' },
-  },
-  {
-    key: 'allowPoliticalOrReligiousUsage',
-    label: 'Political or religious usage',
-    values: { true: 'Allowed', false: 'Not allowed' },
-  },
-  {
-    key: 'allowAntisocialOrHateUsage',
-    label: 'Antisocial or hate speech usage',
-    values: { true: 'Allowed', false: 'Not allowed' },
   },
 ];
 
 export function vroidLicenseRows(
   license: PersonaVroidHubCharacterLicense | null | undefined,
 ): VroidLicenseRow[] {
-  const fields = license?.spec_version === '1.0' ? VROID_LICENSE_FIELDS_V1 : VROID_LICENSE_FIELDS_V0;
-  return fields
-    .map(({ key, label, values }) => {
-      // license's two variants share no keys, so this cast is safe per the
-      // `fields` table already matching license?.spec_version above.
-      const raw = (license as Record<string, unknown> | null | undefined)?.[key as string];
-      if (raw == null) return null;
-      return { label, value: values[String(raw)] ?? String(raw) };
-    })
-    .filter((row): row is VroidLicenseRow => row != null);
+  if (!license) return [];
+
+  const fields: VroidLicenseField[] =
+    license.spec_version === '1.0' ? VROID_LICENSE_FIELDS_V1 : VROID_LICENSE_FIELDS_V0;
+  const values = license as unknown as Record<string, unknown>;
+
+  return fields.map(({ key, label, values: displayValues }) => {
+    const raw = values[key];
+    if (raw == null) return { label, value: 'Not set' };
+    return { label, value: displayValues[String(raw)] ?? String(raw) };
+  });
 }


### PR DESCRIPTION
## Summary
- `characterLicense()` read `latest_character_model_version?.vrm_meta?.license` for VRM 1.0 models, but VRM1Meta (see `node_modules/@pixiv/three-vrm-core/types/meta/VRM1Meta.d.ts`) has no nested `.license` object — its conditions-of-use fields (`commercialUsage`, `modification`, `creditNotation`, `allowRedistribution`, etc.) sit flat on `vrm_meta`, camelCase, with a different vocabulary than VRM 0.0's `license` object.
- The lookup always missed, so every VRM 1.0 hearted model's conditions-of-use dialog silently fell back to "Persona could not read this character's conditions of use," never showing the model's actual terms.
- `characterLicense()` now branches on `spec_version` and returns each version's native shape tagged with `spec_version`, instead of forcing one into the other's vocabulary.
- Extracted the license-row rendering logic out of `SettingsPage.tsx` into `src/vroid-license-fields.ts` so it's unit-testable without mounting the settings UI.

## Test plan
- [x] `npm run test:node` (client-side VRM0/VRM1/no-license extraction)
- [x] `npm run test:renderer` (new `vroid-license-fields.test.ts`)
- [x] `npx tsc -b`
- [x] `npm run lint`
