### PR TITLE
Give the avatar secondary motion on drag and orbit

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,39 +98,27 @@ chunk to begin at a more distant first keyframe.
 Compatibility work is lazy. Short output gaps remain inside Speaking and never
 rank or instantiate an unused Idle action.
 
-`src/drag-inertia.ts` gives the character secondary motion when the user
-handles it. Orbiting moves the camera and Alt+drag moves the window, so
-neither displaces the character in world space and its spring bones see no
-acceleration. The module turns both gestures into a transient displacement of
-the model root — a drag lags the body opposite the drag, an orbit sweep twists
-it about the vertical axis — and lets the existing three-vrm spring simulation
-answer. Both settle to exact rest, so a gesture never leaves the character
-moved or turned.
+`src/drag-inertia.ts` gives the character secondary motion while the user is
+handling it. Orbiting moves the camera and Alt+drag moves the window, so
+neither displaces the character and its spring bones see no acceleration. The
+module turns both gestures into a transient lag that the existing three-vrm
+spring simulation answers, and both settle to exact rest, so a gesture never
+leaves the character moved or turned.
 
-The lag is delivered as a lean of the torso, not a move of the model root. A
+The lag is a lean of the torso rather than a move of the model root, because a
 VRM spring may declare a `center` node and is then blind to any motion of that
-node, so moving the root is cancelled outright by both common conventions: a
-center on the scene root, which VRoid writes, and a center on the hips. Of the
-models on hand only one responded to a root move, and it only did so because
-its export had been changed to drop the centers. Leaning the spine moves the
-joints relative to every such center, since the rotation happens below all of
-them. A rotation cannot reproduce a vertical lag, so a purely up-and-down
-gesture leans less than a sideways one.
+node. Both conventions in the wild cancel a root move outright, a center on
+the scene root and a center on the hips, while a rotation below them registers
+on any rig. The lean is written to the normalized humanoid rig, on top of the
+animated pose each frame and without accumulating, and is shared top heavy so
+that rigid props mounted on the chest are not flung about. A rotation cannot
+reproduce a vertical lag, so a purely up-and-down gesture leans less than a
+sideways one.
 
-The lean is shared along the torso top heavy, most of it on the upper chest.
-Rigid props are mounted lower, on the chest, and a rig may carry very long
-ones: sharing the lean evenly threw a pair of wings 21cm, while the top heavy
-split leaves them a 5cm follow. Sparing them outright would be just as wrong,
-since a body that leans carries what is strapped to it. The spring response is
-within one percent either way, because hair hangs off the head and the chest
-chain off the upper chest, both above every joint the lean touches.
-
-Its offsets are screen-relative and the renderer maps them onto the camera
-basis, which keeps a drag pulling the same visual direction whatever way the
-camera faces. Azimuth is read against the orbit target rather than the model,
-so panning does not register as rotation, and a sweep larger than a hand can
-produce in one frame is discarded as a camera reposition rather than a
-gesture.
+Offsets are relative to the screen and mapped onto the camera basis. Azimuth
+is read against the orbit target rather than the model, so panning does not
+register as a rotation, and a sweep too large to be a hand gesture is
+discarded as a camera reposition.
 
 The persisted
 `speaking_transition.entry_ms` and `speaking_transition.exit_ms`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,6 +98,40 @@ chunk to begin at a more distant first keyframe.
 Compatibility work is lazy. Short output gaps remain inside Speaking and never
 rank or instantiate an unused Idle action.
 
+`src/drag-inertia.ts` gives the character secondary motion when the user
+handles it. Orbiting moves the camera and Alt+drag moves the window, so
+neither displaces the character in world space and its spring bones see no
+acceleration. The module turns both gestures into a transient displacement of
+the model root — a drag lags the body opposite the drag, an orbit sweep twists
+it about the vertical axis — and lets the existing three-vrm spring simulation
+answer. Both settle to exact rest, so a gesture never leaves the character
+moved or turned.
+
+The lag is delivered as a lean of the torso, not a move of the model root. A
+VRM spring may declare a `center` node and is then blind to any motion of that
+node, so moving the root is cancelled outright by both common conventions: a
+center on the scene root, which VRoid writes, and a center on the hips. Of the
+models on hand only one responded to a root move, and it only did so because
+its export had been changed to drop the centers. Leaning the spine moves the
+joints relative to every such center, since the rotation happens below all of
+them. A rotation cannot reproduce a vertical lag, so a purely up-and-down
+gesture leans less than a sideways one.
+
+The lean is shared along the torso top heavy, most of it on the upper chest.
+Rigid props are mounted lower, on the chest, and a rig may carry very long
+ones: sharing the lean evenly threw a pair of wings 21cm, while the top heavy
+split leaves them a 5cm follow. Sparing them outright would be just as wrong,
+since a body that leans carries what is strapped to it. The spring response is
+within one percent either way, because hair hangs off the head and the chest
+chain off the upper chest, both above every joint the lean touches.
+
+Its offsets are screen-relative and the renderer maps them onto the camera
+basis, which keeps a drag pulling the same visual direction whatever way the
+camera faces. Azimuth is read against the orbit target rather than the model,
+so panning does not register as rotation, and a sweep larger than a hand can
+produce in one frame is discarded as a camera reposition rather than a
+gesture.
+
 The persisted
 `speaking_transition.entry_ms` and `speaking_transition.exit_ms`
 settings hold inclusive `[minimum, maximum]` millisecond ranges for the
@@ -252,7 +286,8 @@ asset safety, and release checksums.
 Vitest covers animation priority and configured animation selection, speech
 signal gating, motion compatibility and variety, transition timing, async
 request replacement, pause debounce, Idle interim handling, one-shot actions,
