### PR TITLE
feat: show VRoid Hub character portraits and fix broken model page links

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1196,18 +1196,24 @@ if (!app.requestSingleInstanceLock()) {
         );
       },
     );
-    // Builds the character's Hub page from a bare id rather than trusting a
-    // full URL from the renderer, so this can only ever open
-    // hub.vroid.com/characters/<id>.
+    // Builds the model's Hub page from bare ids rather than trusting a full
+    // URL from the renderer, so this can only ever open
+    // hub.vroid.com/characters/<character id>/models/<model id>. Both ids are
+    // needed: a model lives under the character that owns it, and the model id
+    // alone addresses nothing.
     ipcMain.handle(
       "persona:vroid-open-character-page",
-      (event, characterId) => {
+      (event, characterId, characterModelId) => {
         requireSettingsSender(event);
         if (typeof characterId !== "string" || characterId === "") {
           throw new Error("A character id is required.");
         }
+        if (typeof characterModelId !== "string" || characterModelId === "") {
+          throw new Error("A character model id is required.");
+        }
         void shell.openExternal(
-          `https://hub.vroid.com/characters/${encodeURIComponent(characterId)}`,
+          `https://hub.vroid.com/characters/${encodeURIComponent(characterId)}` +
+            `/models/${encodeURIComponent(characterModelId)}`,
         );
       },
     );

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1158,6 +1158,21 @@ if (!app.requestSingleInstanceLock()) {
       const token = await vroidHubAuth.getValidAccessToken();
       return vroidHubClient.listCharacters(token);
     });
