### PR TITLE
fix: unbreak Electron install on Node.js 24.16.0 and newer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3953,16 +3953,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5576,16 +5566,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -9321,14 +9301,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -164,5 +164,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "zod": "^4.4.3"
+  },
+  "overrides": {
+    "yauzl": "^3.3.1"
   }
 }


### PR DESCRIPTION
Fixes #36.

`npm ci` on Node 24.16.0+ exits 0 while leaving `node_modules/electron/dist/` with only `LICENSES.chromium.html` — no `Electron.app`, no `path.txt` — so `npm start` / `npm run dev` / `npm run demo` fail on a fresh clone with nothing explaining why. Since `engines.node` is `>=24`, any contributor on a current Node release hits it.

**Cause:** `electron`'s `install.js` extracts via `extract-zip@2.0.1`, which pins `yauzl@^2.10.0`. yauzl 2.x uses `fd-slicer`, whose custom `destroy()` collides with the stream-lifecycle change in Node 24.16.0 — extraction stops after the first of 585 entries and the promise **never settles**, so `install.js` falls off the end of the event loop before writing `path.txt`. Nothing throws, so npm reports success. Same root cause as electron/electron#51619, nodejs/node#63487 and cypress-io/cypress#33891; Electron 39.8.10 predates the upstream fix.

**Change:** one `overrides` entry pointing `yauzl` at 3.x, which dropped `fd-slicer`. `package-lock.json` gets slightly smaller as `fd-slicer` drops out.

**Verified** on macOS 26.5.2 / arm64 / Node 24.16.0, from `rm -rf node_modules`:

- `npm ci` → `dist/` contains `Electron.app`, `LICENSE`, `LICENSES.chromium.html`, `version`; `path.txt` written correctly
- app launches and renders, bridge and MCP endpoint respond
- `npm run check` passes: lint, 128 node + 55 renderer tests, asset contract, production audit (0 vulnerabilities), build
- also re-confirmed the boundary: Node 24.15.0 and 22.23.2 were never affected

One caveat worth knowing: the override does not repair an already-broken checkout, because npm won't re-run electron's `postinstall` while the `electron` package itself is unchanged. Anyone currently stuck needs `rm -rf node_modules && npm ci`.

Happy to swap this for an Electron bump instead if you'd rather not carry an override — this was just the smallest change that keeps `engines.node: >=24` working as written.
