### PR TITLE
fix: bump fast-uri and hono past their published advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5562,9 +5562,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -6170,9 +6170,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
CI is currently red on `main` and on every open PR, including my #31. The
failing step is `npm run audit:production`, on all three platforms:

```
fast-uri  3.0.0 - 3.1.4   high       GHSA-7p8r-x3mc-p8w7
hono      <4.12.34        moderate   GHSA-8j4g-w8fx-2239
```

`audit:production` is `npm audit --omit=dev --audit-level=high`, so it's
the fast-uri advisory that trips the exit code. Both advisories were
published after main's last green run, which is why nothing in the code
changed but the job started failing.

Neither package is a direct dependency — both arrive through
`@modelcontextprotocol/sdk`:

```
@modelcontextprotocol/sdk
├─┬ @hono/node-server → hono
└─┬ ajv               → fast-uri
```

Both have fixed versions inside the ranges `package.json` already
declares, so this is a lockfile-only change, no `package.json` edit and no
`overrides` needed:

- `fast-uri` 3.1.4 → **3.1.5** (4.x is a major, outside ajv's `^3.0.1`)
- `hono` 4.12.32 → **4.13.0**

## Verification

`npm run check` passes end to end — lint, 119 node tests, renderer tests,
asset contract, `npm audit --omit=dev --audit-level=high` (now `found 0
vulnerabilities`), and the production build.

Kept separate from #31 so that one stays a pure pagination change; #31
should go green once this lands.