+    // Portraits load one card at a time after the list renders, so a slow or
+    // unreachable image CDN delays a thumbnail rather than the whole picker.
+    // Only ids from the last listing resolve to a URL (see the client), and a
+    // missing portrait is a null, not an error — the card just keeps its
+    // placeholder icon.
+    ipcMain.handle(
+      "persona:vroid-character-portrait",
+      async (event, characterId) => {
+        requireSettingsSender(event);
+        if (typeof characterId !== "string" || characterId === "") {
+          throw new Error("A character id is required.");
+        }
+        return (await vroidHubClient?.loadCharacterPortrait(characterId)) ?? null;
+      },
+    );
     ipcMain.handle(
       "persona:vroid-select-character",
       async (event, characterId, characterName) => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -34,7 +34,10 @@ const {
   MIN_AVATAR_WINDOW_HEIGHT,
 } = require("./settings-store.cjs");
 const { createVroidHubAuth } = require("./vroid-hub-auth.cjs");
-const { createVroidHubClient } = require("./vroid-hub-client.cjs");
+const {
+  characterModelPageUrl,
+  createVroidHubClient,
+} = require("./vroid-hub-client.cjs");
 const {
   clearVroidHubCredentials,
   readVroidHubCredentials,
@@ -1197,23 +1200,14 @@ if (!app.requestSingleInstanceLock()) {
       },
     );
     // Builds the model's Hub page from bare ids rather than trusting a full
-    // URL from the renderer, so this can only ever open
-    // hub.vroid.com/characters/<character id>/models/<model id>. Both ids are
-    // needed: a model lives under the character that owns it, and the model id
-    // alone addresses nothing.
+    // URL from the renderer. characterModelPageUrl validates both ids and
+    // owns the path's shape, where it can be tested — this handler can't.
     ipcMain.handle(
       "persona:vroid-open-character-page",
       (event, characterId, characterModelId) => {
         requireSettingsSender(event);
-        if (typeof characterId !== "string" || characterId === "") {
-          throw new Error("A character id is required.");
-        }
-        if (typeof characterModelId !== "string" || characterModelId === "") {
-          throw new Error("A character model id is required.");
-        }
         void shell.openExternal(
-          `https://hub.vroid.com/characters/${encodeURIComponent(characterId)}` +
-            `/models/${encodeURIComponent(characterModelId)}`,
+          characterModelPageUrl(characterId, characterModelId),
         );
       },
     );

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -101,6 +101,8 @@ contextBridge.exposeInMainWorld("personaVroidHub", {
   connect: () => ipcRenderer.invoke("persona:vroid-connect"),
   disconnect: () => ipcRenderer.invoke("persona:vroid-disconnect"),
   listCharacters: () => ipcRenderer.invoke("persona:vroid-list-characters"),
+  getCharacterPortrait: (characterId) =>
+    ipcRenderer.invoke("persona:vroid-character-portrait", characterId),
   selectCharacter: (characterId, characterName) =>
     ipcRenderer.invoke(
       "persona:vroid-select-character",

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -109,8 +109,12 @@ contextBridge.exposeInMainWorld("personaVroidHub", {
       characterId,
       characterName,
     ),
-  openCharacterPage: (characterId) =>
-    ipcRenderer.invoke("persona:vroid-open-character-page", characterId),
+  openCharacterPage: (characterId, characterModelId) =>
+    ipcRenderer.invoke(
+      "persona:vroid-open-character-page",
+      characterId,
+      characterModelId,
+    ),
   subscribe: (listener) => {
     const handler = (_event, status) => listener(status);
     ipcRenderer.on("persona:vroid-status-updated", handler);

--- a/electron/preload.test.cjs
+++ b/electron/preload.test.cjs
@@ -111,7 +111,7 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
   await vroidHub.listCharacters();
   await vroidHub.getCharacterPortrait("character-id");
   await vroidHub.selectCharacter("character-id", "Character Name");
-  await vroidHub.openCharacterPage("character-id");
+  await vroidHub.openCharacterPage("character-id", "character-model-id");
 
   assert.deepEqual(invocations, [
     ["persona:get-snapshot"],
@@ -179,7 +179,11 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
     ["persona:vroid-list-characters"],
     ["persona:vroid-character-portrait", "character-id"],
     ["persona:vroid-select-character", "character-id", "Character Name"],
-    ["persona:vroid-open-character-page", "character-id"],
+    [
+      "persona:vroid-open-character-page",
+      "character-id",
+      "character-model-id",
+    ],
   ]);
   assert.deepEqual(sent, [
     ["persona:hide"],

--- a/electron/preload.test.cjs
+++ b/electron/preload.test.cjs
@@ -109,6 +109,7 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
   await vroidHub.connect();
   await vroidHub.disconnect();
   await vroidHub.listCharacters();
+  await vroidHub.getCharacterPortrait("character-id");
   await vroidHub.selectCharacter("character-id", "Character Name");
   await vroidHub.openCharacterPage("character-id");
 
@@ -176,6 +177,7 @@ test("preload exposes only narrow Persona and settings IPC operations", async ()
     ["persona:vroid-connect"],
     ["persona:vroid-disconnect"],
     ["persona:vroid-list-characters"],
+    ["persona:vroid-character-portrait", "character-id"],
     ["persona:vroid-select-character", "character-id", "Character Name"],
     ["persona:vroid-open-character-page", "character-id"],
   ]);

--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -12,17 +12,54 @@ const PAGE_SIZE = 100;
 const MAX_PAGES = 20;
 const API_REQUEST_TIMEOUT_MS = 15 * 1000;
 // A portrait is a small JPEG/PNG on VRoid Hub's image CDN rather than its API,
-// so it gets its own budget: generous enough for `original` on a slow link,
-// tight enough that one wedged image can't stall the picker.
+// so it gets its own budget: generous on a slow link, tight enough that one
+// wedged image can't stall the picker.
 const PORTRAIT_TIMEOUT_MS = 20 * 1000;
-// The variants below are a few hundred pixels wide; anything this far past
-// that is not a thumbnail, and inlining it as a data: URL would bloat the
-// renderer for no visible gain.
-const MAX_PORTRAIT_BYTES = 8 * 1024 * 1024;
+// The variants below are a few hundred pixels wide, so a couple of megabytes
+// clears any real one by a wide margin while still refusing a full-size
+// render: a portrait is inlined as base64, which costs the renderer another
+// third again on top of this.
+const MAX_PORTRAIT_BYTES = 2 * 1024 * 1024;
+// Portraits are what an <img> can actually display; SVG in particular buys
+// nothing here, so it isn't accepted just for matching `image/*`.
+const PORTRAIT_CONTENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+// Every visible card asks for its portrait at once, so without a ceiling a
+// large library would open hundreds of simultaneous connections to one host —
+// the shape that earns throttling, and Node's fetch applies no per-origin cap
+// of its own the way a browser does. Six keeps the grid filling quickly
+// without the burst.
+const MAX_CONCURRENT_PORTRAITS = 6;
 // The actual VRM binary can be up to MAX_ASSET_BYTES (200 MB, enforced in
 // settings-store.cjs) and is fetched from a presigned storage URL, not
 // hub.vroid.com's own API, so it gets a longer allowance than the JSON calls.
 const DOWNLOAD_TIMEOUT_MS = 120 * 1000;
+
+/**
+ * The public hub.vroid.com page for one character model.
+ *
+ * A model is nested under the character that owns it, and the two are
+ * separate resources with separate ids: /characters/<character id> alone is
+ * the character's page, and a model id in that position resolves to nothing.
+ * Both ids are percent-encoded into a fixed path so a caller can never widen
+ * this past a model page on hub.vroid.com.
+ */
+function characterModelPageUrl(characterId, characterModelId) {
+  if (typeof characterId !== "string" || characterId === "") {
+    throw new Error("A character id is required.");
+  }
+  if (typeof characterModelId !== "string" || characterModelId === "") {
+    throw new Error("A character model id is required.");
+  }
+  return (
+    `${DEFAULT_BASE_URL}/characters/${encodeURIComponent(characterId)}` +
+    `/models/${encodeURIComponent(characterModelId)}`
+  );
+}
 
 function authorizedHeaders({ accessToken, tokenType = "Bearer" } = {}, extra = {}) {
   if (typeof accessToken !== "string" || accessToken === "") {
@@ -138,6 +175,24 @@ function createVroidHubClient({
   // arbitrary URLs — only addresses VRoid Hub itself just handed us are
   // reachable. Rebuilt (not merged) per listing so it can't grow unbounded.
   const portraitUrlsById = new Map();
+  let activePortraitFetches = 0;
+  const waitingPortraitFetches = [];
+
+  function acquirePortraitSlot() {
+    if (activePortraitFetches < MAX_CONCURRENT_PORTRAITS) {
+      activePortraitFetches += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => waitingPortraitFetches.push(resolve));
+  }
+
+  function releasePortraitSlot() {
+    const next = waitingPortraitFetches.shift();
+    // The slot is handed straight to the next waiter, so the active count is
+    // only decremented once nobody is queued behind it.
+    if (next) next();
+    else activePortraitFetches -= 1;
+  }
 
   async function fetchJson(pathname, token) {
     const url = new URL(pathname, baseUrl);
@@ -244,27 +299,35 @@ function createVroidHubClient({
       return null;
     }
     if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-    // Portraits are public CDN objects: sending the account's access token to
-    // whatever host VRoid Hub named would leak it off hub.vroid.com, so this
-    // request deliberately carries no Authorization header.
-    const response = await fetchImpl(url.toString(), {
-      signal: AbortSignal.timeout(PORTRAIT_TIMEOUT_MS),
-    });
-    if (!response.ok) return null;
-    const contentType = (response.headers.get("content-type") ?? "")
-      .split(";")[0]
-      .trim()
-      .toLowerCase();
-    if (!contentType.startsWith("image/")) return null;
-    const declaredLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(declaredLength) && declaredLength > MAX_PORTRAIT_BYTES) {
-      return null;
+    await acquirePortraitSlot();
+    try {
+      // Portraits are public CDN objects: sending the account's access token
+      // to whatever host VRoid Hub named would leak it off hub.vroid.com, so
+      // this request deliberately carries no Authorization header.
+      const response = await fetchImpl(url.toString(), {
+        signal: AbortSignal.timeout(PORTRAIT_TIMEOUT_MS),
+      });
+      if (!response.ok) return null;
+      const contentType = (response.headers.get("content-type") ?? "")
+        .split(";")[0]
+        .trim()
+        .toLowerCase();
+      if (!PORTRAIT_CONTENT_TYPES.has(contentType)) return null;
+      const declaredLength = Number(response.headers.get("content-length"));
+      if (
+        Number.isFinite(declaredLength) &&
+        declaredLength > MAX_PORTRAIT_BYTES
+      ) {
+        return null;
+      }
+      const bytes = Buffer.from(await response.arrayBuffer());
+      // Re-checked against the body itself: content-length is optional, and a
+      // chunked response can be any size regardless of the header's claim.
+      if (bytes.byteLength > MAX_PORTRAIT_BYTES) return null;
+      return `data:${contentType};base64,${bytes.toString("base64")}`;
+    } finally {
+      releasePortraitSlot();
     }
-    const bytes = Buffer.from(await response.arrayBuffer());
-    // Re-checked against the body itself: content-length is optional, and a
-    // chunked response can be any size regardless of what the header claimed.
-    if (bytes.byteLength > MAX_PORTRAIT_BYTES) return null;
-    return `data:${contentType};base64,${bytes.toString("base64")}`;
   }
 
   async function loadCharacterModel(token, characterId) {
@@ -323,5 +386,6 @@ function createVroidHubClient({
 
 module.exports = {
   DEFAULT_BASE_URL,
+  characterModelPageUrl,
   createVroidHubClient,
 };

--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -11,6 +11,14 @@ const PAGE_SIZE = 100;
 // 20 pages of 100 is far past any real VRoid Hub library.
 const MAX_PAGES = 20;
 const API_REQUEST_TIMEOUT_MS = 15 * 1000;
+// A portrait is a small JPEG/PNG on VRoid Hub's image CDN rather than its API,
+// so it gets its own budget: generous enough for `original` on a slow link,
+// tight enough that one wedged image can't stall the picker.
+const PORTRAIT_TIMEOUT_MS = 20 * 1000;
+// The variants below are a few hundred pixels wide; anything this far past
+// that is not a thumbnail, and inlining it as a data: URL would bloat the
+// renderer for no visible gain.
+const MAX_PORTRAIT_BYTES = 8 * 1024 * 1024;
 // The actual VRM binary can be up to MAX_ASSET_BYTES (200 MB, enforced in
 // settings-store.cjs) and is fetched from a presigned storage URL, not
 // hub.vroid.com's own API, so it gets a longer allowance than the JSON calls.
@@ -61,6 +69,33 @@ function characterLicense(model) {
   return { spec_version: "0.0", ...model.license };
 }
 
+// VRoid Hub's PortraitImageSerializer carries the same portrait at several
+// sizes: sq150/sq300/sq600 (square crops) and w300/w600 (width-constrained),
+// alongside the full-size `original`. The picker draws these as small card
+// banners, so prefer a square crop a little larger than the card is wide —
+// enough for a HiDPI display, far cheaper than `original`, which on VRoid Hub
+// can be a multi-megabyte render. Later entries are pure fallback for models
+// whose response is missing the earlier variants.
+const PORTRAIT_VARIANTS = [
+  "sq300",
+  "sq150",
+  "sq600",
+  "w300",
+  "w600",
+  "q75",
+  "original",
+];
+
+function portraitUrl(model) {
+  const portrait = model.portrait_image;
+  if (portrait == null || typeof portrait !== "object") return null;
+  for (const variant of PORTRAIT_VARIANTS) {
+    const url = portrait[variant]?.url;
+    if (typeof url === "string" && url !== "") return url;
+  }
+  return null;
+}
+
 function toCharacterSummary(model, origin) {
   return {
     id: model.id,
@@ -69,8 +104,7 @@ function toCharacterSummary(model, origin) {
         ? model.name
         : "Untitled character",
     is_downloadable: Boolean(model.is_downloadable),
-    portrait_url:
-      model.portrait_image?.q75?.url ?? model.portrait_image?.original?.url ?? null,
+    portrait_url: portraitUrl(model),
     origin,
     license: characterLicense(model),
   };
@@ -90,6 +124,12 @@ function createVroidHubClient({
   fetchImpl = fetch,
 } = {}) {
   const baseOrigin = new URL(baseUrl).origin;
+  // Portrait URLs the last listCharacters saw, keyed by character id. The
+  // renderer asks for a portrait *by id* rather than by URL so that a
+  // compromised renderer can't turn the main process into a fetcher for
+  // arbitrary URLs — only addresses VRoid Hub itself just handed us are
+  // reachable. Rebuilt (not merged) per listing so it can't grow unbounded.
+  const portraitUrlsById = new Map();
 
   async function fetchJson(pathname, token) {
     const url = new URL(pathname, baseUrl);
@@ -164,7 +204,59 @@ function createVroidHubClient({
       const origin = ownIds.has(model.id) ? "own" : "hearted";
       byId.set(model.id, toCharacterSummary(model, origin));
     }
-    return [...byId.values()];
+    const characters = [...byId.values()];
+    portraitUrlsById.clear();
+    for (const character of characters) {
+      if (character.portrait_url != null) {
+        portraitUrlsById.set(character.id, character.portrait_url);
+      }
+    }
+    return characters;
+  }
+
+  /**
+   * Downloads one character's portrait and returns it as a data: URL, or null
+   * when there's nothing usable to show. The renderer's Content Security
+   * Policy allows `img-src 'self' data: blob:` only, so portraits are fetched
+   * here and inlined rather than pointed at VRoid Hub's image CDN — which also
+   * keeps the settings window from making requests to a third-party host.
+   */
+  async function loadCharacterPortrait(characterId) {
+    const rawUrl = portraitUrlsById.get(characterId);
+    if (rawUrl == null) return null;
+    // Portraits live on an image CDN, so unlike the paging links this URL is
+    // *expected* to point off hub.vroid.com and can't be origin-checked.
+    // Resolving it against baseUrl accepts a relative path and, together with
+    // the protocol check, keeps a file:/data: URL in the API response from
+    // becoming a main-process read.
+    let url;
+    try {
+      url = new URL(rawUrl, baseUrl);
+    } catch {
+      return null;
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    // Portraits are public CDN objects: sending the account's access token to
+    // whatever host VRoid Hub named would leak it off hub.vroid.com, so this
+    // request deliberately carries no Authorization header.
+    const response = await fetchImpl(url.toString(), {
+      signal: AbortSignal.timeout(PORTRAIT_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const contentType = (response.headers.get("content-type") ?? "")
+      .split(";")[0]
+      .trim()
+      .toLowerCase();
+    if (!contentType.startsWith("image/")) return null;
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_PORTRAIT_BYTES) {
+      return null;
+    }
+    const bytes = Buffer.from(await response.arrayBuffer());
+    // Re-checked against the body itself: content-length is optional, and a
+    // chunked response can be any size regardless of what the header claimed.
+    if (bytes.byteLength > MAX_PORTRAIT_BYTES) return null;
+    return `data:${contentType};base64,${bytes.toString("base64")}`;
   }
 
   async function loadCharacterModel(token, characterId) {
@@ -218,7 +310,7 @@ function createVroidHubClient({
     return Buffer.from(await fileResponse.arrayBuffer());
   }
 
-  return { listCharacters, loadCharacterModel };
+  return { listCharacters, loadCharacterModel, loadCharacterPortrait };
 }
 
 module.exports = {

--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -104,6 +104,14 @@ function toCharacterSummary(model, origin) {
         ? model.name
         : "Untitled character",
     is_downloadable: Boolean(model.is_downloadable),
+    // The character a model belongs to is a separate resource with its own
+    // id (CharacterSerializer), and hub.vroid.com pages a model under it:
+    // /characters/<character id>/models/<character model id>. Without this,
+    // there's no way to build a link to the model that resolves.
+    character_id:
+      typeof model.character?.id === "string" && model.character.id !== ""
+        ? model.character.id
+        : null,
     portrait_url: portraitUrl(model),
     origin,
     license: characterLicense(model),

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -3,7 +3,10 @@
 const assert = require("node:assert/strict");
 const http = require("node:http");
 const test = require("node:test");
-const { createVroidHubClient } = require("./vroid-hub-client.cjs");
+const {
+  characterModelPageUrl,
+  createVroidHubClient,
+} = require("./vroid-hub-client.cjs");
 
 const TOKEN = { accessToken: "access-1", tokenType: "Bearer" };
 
@@ -462,12 +465,143 @@ test("returns no portrait for an id the last listing never handed out", async ()
   assert.equal(await client.loadCharacterPortrait("never-listed"), null);
 });
 
-test("ignores a portrait response that isn't an image", async (context) => {
+test("ignores a portrait response that isn't a displayable image", async (context) => {
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url === "/markup.png") {
+        response.writeHead(200, { "content-type": "text/html" });
+        return response.end("<script>nope</script>");
+      }
+      // SVG matches `image/*` but buys nothing as a portrait, so it's not on
+      // the allowlist either.
+      if (request.url === "/vector.png") {
+        response.writeHead(200, { "content-type": "image/svg+xml" });
+        return response.end("<svg xmlns='http://www.w3.org/2000/svg'/>");
+      }
+      if (request.url.startsWith("/api/account/character_models")) {
+        return json(response, 200, {
+          data: [
+            characterModel({
+              id: "markup",
+              portrait_image: { sq300: { url: "/markup.png" } },
+            }),
+            characterModel({
+              id: "vector",
+              portrait_image: { sq300: { url: "/vector.png" } },
+            }),
+          ],
+        });
+      }
+      return json(response, 200, { data: [] });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  await client.listCharacters(TOKEN);
+
+  assert.equal(await client.loadCharacterPortrait("markup"), null);
+  assert.equal(await client.loadCharacterPortrait("vector"), null);
+});
+
+test("addresses a model's Hub page by both the character and model id", () => {
+  // The model id alone resolves to nothing — /characters/<model id> is a 404.
+  assert.equal(
+    characterModelPageUrl("character-9", "model-1"),
+    "https://hub.vroid.com/characters/character-9/models/model-1",
+  );
+});
+
+test("keeps a hostile id inside the model page path", () => {
+  assert.equal(
+    characterModelPageUrl("../../evil", "a b/c?d#e"),
+    "https://hub.vroid.com/characters/..%2F..%2Fevil/models/a%20b%2Fc%3Fd%23e",
+  );
+});
+
+test("refuses to build a model page URL from a missing id", () => {
+  assert.throws(
+    () => characterModelPageUrl("", "model-1"),
+    /character id is required/i,
+  );
+  assert.throws(
+    () => characterModelPageUrl("character-9", ""),
+    /character model id is required/i,
+  );
+  assert.throws(
+    () => characterModelPageUrl("character-9", undefined),
+    /character model id is required/i,
+  );
+});
+
+test("holds portrait downloads to a fixed number of concurrent requests", async (context) => {
+  const modelCount = 20;
+  let inFlight = 0;
+  let peakInFlight = 0;
+  const release = [];
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url.startsWith("/portrait-")) {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        // Held open until every request that's going to arrive has, so the
+        // peak reflects the client's ceiling and not the server's speed.
+        release.push(() => {
+          inFlight -= 1;
+          response.writeHead(200, { "content-type": "image/png" });
+          response.end(Buffer.from([0x89, 0x50]));
+        });
+        return;
+      }
+      if (request.url.startsWith("/api/account/character_models")) {
+        return json(response, 200, {
+          data: Array.from({ length: modelCount }, (_unused, index) =>
+            characterModel({
+              id: `model-${index}`,
+              portrait_image: { sq300: { url: `/portrait-${index}.png` } },
+            }),
+          ),
+        });
+      }
+      return json(response, 200, { data: [] });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+  const characters = await client.listCharacters(TOKEN);
+
+  let done = false;
+  const portraits = Promise.all(
+    characters.map((character) => client.loadCharacterPortrait(character.id)),
+  ).then((results) => {
+    done = true;
+    return results;
+  });
+  // Drained one at a time: each release frees a slot, and the set only ever
+  // finishes if the client hands that slot to a queued request.
+  while (!done) {
+    release.shift()?.();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  assert.equal((await portraits).length, modelCount);
+  assert.ok(
+    peakInFlight <= 6,
+    `expected at most 6 concurrent portrait requests, saw ${peakInFlight}`,
+  );
+});
+
+test("ignores an oversized portrait without buffering it", async (context) => {
   const server = await startFakeHub(context, {
     onRequest(request, response) {
       if (request.url === "/portrait.png") {
-        response.writeHead(200, { "content-type": "text/html" });
-        return response.end("<script>nope</script>");
+        response.writeHead(200, {
+          "content-type": "image/png",
+          "content-length": String(64 * 1024 * 1024),
+        });
+        return response.end(Buffer.alloc(8));
       }
       if (request.url.startsWith("/api/account/character_models")) {
         return json(response, 200, {

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -375,6 +375,89 @@ test("rejects a redirect response with no Location header", async (context) => {
   );
 });
 
+test("inlines a listed character's portrait as a data URL without sending the token", async (context) => {
+  const portraitBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02]);
+  let portraitHeaders = null;
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url === "/portrait-sq300.png") {
+        portraitHeaders = request.headers;
+        response.writeHead(200, { "content-type": "image/png" });
+        return response.end(portraitBytes);
+      }
+      if (request.url.startsWith("/api/account/character_models")) {
+        return json(response, 200, {
+          data: [
+            characterModel({
+              id: "own-1",
+              portrait_image: {
+                // Ordered worst-first to prove the small square crop wins:
+                // `original` on VRoid Hub can be a multi-megabyte render.
+                original: { url: "/portrait-original.png" },
+                sq300: { url: "/portrait-sq300.png" },
+              },
+            }),
+          ],
+        });
+      }
+      return json(response, 200, { data: [] });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const [character] = await client.listCharacters(TOKEN);
+  assert.match(character.portrait_url, /portrait-sq300\.png$/);
+
+  const dataUrl = await client.loadCharacterPortrait("own-1");
+
+  assert.equal(
+    dataUrl,
+    `data:image/png;base64,${portraitBytes.toString("base64")}`,
+  );
+  // The image CDN is a different host from the API, so the access token must
+  // not ride along with the portrait request.
+  assert.equal(portraitHeaders.authorization, undefined);
+});
+
+test("returns no portrait for an id the last listing never handed out", async () => {
+  const client = createVroidHubClient({ baseUrl: "http://127.0.0.1:1" });
+
+  // Nothing is fetched at all: an unlisted id has no URL, which is what keeps
+  // the renderer from steering main-process requests anywhere it likes.
+  assert.equal(await client.loadCharacterPortrait("never-listed"), null);
+});
+
+test("ignores a portrait response that isn't an image", async (context) => {
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url === "/portrait.png") {
+        response.writeHead(200, { "content-type": "text/html" });
+        return response.end("<script>nope</script>");
+      }
+      if (request.url.startsWith("/api/account/character_models")) {
+        return json(response, 200, {
+          data: [
+            characterModel({
+              id: "own-1",
+              portrait_image: { sq300: { url: "/portrait.png" } },
+            }),
+          ],
+        });
+      }
+      return json(response, 200, { data: [] });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  await client.listCharacters(TOKEN);
+
+  assert.equal(await client.loadCharacterPortrait("own-1"), null);
+});
+
 test("requires a character id", async () => {
   const client = createVroidHubClient({ baseUrl: "http://127.0.0.1:1" });
   await assert.rejects(

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -44,7 +44,10 @@ function characterModel(overrides = {}) {
     name: "My Character",
     is_downloadable: false,
     is_other_users_available: true,
-    portrait_image: { q75: { url: "https://hub.vroid.com/portrait.png" } },
+    // A model is nested under the character that owns it, and the two have
+    // separate ids — model pages are addressed by both.
+    character: { id: "character-1" },
+    portrait_image: { sq300: { url: "https://images.vroid.com/portrait.png" } },
     ...overrides,
   };
 }
@@ -372,6 +375,36 @@ test("rejects a redirect response with no Location header", async (context) => {
   await assert.rejects(
     () => client.loadCharacterModel(TOKEN, "model-1"),
     /download URL/i,
+  );
+});
+
+test("carries the owning character's id, which a model's Hub page is addressed by", async (context) => {
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url.startsWith("/api/account/character_models")) {
+        return json(response, 200, {
+          data: [
+            characterModel({ id: "model-1", character: { id: "character-9" } }),
+            // A model with no character block still lists; the picker just
+            // can't offer a link to it.
+            characterModel({ id: "model-2", character: undefined }),
+          ],
+        });
+      }
+      return json(response, 200, { data: [] });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const characters = await client.listCharacters(TOKEN);
+
+  assert.deepEqual(
+    Object.fromEntries(
+      characters.map((character) => [character.id, character.character_id]),
+    ),
+    { "model-1": "character-9", "model-2": null },
   );
 });
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -119,7 +119,7 @@ function VroidCharacterPortrait({
 
 function vroidConditionsOfUse(
   character: PersonaVroidHubCharacter,
-  onOpenHubPage: () => void,
+  onOpenHubPage: (() => void) | null,
 ): ReactNode {
   const rows = vroidLicenseRows(character.license);
 
@@ -145,15 +145,20 @@ function vroidConditionsOfUse(
           VRoid Hub.
         </p>
       )}
-      <p>
-        <button
-          className="link-button"
-          onClick={onOpenHubPage}
-          type="button"
-        >
-          View {character.name} on VRoid Hub
-        </button>
-      </p>
+      {/* Only offered when VRoid Hub gave us the owning character's id: the
+          model's page lives under it, so without it there's no address to
+          open and a link would only lead to a 404. */}
+      {onOpenHubPage && (
+        <p>
+          <button
+            className="link-button"
+            onClick={onOpenHubPage}
+            type="button"
+          >
+            View {character.name} on VRoid Hub
+          </button>
+        </p>
+      )}
     </>
   );
 }
@@ -898,11 +903,19 @@ export function SettingsPage() {
     }
     // VRoid Hub's third-party integration guidelines require a conditions-
     // of-use confirmation before a hearted (not-owned) model is used.
+    const owningCharacterId = character.character_id;
     openConfirmation({
       confirmLabel: 'Use this character',
       title: 'Model Data Conditions of Use',
-      detail: vroidConditionsOfUse(character, () =>
-        void vroidHubBridge.openCharacterPage(character.id),
+      detail: vroidConditionsOfUse(
+        character,
+        owningCharacterId == null
+          ? null
+          : () =>
+              void vroidHubBridge.openCharacterPage(
+                owningCharacterId,
+                character.id,
+              ),
       ),
       onConfirm: () => activateVroidCharacter(character),
     });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -61,6 +61,62 @@ interface ConfirmationRequest {
   title: string;
 }
 
+// Portraits arrive from the main process as data: URLs, one request per card,
+// and stay cached for the window's lifetime: they're immutable enough that
+// re-downloading them on every "Refresh list" would only cost time. Module
+// scope rather than component state so the cache survives leaving and
+// re-entering the Models section.
+const vroidPortraitCache = new Map<string, string | null>();
+
+function VroidCharacterPortrait({
+  character,
+}: {
+  character: PersonaVroidHubCharacter;
+}) {
+  const [portrait, setPortrait] = useState<string | null>(
+    () => vroidPortraitCache.get(character.id) ?? null,
+  );
+
+  useEffect(() => {
+    const bridge = window.personaVroidHub;
+    // No portrait_url means VRoid Hub has no image for this model, so there's
+    // nothing to ask the main process for.
+    if (!bridge || character.portrait_url == null) return;
+    if (vroidPortraitCache.has(character.id)) {
+      setPortrait(vroidPortraitCache.get(character.id) ?? null);
+      return;
+    }
+    let cancelled = false;
+    void bridge
+      .getCharacterPortrait(character.id)
+      // A portrait that won't load is cosmetic: cache the miss so the card
+      // settles on its placeholder instead of retrying on every render.
+      .catch(() => null)
+      .then((dataUrl) => {
+        vroidPortraitCache.set(character.id, dataUrl);
+        if (!cancelled) setPortrait(dataUrl);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [character.id, character.portrait_url]);
+
+  if (portrait == null) {
+    return (
+      <span aria-hidden="true" className="asset-portrait asset-portrait-empty">
+        VRM
+      </span>
+    );
+  }
+  return (
+    <img
+      alt={`${character.name} portrait`}
+      className="asset-portrait"
+      src={portrait}
+    />
+  );
+}
+
 function vroidConditionsOfUse(
   character: PersonaVroidHubCharacter,
   onOpenHubPage: () => void,
@@ -1603,8 +1659,8 @@ export function SettingsPage() {
                       )}
                       {vroidCharacters?.map((character) => (
                         <article className="asset-card" key={character.id}>
+                          <VroidCharacterPortrait character={character} />
                           <span className="asset-card-main">
-                            <span className="asset-icon">VRM</span>
                             <span>
                               <strong>{character.name}</strong>
                               <small>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -62,11 +62,46 @@ interface ConfirmationRequest {
 }
 
 // Portraits arrive from the main process as data: URLs, one request per card,
-// and stay cached for the window's lifetime: they're immutable enough that
-// re-downloading them on every "Refresh list" would only cost time. Module
-// scope rather than component state so the cache survives leaving and
-// re-entering the Models section.
+// and stay cached: they're immutable enough that re-downloading them on every
+// "Refresh list" would only cost time. Module scope rather than component
+// state so the cache survives leaving and re-entering the Models section.
 const vroidPortraitCache = new Map<string, string | null>();
+// In-flight requests, so the same model is only ever fetched once at a time.
+// Without this, StrictMode's double-mounted effects in development — and any
+// future card that repeats a model — would each open their own request.
+const vroidPortraitRequests = new Map<string, Promise<string | null>>();
+
+function requestVroidPortrait(
+  bridge: NonNullable<Window['personaVroidHub']>,
+  characterId: string,
+): Promise<string | null> {
+  const pending = vroidPortraitRequests.get(characterId);
+  if (pending) return pending;
+  const request = bridge
+    .getCharacterPortrait(characterId)
+    // A portrait that won't load is cosmetic, so a failure settles the card on
+    // its placeholder rather than surfacing an error. The miss is remembered
+    // only until the next "Refresh list", which clears misses so a transient
+    // failure — or a portrait the main process hadn't listed yet — isn't
+    // remembered for the window's lifetime.
+    .catch(() => null)
+    .then((dataUrl) => {
+      vroidPortraitCache.set(characterId, dataUrl);
+      return dataUrl;
+    })
+    .finally(() => vroidPortraitRequests.delete(characterId));
+  vroidPortraitRequests.set(characterId, request);
+  return request;
+}
+
+// Drops remembered misses while keeping portraits that already loaded, so a
+// refresh is also the user's "try again" for cards stuck on the placeholder.
+// Deleting during iteration is well defined for a Map.
+function forgetMissingVroidPortraits() {
+  for (const [characterId, portrait] of vroidPortraitCache) {
+    if (portrait == null) vroidPortraitCache.delete(characterId);
+  }
+}
 
 function VroidCharacterPortrait({
   character,
@@ -81,21 +116,18 @@ function VroidCharacterPortrait({
     const bridge = window.personaVroidHub;
     // No portrait_url means VRoid Hub has no image for this model, so there's
     // nothing to ask the main process for.
-    if (!bridge || character.portrait_url == null) return;
+    if (!bridge || character.portrait_url == null) {
+      setPortrait(null);
+      return;
+    }
     if (vroidPortraitCache.has(character.id)) {
       setPortrait(vroidPortraitCache.get(character.id) ?? null);
       return;
     }
     let cancelled = false;
-    void bridge
-      .getCharacterPortrait(character.id)
-      // A portrait that won't load is cosmetic: cache the miss so the card
-      // settles on its placeholder instead of retrying on every render.
-      .catch(() => null)
-      .then((dataUrl) => {
-        vroidPortraitCache.set(character.id, dataUrl);
-        if (!cancelled) setPortrait(dataUrl);
-      });
+    void requestVroidPortrait(bridge, character.id).then((dataUrl) => {
+      if (!cancelled) setPortrait(dataUrl);
+    });
     return () => {
       cancelled = true;
     };
@@ -416,6 +448,9 @@ export function SettingsPage() {
     PersonaVroidHubCharacter[] | null
   >(null);
   const [vroidLoading, setVroidLoading] = useState(false);
+  // Remounts the portrait of every card when it changes — see
+  // refreshVroidCharacters.
+  const [vroidPortraitEpoch, setVroidPortraitEpoch] = useState(0);
   const confirmationDialogRef = useRef<HTMLDivElement>(null);
   const confirmationCancelRef = useRef<HTMLButtonElement>(null);
   const confirmationConfirmRef = useRef<HTMLButtonElement>(null);
@@ -462,6 +497,11 @@ export function SettingsPage() {
   const refreshVroidCharacters = useCallback(async () => {
     if (!vroidHubBridge) return;
     setVroidLoading(true);
+    forgetMissingVroidPortraits();
+    // Bumped so every card's portrait effect runs again against the freshened
+    // cache; the character ids a refresh returns are usually identical, which
+    // on its own would leave the effects — and any stuck placeholder — alone.
+    setVroidPortraitEpoch((epoch) => epoch + 1);
     try {
       setVroidCharacters(await vroidHubBridge.listCharacters());
     } catch (error) {
@@ -1672,7 +1712,10 @@ export function SettingsPage() {
                       )}
                       {vroidCharacters?.map((character) => (
                         <article className="asset-card" key={character.id}>
-                          <VroidCharacterPortrait character={character} />
+                          <VroidCharacterPortrait
+                            character={character}
+                            key={vroidPortraitEpoch}
+                          />
                           <span className="asset-card-main">
                             <span>
                               <strong>{character.name}</strong>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1002,6 +1002,31 @@ button {
   background: var(--accent-soft);
 }
 
+/* VRoid Hub cards lead with the character's portrait: models are often left
+   unnamed on Hub, so the picture is the only thing that tells them apart. */
+.asset-portrait {
+  display: block;
+  width: 100%;
+  max-height: 220px;
+  aspect-ratio: 4 / 3;
+  border-bottom: 1px solid var(--border);
+  background: var(--fill-subtle);
+  object-fit: cover;
+  /* Hub portraits frame the character centred with headroom above, so bias
+     the crop upwards to keep the face in a box wider than it is tall. */
+  object-position: center 20%;
+}
+
+.asset-portrait-empty {
+  display: grid;
+  place-items: center;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
 .asset-card-footer {
   display: flex;
   align-items: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2570,12 +2570,21 @@ button {
   margin-top: 0;
 }
 
+/* One term per line. The two-column grid goes on each row rather than the
+   list, because every dt/dd pair is wrapped in a div — put it on the <dl> and
+   those wrappers become the cells, pairing terms two-to-a-line instead. */
 .vroid-license-terms {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 4px 12px;
+  gap: 4px;
   margin: 10px 0 0;
   font-size: var(--fs-sm);
+}
+
+.vroid-license-terms > div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  gap: 12px;
 }
 
 .vroid-license-terms dt {
@@ -2583,8 +2592,11 @@ button {
 }
 
 .vroid-license-terms dd {
+  min-width: 0;
   margin: 0;
   color: var(--text-primary);
+  /* Values share the right edge so "Allow"/"Do not allow" read as one column
+     no matter how long the term next to them is. */
   text-align: right;
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -187,7 +187,11 @@ type PersonaVroidHubCharacterLicense =
   | PersonaVroidHubCharacterLicenseV1;
 
 interface PersonaVroidHubCharacter {
+  // The character *model*'s id — what downloads and page links are keyed by.
   id: string;
+  // The id of the character the model belongs to, needed alongside `id` to
+  // address the model's page on hub.vroid.com. Null when VRoid Hub omitted it.
+  character_id: string | null;
   name: string;
   is_downloadable: boolean;
   portrait_url: string | null;
@@ -289,7 +293,10 @@ interface Window {
       characterId: string,
       characterName: string,
     ): Promise<PersonaSettingsSnapshot>;
-    openCharacterPage(characterId: string): Promise<void>;
+    openCharacterPage(
+      characterId: string,
+      characterModelId: string,
+    ): Promise<void>;
     subscribe(
       listener: (status: PersonaVroidHubStatus) => void,
     ): () => void;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -281,6 +281,10 @@ interface Window {
     connect(): Promise<PersonaVroidHubStatus>;
     disconnect(): Promise<PersonaVroidHubStatus>;
     listCharacters(): Promise<PersonaVroidHubCharacter[]>;
+    // Resolves to a data: URL for the character's portrait, or null when the
+    // model has none — the renderer's CSP forbids loading it from VRoid Hub's
+    // image CDN directly.
+    getCharacterPortrait(characterId: string): Promise<string | null>;
     selectCharacter(
       characterId: string,
       characterName: string,


### PR DESCRIPTION
Fixes #33 

## What was wrong

Two things about the VRoid Hub character picker, found while using it against
a real account.

Cards showed a `VRM` badge and the model's name. Models uploaded to VRoid Hub
are frequently left unnamed, so a library renders as a column of "Untitled
character" rows with nothing to tell them apart — you pick one, wait for the
download, and find out whether it was the one you meant.

Separately, the conditions-of-use dialog's "View … on VRoid Hub" link built
`hub.vroid.com/characters/<id>` out of the character **model** id. A model is a
separate resource nested under the character that owns it, addressed as
`/characters/<character id>/models/<model id>`, so every one of those links
404'd. That link is how a user reviews a third-party model's terms before
agreeing to them, which is the part VRoid Hub's integration guidelines are
about.

## The fix

**Portraits.** Cards now lead with the model's portrait. The renderer's CSP
allows `img-src 'self' data: blob:` only, so rather than widen it for an image
CDN whose host isn't documented, portraits are fetched in the main process and
handed over as `data:` URLs — which also keeps the Settings window from making
requests to a third-party host at all.

The renderer asks **by character id**, never by URL: `listCharacters` records
each model's portrait URL, and `loadCharacterPortrait` resolves only ids from
that listing, so this can't become a fetcher for arbitrary addresses. The
request deliberately carries no `Authorization` header — the portrait lives on
a different host from the API, and the account's access token has no business
going there.

Portrait selection prefers `sq300` and falls back through the other documented
`PortraitImageSerializer` variants to `original`. The previous code read
`q75`, which isn't among them, so it was likely falling through to the
full-size render in practice.

Fetches are bounded: six at a time (every visible card asks at once, and Node's
`fetch` applies no per-origin cap of its own), 20s timeout, 2 MB ceiling
checked against both `content-length` and the body, and a
png/jpeg/webp/gif allowlist — SVG matches `image/*` but buys nothing as a
portrait. Anything that fails is a `null`, not an error: the card keeps its
placeholder.

They load per card after the list renders, so a slow CDN costs a thumbnail
rather than the whole picker, and results are cached. "Refresh list" drops
remembered *misses* while keeping portraits that already loaded, so it doubles
as "try again" for a card stuck on its placeholder — without that, a transient
failure was remembered for the window's lifetime.

**Model page links.** Character summaries now carry `character_id`, and
`openCharacterPage` takes both ids. The URL is still assembled from bare,
percent-encoded ids rather than accepting one from the renderer, but that
assembly moved out of `main.cjs` — which has no test harness, which is how it
shipped addressing a model by the wrong id — into `characterModelPageUrl` in
the client, where it's covered. When VRoid Hub omits the character block the
link is left out rather than pointing somewhere broken.

**Conditions-of-use layout.** Each `dt`/`dd` pair in that dialog is wrapped in
a `div`, but the two-column grid sat on the `<dl>`, so the wrappers became the
grid cells: terms were paired two-to-a-line, each label stacked above a
right-aligned value. The grid moves onto each row — one term per line, values
sharing a right edge.

## Trade-offs

Portraits are inlined as base64, which costs a third again over the raw bytes
in renderer memory, and the cache isn't evicted while the window lives. With
the 2 MB ceiling and real `sq300` files this stays small, and it buys a picker
that doesn't re-download on every refresh.

Redirects are followed normally and validated only on the initial URL. No
credentials ride along, so closing that would mean either breaking legitimate
CDN redirects or resolving and filtering private address ranges — cost well
past the benefit when VRoid Hub is already the trust anchor for these URLs.

Models with no portrait get a full-size placeholder rather than the old small
badge, which keeps the grid uniform but leaves a larger empty box.

## Tests

`electron/vroid-hub-client.test.cjs` gains ten cases: portrait inlining as a
`data:` URL with the access token asserted absent from the request, an id the
last listing never handed out resolving without any fetch, `text/html` and
`image/svg+xml` responses refused, an oversized response refused, concurrency
held at six across twenty models with the slot hand-off exercised by draining
one request at a time, `character_id` extraction including a model with no
character block, the Hub page URL's shape, hostile ids staying percent-encoded
inside that path, and missing ids rejected. `electron/preload.test.cjs` covers
the changed channel surface.

`npm run lint`, `npm run test:node` (128 tests) and the renderer build pass
locally; CI is green on the fork branch.

## Manual verification

Windows 11, against a real VRoid Hub account with both owned and hearted
models: thumbnails render on the cards, the conditions-of-use dialog opens the
correct model page, and the terms table reads as one column.