-and scheduler cleanup. GitHub Actions then compiles and self-tests the native
+scheduler cleanup, and drag inertia including camera-jump rejection and
+return-to-rest. GitHub Actions then compiles and self-tests the native
 helper on its real operating system and builds the renderer on all three
 platforms.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
   SETTINGS_FALLBACK,
 } from './settings-defaults';
 import { useWindowDrag } from './hooks/useWindowDrag';
+import { createDragInertiaState, queueDragPixels } from './drag-inertia';
 import {
   BODY_SPEECH_LEVEL_THRESHOLD,
   bodySpeechSignalActive,
@@ -33,7 +34,15 @@ const INITIAL_STATE: VoiceState = {
 };
 
 export function App() {
-  useWindowDrag();
+  // Shared with the render loop by reference: drag events arrive far more
+  // often than React should re-render the scene.
+  const [dragInertia] = useState(createDragInertiaState);
+  useWindowDrag(
+    useCallback(
+      (dx: number, dy: number) => queueDragPixels(dragInertia, dx, dy),
+      [dragInertia],
+    ),
+  );
   const [voice, setVoice] = useState<VoiceState>(INITIAL_STATE);
   const [audioLevel, setAudioLevel] = useState(0);
   const [hasObservedAudioLevel, setHasObservedAudioLevel] = useState(false);
@@ -149,6 +158,7 @@ export function App() {
         audioLevel={audioLevel}
         bodySpeaking={bodySpeaking}
         characterSize={settings.character_size}
+        dragInertia={dragInertia}
         lighting={settings.model_lighting[defaultModel.id]}
         modelUrl={defaultModel.asset_url}
         onAnimationComplete={handleAnimationComplete}

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,6 +1,20 @@
-import { Suspense, useEffect, useLayoutEffect, useMemo } from 'react';
+import { Suspense, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import type * as THREE from 'three';
+import * as THREE from 'three';
+import {
+  advanceDragInertia,
+  applyPendingDrag,
+  applyPendingOrbit,
+  cameraAzimuth,
+  isDragInertiaAtRest,
+  orbitSweep,
+  queueOrbitRadians,
+  torsoLeanAngle,
+  TORSO_LEAN_WEIGHTS,
+  leanWeightsFor,
+  worldPerPixel,
+  type DragInertiaState,
+} from '../drag-inertia';
 import { useVrmLoader } from '../hooks/useVrmLoader';
 import { useVrmAnimation } from '../hooks/useVrmAnimation';
 import { useAmplitudeLipSync } from '../hooks/useAmplitudeLipSync';
@@ -10,6 +24,59 @@ import {
   type PlayableAnimationType,
 } from '../animation-catalog';
 
+// Reused every frame so the render loop allocates nothing.
+const CAMERA_RIGHT = new THREE.Vector3();
+const CAMERA_UP = new THREE.Vector3();
+const ORBIT_TARGET = new THREE.Vector3();
+const LAG = new THREE.Vector3();
+const LEAN_AXIS = new THREE.Vector3();
+const PARENT_ROTATION = new THREE.Quaternion();
+const LEAN = new THREE.Quaternion();
+const TWIST = new THREE.Quaternion();
+const UP = new THREE.Vector3(0, 1, 0);
+
+const TORSO_BONES = TORSO_LEAN_WEIGHTS.map(([name]) => name);
+
+function orbitTarget(controls: unknown, fallback: THREE.Vector3): THREE.Vector3 {
+  const target = (controls as { target?: unknown } | null)?.target;
+  return target instanceof THREE.Vector3 ? target : fallback;
+}
+
+interface Torso {
+  /** Each joint with its share of the lean; the shares sum to one. */
+  bones: { node: THREE.Object3D; weight: number }[];
+  /** Hips-to-head distance at rest, so the lean scales with the model. */
+  length: number;
+}
+
+/**
+ * The normalized humanoid rig is what animation drives and what `vrm.update`
+ * copies onto the render skeleton, so the lean has to be written there.
+ */
+function readTorso(vrm: {
+  humanoid: {
+    getNormalizedBoneNode(name: string): THREE.Object3D | null;
+  };
+  scene: THREE.Object3D;
+}): Torso | null {
+  vrm.scene.updateMatrixWorld(true);
+  const hips = vrm.humanoid.getNormalizedBoneNode('hips');
+  const head = vrm.humanoid.getNormalizedBoneNode('head');
+  if (!hips || !head) return null;
+  const present = TORSO_BONES.filter(
+    (name) => vrm.humanoid.getNormalizedBoneNode(name) !== null,
+  );
+  const bones = leanWeightsFor(present).flatMap(([name, weight]) => {
+    const node = vrm.humanoid.getNormalizedBoneNode(name);
+    return node ? [{ node, weight }] : [];
+  });
+  if (bones.length === 0) return null;
+  const length = hips
+    .getWorldPosition(new THREE.Vector3())
+    .distanceTo(head.getWorldPosition(new THREE.Vector3()));
+  return length > 0 ? { bones, length } : null;
+}
+
 interface AvatarProps {
   animation: PlayableAnimationType;
   animationRequest: number;
@@ -18,6 +85,7 @@ interface AvatarProps {
   preloadAnimationUrls?: readonly string[];
   audioLevel: number;
   bodySpeaking: boolean;
+  dragInertia?: DragInertiaState;
   modelUrl: string;
   onAnimationComplete: () => void;
   playback: 'loop' | 'once';
@@ -37,6 +105,7 @@ function AvatarModel({
   preloadAnimationUrls,
   audioLevel,
   bodySpeaking,
+  dragInertia,
   modelUrl,
   onAnimationComplete,
   playback,
@@ -91,15 +160,100 @@ function AvatarModel({
     stableFallbackAnimationUrls,
   ]);
 
+  const torsoRef = useRef<Torso | null>(null);
+  const lastAzimuth = useRef<number | null>(null);
+
   useLayoutEffect(() => {
+    torsoRef.current = null;
+    // Re-framing jumps the camera, and that jump is not an orbit gesture.
+    lastAzimuth.current = null;
     if (vrm) onReady?.(vrm.scene);
   }, [onReady, vrm]);
 
-  useFrame((_, delta) => {
+  useFrame((state, delta) => {
     if (!vrm) return;
     updateAnimation(delta);
     updateBlink(delta);
     updateLipSync(delta, audioLevel, speaking || bodySpeaking);
+
+    if (dragInertia) {
+      const torso = (torsoRef.current ??= readTorso(vrm));
+      const { camera } = state;
+      const target = orbitTarget(
+        state.controls,
+        vrm.scene.getWorldPosition(ORBIT_TARGET),
+      );
+
+      // Orbiting sweeps the camera around the target; the character itself
+      // never moves, so read the sweep off the camera rather than the pointer.
+      const azimuth = cameraAzimuth(
+        camera.position.x,
+        camera.position.z,
+        target.x,
+        target.z,
+      );
+      const previousAzimuth = lastAzimuth.current;
+      lastAzimuth.current = azimuth;
+      if (previousAzimuth !== null) {
+        queueOrbitRadians(dragInertia, orbitSweep(previousAzimuth, azimuth));
+      }
+      applyPendingOrbit(dragInertia);
+
+      if (camera instanceof THREE.PerspectiveCamera) {
+        applyPendingDrag(
+          dragInertia,
+          worldPerPixel(
+            camera.position.distanceTo(target),
+            camera.fov,
+            state.size.height,
+          ),
+        );
+      }
+      advanceDragInertia(dragInertia, delta);
+
+      if (torso && !isDragInertiaAtRest(dragInertia)) {
+        // The lag is screen-relative, so it rides the camera basis. Held in
+        // world axes it would swing along the view direction once the user had
+        // orbited a quarter turn, and read as barely moving at all.
+        CAMERA_RIGHT.setFromMatrixColumn(camera.matrixWorld, 0);
+        CAMERA_UP.setFromMatrixColumn(camera.matrixWorld, 1);
+        LAG.set(0, 0, 0)
+          .addScaledVector(CAMERA_RIGHT, dragInertia.x)
+          .addScaledVector(CAMERA_UP, dragInertia.y);
+
+        // Into the frame the torso rotates in. Its matrix is a frame stale,
+        // which at these angles is not visible.
+        const parent = torso.bones[0].node.parent;
+        if (parent) {
+          LAG.applyQuaternion(
+            parent.getWorldQuaternion(PARENT_ROTATION).invert(),
+          );
+        }
+
+        // Tip the torso toward the lag, about the axis square to it and to up.
+        // A vertical lag leaves no axis to turn about, so it leans none.
+        LEAN_AXIS.crossVectors(UP, LAG);
+        const horizontal = LEAN_AXIS.length();
+        const lean =
+          horizontal > 0 ? torsoLeanAngle(horizontal, torso.length) : 0;
+        if (lean !== 0) LEAN_AXIS.divideScalar(horizontal);
+
+        for (const { node, weight } of torso.bones) {
+          if (lean !== 0) {
+            node.quaternion.premultiply(
+              LEAN.setFromAxisAngle(LEAN_AXIS, lean * weight),
+            );
+          }
+          node.quaternion.premultiply(
+            TWIST.setFromAxisAngle(UP, dragInertia.yaw * weight),
+          );
+        }
+        // Spring bones simulate against joint world matrices, so the lean has
+        // to be committed before vrm.update runs them for this frame.
+        vrm.scene.updateMatrixWorld(true);
+      }
+    }
+
     vrm.update(delta);
   });
 

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -10,6 +10,7 @@ import * as THREE from 'three';
 import { Avatar } from './Avatar';
 import type { PlayableAnimationType } from '../animation-catalog';
 import { calculateFullBodyFraming } from '../camera-framing';
+import type { DragInertiaState } from '../drag-inertia';
 import { resolveLightingSettings } from '../settings-defaults';
 
 interface SceneProps {
@@ -21,6 +22,7 @@ interface SceneProps {
   audioLevel: number;
   bodySpeaking: boolean;
   characterSize: number;
+  dragInertia?: DragInertiaState;
   enablePan?: boolean;
   framingMargin?: number;
   groundShadow?: boolean;

--- a/src/drag-inertia.test.ts
+++ b/src/drag-inertia.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest';
+import {
+  advanceDragInertia,
+  applyPendingDrag,
+  createDragInertiaState,
+  DEFAULT_DRAG_INERTIA,
+  applyPendingOrbit,
+  cameraAzimuth,
+  isDragInertiaAtRest,
+  leanWeightsFor,
+  MAX_ORBIT_SWEEP_PER_FRAME,
+  orbitSweep,
+  queueDragPixels,
+  queueOrbitRadians,
+  torsoLeanAngle,
+  worldPerPixel,
+} from './drag-inertia';
+
+const WORLD_PER_PIXEL = 0.004;
+
+function settle(state: ReturnType<typeof createDragInertiaState>) {
+  for (let frame = 0; frame < 600; frame += 1) {
+    advanceDragInertia(state, 1 / 60);
+    if (isDragInertiaAtRest(state)) return frame;
+  }
+  return -1;
+}
+
+describe('cameraAzimuth', () => {
+  it('ignores a pan, which moves camera and target together', () => {
+    const before = cameraAzimuth(0, 4, 0, 0);
+    const after = cameraAzimuth(1.5, 4.5, 1.5, 0.5);
+    expect(after).toBeCloseTo(before);
+  });
+
+  it('follows the camera swinging around a fixed target', () => {
+    expect(cameraAzimuth(0, 4, 0, 0)).toBeCloseTo(0);
+    expect(cameraAzimuth(4, 0, 0, 0)).toBeCloseTo(Math.PI / 2);
+  });
+});
+
+describe('orbitSweep', () => {
+  it('reports the signed delta of an ordinary gesture', () => {
+    expect(orbitSweep(0.2, 0.35)).toBeCloseTo(0.15);
+    expect(orbitSweep(0.35, 0.2)).toBeCloseTo(-0.15);
+  });
+
+  it('takes the short way across the -pi/pi seam', () => {
+    expect(orbitSweep(Math.PI - 0.05, -Math.PI + 0.05)).toBeCloseTo(0.1);
+  });
+
+  it('discards a camera jump too large to be a hand gesture', () => {
+    // Re-framing after a character-size change snaps the camera to the front.
+    // That is not the user spinning the view.
+    expect(orbitSweep(1.5, 0)).toBe(0);
+    expect(orbitSweep(0, MAX_ORBIT_SWEEP_PER_FRAME + 0.01)).toBe(0);
+    expect(orbitSweep(0, MAX_ORBIT_SWEEP_PER_FRAME - 0.01)).not.toBe(0);
+  });
+
+  it('treats a non-finite azimuth as no sweep', () => {
+    expect(orbitSweep(Number.NaN, 0.2)).toBe(0);
+    expect(orbitSweep(0.2, Number.NaN)).toBe(0);
+  });
+});
+
+describe('torsoLeanAngle', () => {
+  it('tips further the further the body has to trail', () => {
+    expect(torsoLeanAngle(0, 0.6)).toBe(0);
+    expect(torsoLeanAngle(0.1, 0.6)).toBeGreaterThan(0);
+    expect(torsoLeanAngle(0.2, 0.6)).toBeGreaterThan(torsoLeanAngle(0.1, 0.6));
+  });
+
+  it('leans a short torso and a long one by a comparable amount', () => {
+    // Same lag as a fraction of the torso, so the visual answer matches even
+    // though a chibi model is half the height of a tall one.
+    expect(torsoLeanAngle(0.15, 0.3)).toBeCloseTo(torsoLeanAngle(0.3, 0.6));
+  });
+
+  it('saturates rather than growing without bound', () => {
+    expect(torsoLeanAngle(1e6, 0.6)).toBeLessThan(Math.PI / 2);
+  });
+
+  it('keeps sign, so the body trails whichever way the drag went', () => {
+    expect(torsoLeanAngle(-0.2, 0.6)).toBeCloseTo(-torsoLeanAngle(0.2, 0.6));
+  });
+
+  it('returns zero for a rig with no measurable torso', () => {
+    expect(torsoLeanAngle(0.2, 0)).toBe(0);
+    expect(torsoLeanAngle(Number.NaN, 0.6)).toBe(0);
+  });
+});
+
+describe('leanWeightsFor', () => {
+  const ALL = ['upperChest', 'chest', 'spine'];
+
+  it('always sums to one, so the lean angle is the angle asked for', () => {
+    for (const present of [ALL, ['chest', 'spine'], ['spine'], ['upperChest']]) {
+      const total = leanWeightsFor(present).reduce((s, [, w]) => s + w, 0);
+      expect(total).toBeCloseTo(1);
+    }
+  });
+
+  it('puts most of the lean on the highest joint', () => {
+    const [top, ...rest] = leanWeightsFor(ALL);
+    expect(top[0]).toBe('upperChest');
+    // Rigid props hang off the chest, below this joint, and get thrown when
+    // the lean is shared out evenly.
+    for (const [, weight] of rest) expect(weight).toBeLessThan(top[1]);
+    expect(top[1]).toBeGreaterThan(0.5);
+  });
+
+  it('descends down the chain', () => {
+    const weights = leanWeightsFor(ALL).map(([, w]) => w);
+    for (let i = 1; i < weights.length; i += 1) {
+      expect(weights[i]).toBeLessThanOrEqual(weights[i - 1]);
+    }
+  });
+
+  it('leans by the full angle on a rig missing the upper joints', () => {
+    expect(leanWeightsFor(['spine'])).toEqual([['spine', 1]]);
+  });
+
+  it('returns nothing for a rig with no torso at all', () => {
+    expect(leanWeightsFor([])).toEqual([]);
+    expect(leanWeightsFor(['head'])).toEqual([]);
+  });
+});
+
+describe('worldPerPixel', () => {
+  it('scales with distance so the feel survives zooming', () => {
+    expect(worldPerPixel(4, 20, 680)).toBeCloseTo(worldPerPixel(2, 20, 680) * 2);
+  });
+
+  it('shrinks as the viewport gains pixels', () => {
+    expect(worldPerPixel(2, 20, 1360)).toBeCloseTo(
+      worldPerPixel(2, 20, 680) / 2,
+    );
+  });
+
+  it('returns zero rather than infinity for a degenerate viewport', () => {
+    expect(worldPerPixel(2, 20, 0)).toBe(0);
+    expect(worldPerPixel(0, 20, 680)).toBe(0);
+  });
+});
+
+describe('drag inertia', () => {
+  it('starts at rest and stays there without a drag', () => {
+    const state = createDragInertiaState();
+    expect(isDragInertiaAtRest(state)).toBe(true);
+    advanceDragInertia(state, 1 / 60);
+    expect(isDragInertiaAtRest(state)).toBe(true);
+  });
+
+  it('lags opposite the drag, flipping screen Y into camera up', () => {
+    const state = createDragInertiaState();
+    queueDragPixels(state, 100, 40);
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+
+    // Window moved right and down, so the body trails left and up.
+    expect(state.x).toBeCloseTo(-100 * WORLD_PER_PIXEL * DEFAULT_DRAG_INERTIA.gain);
+    expect(state.y).toBeCloseTo(40 * WORLD_PER_PIXEL * DEFAULT_DRAG_INERTIA.gain);
+  });
+
+  it('accumulates the same lag regardless of how the drag is split up', () => {
+    const oneEvent = createDragInertiaState();
+    queueDragPixels(oneEvent, 60, 0);
+    applyPendingDrag(oneEvent, WORLD_PER_PIXEL);
+
+    const manyEvents = createDragInertiaState();
+    for (let i = 0; i < 6; i += 1) {
+      queueDragPixels(manyEvents, 10, 0);
+      applyPendingDrag(manyEvents, WORLD_PER_PIXEL);
+    }
+
+    expect(manyEvents.x).toBeCloseTo(oneEvent.x);
+  });
+
+  it('drains pending pixels so one drag is never applied twice', () => {
+    const state = createDragInertiaState();
+    queueDragPixels(state, 100, 0);
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+    const afterFirst = state.x;
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+    expect(state.x).toBe(afterFirst);
+  });
+
+  it('clamps a fast fling to the configured maximum lag', () => {
+    const state = createDragInertiaState();
+    queueDragPixels(state, 100000, -100000);
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+
+    expect(state.x).toBeCloseTo(-DEFAULT_DRAG_INERTIA.maxOffset);
+    expect(state.y).toBeCloseTo(-DEFAULT_DRAG_INERTIA.maxOffset);
+  });
+
+  it('overshoots through rest before settling, so the body visibly wobbles', () => {
+    const state = createDragInertiaState();
+    queueDragPixels(state, 100, 0);
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+    const start = state.x;
+    expect(start).toBeLessThan(0);
+
+    let overshoot = 0;
+    for (let frame = 0; frame < 600; frame += 1) {
+      advanceDragInertia(state, 1 / 60);
+      overshoot = Math.max(overshoot, state.x);
+    }
+    expect(overshoot).toBeGreaterThan(0);
+    expect(overshoot).toBeLessThan(Math.abs(start));
+  });
+
+  it('returns to exact rest within about a second', () => {
+    const state = createDragInertiaState();
+    queueDragPixels(state, 120, 80);
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+
+    const frames = settle(state);
+    expect(frames).toBeGreaterThan(0);
+    expect(frames).toBeLessThan(120);
+    expect(state.x).toBe(0);
+    expect(state.y).toBe(0);
+  });
+
+  it('stays bounded when a long frame hitch is integrated', () => {
+    const state = createDragInertiaState();
+    queueDragPixels(state, 100, 0);
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+
+    advanceDragInertia(state, 5);
+    expect(Number.isFinite(state.x)).toBe(true);
+    expect(Math.abs(state.x)).toBeLessThanOrEqual(DEFAULT_DRAG_INERTIA.maxOffset);
+  });
+
+  it('twists opposite an orbit sweep and unwinds to the original facing', () => {
+    const state = createDragInertiaState();
+    queueOrbitRadians(state, 0.1);
+    applyPendingOrbit(state);
+    expect(state.yaw).toBeCloseTo(-0.1 * DEFAULT_DRAG_INERTIA.yawGain);
+
+    expect(settle(state)).toBeGreaterThan(0);
+    // Facing must return exactly, or orbiting would slowly rotate the model.
+    expect(state.yaw).toBe(0);
+  });
+
+  it('clamps a long orbit sweep to the configured maximum twist', () => {
+    const state = createDragInertiaState();
+    for (let i = 0; i < 40; i += 1) {
+      queueOrbitRadians(state, 0.5);
+      applyPendingOrbit(state);
+    }
+    expect(state.yaw).toBeCloseTo(-DEFAULT_DRAG_INERTIA.maxYaw);
+  });
+
+  it('holds a visible twist while an orbit gesture is sustained', () => {
+    // A steady drag: about 2 rad/s for a second, at 60fps. The spring eats
+    // the lag as fast as the sweep adds it, so this settles at an equilibrium
+    // rather than accumulating. That equilibrium is what has to be visible;
+    // at a low gain it collapsed to a degree or two and read as nothing.
+    const state = createDragInertiaState();
+    let smallest = Infinity;
+    for (let frame = 0; frame < 60; frame += 1) {
+      queueOrbitRadians(state, 2 / 60);
+      applyPendingOrbit(state);
+      advanceDragInertia(state, 1 / 60);
+      if (frame > 10) smallest = Math.min(smallest, Math.abs(state.yaw));
+    }
+    expect(smallest).toBeGreaterThan(0.1);
+  });
+
+  it('reports rest only when the twist has settled too', () => {
+    const state = createDragInertiaState();
+    queueOrbitRadians(state, 0.5);
+    applyPendingOrbit(state);
+    expect(isDragInertiaAtRest(state)).toBe(false);
+  });
+
+  it('ignores non-finite input rather than poisoning the spring', () => {
+    const state = createDragInertiaState();
+    queueDragPixels(state, Number.NaN, 10);
+    applyPendingDrag(state, WORLD_PER_PIXEL);
+    expect(state.x).toBe(0);
+    expect(state.y).toBe(0);
+
+    queueDragPixels(state, 100, 0);
+    applyPendingDrag(state, Number.NaN);
+    expect(state.x).toBe(0);
+    expect(state.pendingX).toBe(0);
+
+    advanceDragInertia(state, Number.NaN);
+    expect(isDragInertiaAtRest(state)).toBe(true);
+  });
+});

--- a/src/drag-inertia.ts
+++ b/src/drag-inertia.ts
@@ -1,0 +1,307 @@
+/**
+ * Secondary motion for window drags and camera orbits.
+ *
+ * Orbit controls move the camera and Alt+drag moves the window. Neither moves
+ * the character, so its spring bones have no acceleration to react to and the
+ * model stays rigid exactly when the user is handling it. This turns both
+ * gestures into a transient lag that the existing three-vrm spring simulation
+ * answers; nothing here simulates hair or cloth itself.
+ *
+ * The lag is delivered as a lean of the torso rather than a move of the model
+ * root, because a VRM spring may declare a `center` node and is then blind to
+ * any motion of that node — moving the root is cancelled outright by the two
+ * common conventions, a center on the scene root (what VRoid writes) and a
+ * center on the hips. Leaning the spine moves the joints relative to every
+ * such center, since the rotation happens below all of them.
+ *
+ * A rotation cannot reproduce a vertical lag, so a purely up-and-down gesture
+ * leans less than a sideways one. The horizontal component carries the effect.
+ */
+
+export interface DragInertiaSettings {
+  /** Fraction of the drag distance the body lags behind the window. */
+  gain: number;
+  /** Spring constant pulling the body back to rest. */
+  stiffness: number;
+  /** Velocity damping; below 2*sqrt(stiffness) the body overshoots. */
+  damping: number;
+  /** Maximum lag in world units, so a fast drag cannot fling the model away. */
+  maxOffset: number;
+  /** Fraction of an orbit sweep the body twists before catching up. */
+  yawGain: number;
+  /** Maximum twist in radians. */
+  maxYaw: number;
+}
+
+export const DEFAULT_DRAG_INERTIA: DragInertiaSettings = {
+  gain: 0.35,
+  stiffness: 120,
+  damping: 14,
+  maxOffset: 0.25,
+  // A sustained gesture settles at roughly
+  //   rate * gain * damping / stiffness
+  // because the spring eats the lag as fast as the gesture adds it. Orbiting
+  // sweeps a couple of radians per second at most, an order of magnitude less
+  // than a window drag covers in world units, so the angular gain has to be
+  // correspondingly larger to land in the same visible range.
+  yawGain: 1.0,
+  maxYaw: 0.3,
+};
+
+export interface DragInertiaState {
+  /**
+   * Current offset of the model root from its rest position, along the
+   * camera's right and up axes. Screen-relative rather than world-relative
+   * because the gesture that drives it is: a drag to the right of the screen
+   * has to lag the body to the left of the screen whatever way the camera
+   * happens to be facing. The caller maps these onto the camera basis.
+   */
+  x: number;
+  y: number;
+  /** Offset velocity, in world units per second. */
+  vx: number;
+  vy: number;
+  /** Current twist of the model root about the vertical axis, in radians. */
+  yaw: number;
+  vyaw: number;
+  /** Drag pixels recorded since the last frame drained them. */
+  pendingX: number;
+  pendingY: number;
+  /** Orbit sweep in radians recorded since the last frame drained it. */
+  pendingYaw: number;
+}
+
+export function createDragInertiaState(): DragInertiaState {
+  return {
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    yaw: 0,
+    vyaw: 0,
+    pendingX: 0,
+    pendingY: 0,
+    pendingYaw: 0,
+  };
+}
+
+/**
+ * Records a drag in screen pixels. The render loop owns the pixel-to-world
+ * conversion because only it knows the current camera distance, so drags are
+ * buffered here rather than applied immediately.
+ */
+export function queueDragPixels(
+  state: DragInertiaState,
+  dxPixels: number,
+  dyPixels: number,
+): void {
+  if (!Number.isFinite(dxPixels) || !Number.isFinite(dyPixels)) return;
+  state.pendingX += dxPixels;
+  state.pendingY += dyPixels;
+}
+
+function clamp(value: number, limit: number): number {
+  return Math.min(limit, Math.max(-limit, value));
+}
+
+/**
+ * Angle of the camera around the vertical axis through what it is looking at.
+ * Measured against the orbit target rather than the model, so panning — which
+ * translates camera and target together — does not read as a rotation.
+ */
+export function cameraAzimuth(
+  cameraX: number,
+  cameraZ: number,
+  targetX: number,
+  targetZ: number,
+): number {
+  return Math.atan2(cameraX - targetX, cameraZ - targetZ);
+}
+
+/**
+ * A hand gesture cannot sweep more than this in one frame. Anything larger is
+ * the camera being repositioned in code -- re-framing after a character-size
+ * change snaps it back to the front, for one -- and must not be mistaken for
+ * the user spinning the view.
+ */
+export const MAX_ORBIT_SWEEP_PER_FRAME = 0.5;
+
+/**
+ * Signed sweep between two azimuths, the shortest way round so crossing the
+ * -pi/pi seam is not a spin. Returns 0 for a jump too large to be a gesture.
+ */
+export function orbitSweep(
+  previousAzimuth: number,
+  azimuth: number,
+  maxSweep: number = MAX_ORBIT_SWEEP_PER_FRAME,
+): number {
+  if (!Number.isFinite(previousAzimuth) || !Number.isFinite(azimuth)) return 0;
+  let sweep = azimuth - previousAzimuth;
+  if (sweep > Math.PI) sweep -= 2 * Math.PI;
+  else if (sweep < -Math.PI) sweep += 2 * Math.PI;
+  return Math.abs(sweep) > maxSweep ? 0 : sweep;
+}
+
+/**
+ * World distance spanned by one screen pixel at the subject's depth, so a drag
+ * lags the body by the distance it actually travelled rather than by a
+ * resolution- or zoom-dependent guess.
+ */
+export function worldPerPixel(
+  distance: number,
+  verticalFovDegrees: number,
+  viewportHeightPixels: number,
+): number {
+  if (!(viewportHeightPixels > 0) || !(distance > 0)) return 0;
+  const halfFov = (verticalFovDegrees * Math.PI) / 360;
+  return (2 * distance * Math.tan(halfFov)) / viewportHeightPixels;
+}
+
+/**
+ * Angle to tip the torso by so its top trails the gesture by `lagDistance`.
+ * Saturates instead of growing without bound, so a long torso and a short one
+ * lean by a comparable amount for the same drag.
+ */
+export function torsoLeanAngle(
+  lagDistance: number,
+  torsoLength: number,
+): number {
+  if (!Number.isFinite(lagDistance) || !(torsoLength > 0)) return 0;
+  return Math.atan(lagDistance / torsoLength);
+}
+
+/**
+ * How the lean is shared out along the torso, top heavy on purpose.
+ *
+ * Rigid props are mounted low, on the chest, and a rig may carry very long
+ * ones. Sharing the lean evenly swung a pair of wings by 21cm, which reads as
+ * the wings being thrown rather than the body moving. Sparing them entirely
+ * is just as wrong, since a body that leans should carry what is strapped to
+ * it. Weighting the top joint leaves the wings a 5cm follow. The spring
+ * response is the same either way: hair hangs off the head and the chest
+ * chain off the upper chest, both above every joint here.
+ */
+export const TORSO_LEAN_WEIGHTS: readonly (readonly [string, number])[] = [
+  ['upperChest', 0.85],
+  ['chest', 0.1],
+  ['spine', 0.05],
+];
+
+/**
+ * Picks the weights for the torso bones a rig actually has and rescales them
+ * to sum to one, so a rig missing the upper chest still leans by the full
+ * angle rather than a fraction of it.
+ */
+export function leanWeightsFor(
+  present: readonly string[],
+): readonly (readonly [string, number])[] {
+  const found = TORSO_LEAN_WEIGHTS.filter(([name]) => present.includes(name));
+  const total = found.reduce((sum, [, weight]) => sum + weight, 0);
+  if (total <= 0) return [];
+  return found.map(([name, weight]) => [name, weight / total] as const);
+}
+
+/**
+ * Records an orbit sweep in radians. Orbiting moves the camera rather than
+ * the character, so on its own it gives the spring bones nothing to react to.
+ * The body answers with a brief twist that unwinds back to zero, which leaves
+ * the character's facing unchanged once it settles.
+ */
+export function queueOrbitRadians(
+  state: DragInertiaState,
+  deltaRadians: number,
+): void {
+  if (!Number.isFinite(deltaRadians)) return;
+  state.pendingYaw += deltaRadians;
+}
+
+export function applyPendingOrbit(
+  state: DragInertiaState,
+  settings: DragInertiaSettings = DEFAULT_DRAG_INERTIA,
+): void {
+  const { pendingYaw } = state;
+  state.pendingYaw = 0;
+  if (pendingYaw === 0) return;
+  state.yaw = clamp(state.yaw - pendingYaw * settings.yawGain, settings.maxYaw);
+}
+
+/**
+ * Applies buffered drag pixels as a lag offset. `worldPerPixel` converts
+ * screen distance to world distance at the model's current depth. Screen Y
+ * grows downward and the camera's up axis grows upward, so the vertical axis
+ * is flipped here rather than at every call site.
+ */
+export function applyPendingDrag(
+  state: DragInertiaState,
+  worldPerPixel: number,
+  settings: DragInertiaSettings = DEFAULT_DRAG_INERTIA,
+): void {
+  const { pendingX, pendingY } = state;
+  state.pendingX = 0;
+  state.pendingY = 0;
+  if (!Number.isFinite(worldPerPixel) || worldPerPixel <= 0) return;
+  if (pendingX === 0 && pendingY === 0) return;
+
+  const lagX = -pendingX * worldPerPixel * settings.gain;
+  const lagY = pendingY * worldPerPixel * settings.gain;
+  state.x = clamp(state.x + lagX, settings.maxOffset);
+  state.y = clamp(state.y + lagY, settings.maxOffset);
+}
+
+const MAX_STEP_SECONDS = 1 / 120;
+const MAX_FRAME_SECONDS = 0.1;
+const REST_EPSILON = 1e-5;
+
+/**
+ * Advances the spring toward rest. Long frames are split into fixed substeps
+ * so a hitch cannot make the explicit integrator blow up.
+ */
+export function advanceDragInertia(
+  state: DragInertiaState,
+  deltaSeconds: number,
+  settings: DragInertiaSettings = DEFAULT_DRAG_INERTIA,
+): void {
+  if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) return;
+  if (isDragInertiaAtRest(state)) return;
+
+  let remaining = Math.min(deltaSeconds, MAX_FRAME_SECONDS);
+  while (remaining > 0) {
+    const step = Math.min(MAX_STEP_SECONDS, remaining);
+    remaining -= step;
+    state.vx += (-settings.stiffness * state.x - settings.damping * state.vx) * step;
+    state.vy += (-settings.stiffness * state.y - settings.damping * state.vy) * step;
+    state.vyaw +=
+      (-settings.stiffness * state.yaw - settings.damping * state.vyaw) * step;
+    state.x += state.vx * step;
+    state.y += state.vy * step;
+    state.yaw += state.vyaw * step;
+  }
+
+  // Snap to exact rest so an idle avatar stops writing to its transform.
+  if (
+    Math.abs(state.x) < REST_EPSILON &&
+    Math.abs(state.y) < REST_EPSILON &&
+    Math.abs(state.yaw) < REST_EPSILON &&
+    Math.abs(state.vx) < REST_EPSILON &&
+    Math.abs(state.vy) < REST_EPSILON &&
+    Math.abs(state.vyaw) < REST_EPSILON
+  ) {
+    state.x = 0;
+    state.y = 0;
+    state.yaw = 0;
+    state.vx = 0;
+    state.vy = 0;
+    state.vyaw = 0;
+  }
+}
+
+export function isDragInertiaAtRest(state: DragInertiaState): boolean {
+  return (
+    state.x === 0 &&
+    state.y === 0 &&
+    state.yaw === 0 &&
+    state.vx === 0 &&
+    state.vy === 0 &&
+    state.vyaw === 0
+  );
+}

--- a/src/hooks/useWindowDrag.ts
+++ b/src/hooks/useWindowDrag.ts
@@ -1,6 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-export function useWindowDrag() {
+/**
+ * @param onDrag Receives each drag step in screen pixels, so the renderer can
+ *   give the character secondary motion the window move itself cannot produce.
+ */
+export function useWindowDrag(onDrag?: (dx: number, dy: number) => void) {
+  const onDragRef = useRef(onDrag);
+  useEffect(() => {
+    onDragRef.current = onDrag;
+  }, [onDrag]);
+
   useEffect(() => {
     const bridge = window.personaBridge;
     if (!bridge) return;
@@ -37,7 +46,10 @@ export function useWindowDrag() {
         stopDragging();
         return;
       }
-      bridge.moveBy(event.screenX - lastX, event.screenY - lastY);
+      const dx = event.screenX - lastX;
+      const dy = event.screenY - lastY;
+      bridge.moveBy(dx, dy);
+      onDragRef.current?.(dx, dy);
       lastX = event.screenX;
       lastY = event.screenY;
       event.stopPropagation();


### PR DESCRIPTION
Closes #38.

The character is completely rigid while you are handling it. Dragging the window with Alt moves the OS window, orbiting moves the camera, and neither displaces the model, so its spring bones see no acceleration and the hair and cloth that swing during an animation sit still during exactly the interaction that invites a physical response.

This turns both gestures into a transient lag and lets the existing `three-vrm` spring simulation answer it. Nothing here simulates hair or cloth. A window drag leans the body opposite the drag, an orbit sweep twists it about the vertical axis, and both settle to exact rest, so no gesture leaves the character moved or turned.

## Why a torso lean rather than moving the model root

A VRM spring may declare a `center` node, and is then blind to any motion of that node. Both conventions I found cancel a root move outright: a center on the scene root, which is what VRoid writes and what `AvatarSample_A` has on all ten of its groups, and a center on the hips.

Measured headlessly across four models, loading each VRM, running the renderer's update order, letting the springs settle, then comparing spring joint travel. Peak displacement in world units:

| model | move the root | lean the torso |
| --- | --- | --- |
| `AvatarSample_A` (shipped here) | 0.0000 | 0.2133 |
| MMD converted model | 0.0000 | 0.8235 |
| second MMD converted model | 0.0000 | 0.6761 |
| same model re exported without spring centers | 0.6904 | 0.6472 |

Leaning the spine registers on every model that has spring bones, because the rotation happens below every plausible center. Detail and method are in #38.

## What the change contains

`src/drag-inertia.ts` is the whole model, written as plain functions over a state record so it is unit tested without a renderer. The render loop owns only the camera and rig plumbing.

The lean is written to the normalized humanoid rig, applied on top of the animated pose each frame. It never accumulates, so returning to rest needs no cleanup and the root transform is untouched.

The lean is shared along the torso top heavy, most of it on the upper chest. Rigid props mount lower, on the chest, and a rig may carry very long ones: sharing it evenly threw a pair of wings 21cm, which reads as the wings being flung rather than the body moving, and the top heavy split leaves them a 5cm follow. Sparing them outright seemed just as wrong, since a body that leans carries what is strapped to it. The spring response lands within one percent either way.

Offsets are held relative to the screen and mapped onto the camera basis, otherwise a sideways drag starts pushing the body along the view direction once you have orbited a quarter turn. Azimuth is read against the orbit target rather than the model, so panning does not register as a rotation, and a sweep too large to be a hand gesture is discarded, since re framing after a character size change snaps the camera to the front and would otherwise fire a spurious twist.

One limitation worth stating: a rotation cannot reproduce a vertical lag, so a purely up and down drag leans less than a sideways one. The horizontal component carries the effect.

## Interface

One optional prop on `SceneProps`, and an optional callback on `useWindowDrag`. Nothing crosses the preload, no new dependency, no change to the MCP surface or the audio path. Happy to reshape the prop if you would rather it arrived some other way.

The feel is fixed constants in `drag-inertia.ts`: gain, stiffness, damping, and the clamps. I left them internal rather than adding a Settings control, since that felt like your call to make.

## Verification

`npm run check` passes: lint, 128 Node tests, 87 renderer tests, the asset contract, the production audit, and the renderer build. Twenty seven of the renderer tests cover this module, including camera jump rejection, that panning reads as no rotation, and that both the lag and the twist return to exact rest.

Verified by hand on macOS only. The window drag path is the shared IPC one, so I do not expect platform specific behaviour, but I have not run it on Linux or Windows.

The recording in #38 shows the drag and the orbit. It predates the top heavy weighting, so the wings in it swing more than they now do; everything else looks the same.

https://github.com/user-attachments/assets/037a3632-9ca1-4fc4-a504-a1428b00c0cd
