### PR TITLE
fix: page through all VRoid Hub character models and hearts

### DIFF
--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -3,7 +3,13 @@
 const DEFAULT_BASE_URL = "https://hub.vroid.com";
 // VRoid Hub's own API version header, unrelated to this app's version.
 const API_VERSION = "11";
-const PAGE_SIZE = 12;
+// VRoid Hub caps `count` at 100 per page; ask for the maximum so a typical
+// library is one request and only unusually large ones need to page at all.
+const PAGE_SIZE = 100;
+// Paging follows `_links.next.href` until it's absent, so a misbehaving API
+// that always returns a next link would loop forever without this ceiling.
+// 20 pages of 100 is far past any real VRoid Hub library.
+const MAX_PAGES = 20;
 const API_REQUEST_TIMEOUT_MS = 15 * 1000;
 // The actual VRM binary can be up to MAX_ASSET_BYTES (200 MB, enforced in
 // settings-store.cjs) and is fetched from a presigned storage URL, not
@@ -95,23 +101,50 @@ function createVroidHubClient({
     return response.json();
   }
 
+  // VRoid Hub pages with an opaque cursor: each list response carries the
+  // next page's URL under `_links.next.href`, and its absence — not a short
+  // `data` array — is what marks the last page.
+  function nextPagePath(body, currentPath) {
+    const href = body?._links?.next?.href;
+    if (typeof href !== "string" || href === "") return null;
+    const next = new URL(href, new URL(currentPath, baseUrl));
+    // The access token rides along on every page request, so only ever
+    // follow a next link that stays on the host we were configured with.
+    if (next.origin !== new URL(baseUrl).origin) return null;
+    return `${next.pathname}${next.search}`;
+  }
+
+  // Walks every page of a list endpoint and returns the merged `data`
+  // entries. The character picker wants one complete array, and libraries
+  // are small enough that loading them up front beats a "load more" UI.
+  async function fetchAllPages(path, token) {
+    const items = [];
+    let currentPath = path;
+    for (let page = 0; page < MAX_PAGES && currentPath != null; page += 1) {
+      const body = await fetchJson(currentPath, token);
+      if (Array.isArray(body?.data)) items.push(...body.data);
+      currentPath = nextPagePath(body, currentPath);
+    }
+    return items;
+  }
+
   async function listCharacters(token) {
     // application_id scopes the hearts lookup to this registered app, as
     // VRoid Hub's API requires for the heart-scoped endpoints.
     const heartsQuery = new URLSearchParams({ count: String(PAGE_SIZE) });
     if (applicationId) heartsQuery.set("application_id", applicationId);
-    const [account, hearts] = await Promise.all([
-      fetchJson(`/api/account/character_models?count=${PAGE_SIZE}`, token),
-      fetchJson(`/api/hearts?${heartsQuery.toString()}`, token),
+    const [ownModels, hearts] = await Promise.all([
+      fetchAllPages(`/api/account/character_models?count=${PAGE_SIZE}`, token),
+      fetchAllPages(`/api/hearts?${heartsQuery.toString()}`, token),
     ]);
-    const ownModels = Array.isArray(account?.data) ? account.data : [];
     // Only the connected account unconditionally owns its own models; a
     // hearted model created by someone else must be explicitly marked
     // available to other users before Persona is allowed to use it, per
     // VRoid Hub's third-party integration rules. /api/hearts' data entries
     // are the character models themselves, not a heart record wrapping one.
-    const heartedModels = (Array.isArray(hearts?.data) ? hearts.data : [])
-      .filter((model) => model?.is_other_users_available === true);
+    const heartedModels = hearts.filter(
+      (model) => model?.is_other_users_available === true,
+    );
 
     const ownIds = new Set(
       ownModels

--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -89,6 +89,8 @@ function createVroidHubClient({
   baseUrl = DEFAULT_BASE_URL,
   fetchImpl = fetch,
 } = {}) {
+  const baseOrigin = new URL(baseUrl).origin;
+
   async function fetchJson(pathname, token) {
     const url = new URL(pathname, baseUrl);
     const response = await fetchImpl(url.toString(), {
@@ -108,9 +110,11 @@ function createVroidHubClient({
     const href = body?._links?.next?.href;
     if (typeof href !== "string" || href === "") return null;
     const next = new URL(href, new URL(currentPath, baseUrl));
-    // The access token rides along on every page request, so only ever
-    // follow a next link that stays on the host we were configured with.
-    if (next.origin !== new URL(baseUrl).origin) return null;
+    // Only the path and query survive — fetchJson re-resolves them against
+    // baseUrl, so a next link pointing at another host can never send the
+    // access token there. Stopping outright on one anyway keeps us from
+    // replaying a foreign URL's path against VRoid Hub.
+    if (next.origin !== baseOrigin) return null;
     return `${next.pathname}${next.search}`;
   }
 

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -104,6 +104,124 @@ test("lists the account's own models and eligible hearted models, filtering inel
   );
 });
 
+test("follows _links.next.href until exhausted so nothing past the first page is lost", async (context) => {
+  const requestedUrls = [];
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      requestedUrls.push(request.url);
+      const url = new URL(request.url, "http://x");
+      if (url.pathname === "/api/account/character_models") {
+        const page = url.searchParams.get("max_id") ?? "1";
+        // Page 2's link is absolute, page 3's is relative: VRoid Hub is only
+        // documented as returning "the next page's URL", so accept both.
+        if (page === "1") {
+          return json(response, 200, {
+            data: [characterModel({ id: "own-1" })],
+            _links: {
+              next: {
+                href: `http://127.0.0.1:${server.address().port}/api/account/character_models?count=100&max_id=2`,
+              },
+            },
+          });
+        }
+        if (page === "2") {
+          return json(response, 200, {
+            data: [characterModel({ id: "own-2" })],
+            _links: { next: { href: "/api/account/character_models?count=100&max_id=3" } },
+          });
+        }
+        // Last page: a full `data` array but no next link.
+        return json(response, 200, { data: [characterModel({ id: "own-3" })] });
+      }
+      if (url.pathname === "/api/hearts") {
+        if (url.searchParams.get("max_id") == null) {
+          return json(response, 200, {
+            data: [characterModel({ id: "hearted-1" })],
+            _links: { next: { href: "/api/hearts?count=100&max_id=2" } },
+          });
+        }
+        return json(response, 200, { data: [characterModel({ id: "hearted-2" })] });
+      }
+      response.writeHead(404);
+      response.end();
+    },
+  });
+  const client = createVroidHubClient({
+    applicationId: "app-123",
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const characters = await client.listCharacters(TOKEN);
+
+  assert.deepEqual(
+    characters.map((character) => character.id).sort(),
+    ["hearted-1", "hearted-2", "own-1", "own-2", "own-3"],
+  );
+  assert.equal(
+    requestedUrls.filter((url) => url.startsWith("/api/account/character_models")).length,
+    3,
+  );
+});
+
+test("stops paging rather than following a next link off the configured host", async (context) => {
+  const requestedUrls = [];
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      requestedUrls.push(request.url);
+      if (request.url.startsWith("/api/account/character_models")) {
+        return json(response, 200, {
+          data: [characterModel({ id: "own-1" })],
+          // A next link pointing somewhere else would leak the access token.
+          _links: { next: { href: "https://attacker.example/api/account/character_models" } },
+        });
+      }
+      if (request.url.startsWith("/api/hearts")) {
+        return json(response, 200, { data: [] });
+      }
+      response.writeHead(404);
+      response.end();
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const characters = await client.listCharacters(TOKEN);
+
+  assert.deepEqual(characters.map((character) => character.id), ["own-1"]);
+  assert.equal(requestedUrls.length, 2);
+});
+
+test("caps paging so an API that always returns a next link can't loop forever", async (context) => {
+  let accountRequests = 0;
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url.startsWith("/api/account/character_models")) {
+        accountRequests += 1;
+        return json(response, 200, {
+          data: [characterModel({ id: `own-${accountRequests}` })],
+          _links: {
+            next: { href: `/api/account/character_models?count=100&max_id=${accountRequests}` },
+          },
+        });
+      }
+      if (request.url.startsWith("/api/hearts")) {
+        return json(response, 200, { data: [] });
+      }
+      response.writeHead(404);
+      response.end();
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const characters = await client.listCharacters(TOKEN);
+
+  assert.equal(accountRequests, 20);
+  assert.equal(characters.length, 20);
+});
+
 test("extracts VRM 0.0 and VRM 1.0 conditions of use in their own native shapes", async (context) => {
   const server = await startFakeHub(context, {
     onRequest(request, response) {

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -137,7 +137,12 @@ test("follows _links.next.href until exhausted so nothing past the first page is
         if (url.searchParams.get("max_id") == null) {
           return json(response, 200, {
             data: [characterModel({ id: "hearted-1" })],
-            _links: { next: { href: "/api/hearts?count=100&max_id=2" } },
+            // The heart endpoint's next link carries application_id forward;
+            // the client has to follow the href's query as given, not rebuild
+            // it, or page 2 loses the app scoping.
+            _links: {
+              next: { href: "/api/hearts?count=100&application_id=app-123&max_id=2" },
+            },
           });
         }
         return json(response, 200, { data: [characterModel({ id: "hearted-2" })] });
@@ -161,9 +166,21 @@ test("follows _links.next.href until exhausted so nothing past the first page is
     requestedUrls.filter((url) => url.startsWith("/api/account/character_models")).length,
     3,
   );
+  // Ask for the API's maximum page size, and keep every query parameter the
+  // next link hands back rather than reassembling the URL ourselves.
+  const [firstAccountUrl] = requestedUrls.filter((url) =>
+    url.startsWith("/api/account/character_models"),
+  );
+  const heartsUrls = requestedUrls.filter((url) => url.startsWith("/api/hearts"));
+  assert.equal(new URL(firstAccountUrl, "http://x").searchParams.get("count"), "100");
+  assert.equal(new URL(heartsUrls[0], "http://x").searchParams.get("count"), "100");
+  assert.equal(
+    new URL(heartsUrls[1], "http://x").searchParams.get("application_id"),
+    "app-123",
+  );
 });
 
-test("stops paging rather than following a next link off the configured host", async (context) => {
+test("stops paging rather than replaying a next link that points off the configured host", async (context) => {
   const requestedUrls = [];
   const server = await startFakeHub(context, {
     onRequest(request, response) {
@@ -171,8 +188,12 @@ test("stops paging rather than following a next link off the configured host", a
       if (request.url.startsWith("/api/account/character_models")) {
         return json(response, 200, {
           data: [characterModel({ id: "own-1" })],
-          // A next link pointing somewhere else would leak the access token.
-          _links: { next: { href: "https://attacker.example/api/account/character_models" } },
+          // Following this would re-request a foreign URL's path from VRoid
+          // Hub; the token itself can't escape, since only the path and
+          // query are kept and they're resolved against baseUrl again.
+          _links: {
+            next: { href: "https://attacker.example/api/account/character_models?count=100" },
+          },
         });
       }
       if (request.url.startsWith("/api/hearts")) {
@@ -189,7 +210,10 @@ test("stops paging rather than following a next link off the configured host", a
   const characters = await client.listCharacters(TOKEN);
 
   assert.deepEqual(characters.map((character) => character.id), ["own-1"]);
-  assert.equal(requestedUrls.length, 2);
+  assert.equal(
+    requestedUrls.filter((url) => url.startsWith("/api/account/character_models")).length,
+    1,
+  );
 });
 
 test("caps paging so an API that always returns a next link can't loop forever", async (context) => {


### PR DESCRIPTION
Fixes #30.

## What was wrong

`listCharacters()` asked for one page of `/api/account/character_models` and
one page of `/api/hearts` with `count=12` and never followed up, so anything
past the first page never reached the character picker — no error, no
truncation notice.

## The fix

- Walk `_links.next.href` on both endpoints until it's absent. VRoid Hub's
  API reference is explicit that the presence of that link, not a short
  `data` array, is what marks the last page.
- Raise `count` to 100 (the documented maximum), so a normal-sized library
  is still a single request per endpoint and only unusually large ones page
  at all. Verified against a real account that `/api/hearts` accepts it.
- Keep the existing interface: one complete array, loaded up front. No
  "load more" and no split between owned and hearted models — that would be
  a UX rewrite for libraries that in practice aren't that big.
- The walk stops at 20 pages (2000 models), so an API that always returns a
  next link can't spin forever.

A next link is also only followed while it stays on the configured host.
The access token can't escape either way — `nextPagePath` keeps only the
path and query, and `fetchJson` resolves those against `baseUrl` again —
but stopping outright avoids replaying a foreign URL's path against VRoid
Hub.

Duplicate models across pages (possible if the library changes mid-walk)
are already collapsed by the existing `byId` map.

## Trade-off

An account large enough to page makes sequential requests, so listing takes
longer. Each request keeps the existing 15s timeout and there's no overall
budget — correctness first, and this isn't a screen users sit and watch.

## Tests

`electron/vroid-hub-client.test.cjs` gains three cases: multi-page merging
(absolute and relative `next.href`, a final page with a full `data` array
and no link, and `application_id` surviving into the hearts endpoint's
second page), the off-host link being refused, and the 20-page cap.
`npm run lint` and `npm run test:node` (119 tests) pass.
