### PR TITLE
Stop the drag lean compounding, and let an orbit reach the spring bones

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -109,11 +109,18 @@ The lag is a lean of the torso rather than a move of the model root, because a
 VRM spring may declare a `center` node and is then blind to any motion of that
 node. Both conventions in the wild cancel a root move outright, a center on
 the scene root and a center on the hips, while a rotation below them registers
-on any rig. The lean is written to the normalized humanoid rig, on top of the
-animated pose each frame and without accumulating, and is shared top heavy so
-that rigid props mounted on the chest are not flung about. A rotation cannot
-reproduce a vertical lag, so a purely up-and-down gesture leans less than a
-sideways one.
+on any rig. The lean is written to the normalized humanoid rig on top of the
+animated pose, and is shared top heavy so that rigid props mounted on the chest
+are not flung about. It is taken back off once `vrm.update` has copied it onto
+the render skeleton, because three-vrm never resets the normalized rig and a
+lean left in place is layered on again every frame a clip is not driving that
+joint. A rotation cannot reproduce a vertical lag, so a purely up-and-down
+gesture leans less than a sideways one.
+
+An orbit sweep answers with a sideways swing as well as a twist. The twist
+turns the body about a vertical axis through the spine, and the head the hair
+hangs off sits on that axis, so on its own it barely moves the spring roots at
+all however far it is turned up.
 
 Offsets are relative to the screen and mapped onto the camera basis. Azimuth
 is read against the orbit target rather than the model, so panning does not
@@ -274,10 +281,10 @@ asset safety, and release checksums.
 Vitest covers animation priority and configured animation selection, speech
 signal gating, motion compatibility and variety, transition timing, async
 request replacement, pause debounce, Idle interim handling, one-shot actions,
-scheduler cleanup, and drag inertia including camera-jump rejection and
-return-to-rest. GitHub Actions then compiles and self-tests the native
-helper on its real operating system and builds the renderer on all three
-platforms.
+scheduler cleanup, and drag inertia including camera-jump rejection, the lean
+cap, the direction each channel lags in, and return-to-rest. GitHub Actions
+then compiles and self-tests the native helper on its real operating system
+and builds the renderer on all three platforms.
 
 Headless CI cannot create a real Codex voice call or approve operating-system
 audio permissions. Before a release, manually run the checklist in

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,6 +63,7 @@ Treat signed and notarized artifacts as the production release path.
    - packaged action edit, removal, and reset without changing user uploads;
    - random clip selection for voice-driven and MCP-triggered actions;
    - shortcut, URL protocol, zoom, orbit, and pan;
+   - secondary motion on window drag and orbit, settling back to rest;
    - transparent background and always-on-top behavior; and
    - uninstall.
 

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -43,8 +43,11 @@ function orbitTarget(controls: unknown, fallback: THREE.Vector3): THREE.Vector3 
 }
 
 interface Torso {
-  /** Each joint with its share of the lean; the shares sum to one. */
-  bones: { node: THREE.Object3D; weight: number }[];
+  /**
+   * Each joint with its share of the lean; the shares sum to one. `pose` is the
+   * rotation the animation left, kept so the lean can be taken back off.
+   */
+  bones: { node: THREE.Object3D; weight: number; pose: THREE.Quaternion }[];
   /** Hips-to-head distance at rest, so the lean scales with the model. */
   length: number;
 }
@@ -68,7 +71,7 @@ function readTorso(vrm: {
   );
   const bones = leanWeightsFor(present).flatMap(([name, weight]) => {
     const node = vrm.humanoid.getNormalizedBoneNode(name);
-    return node ? [{ node, weight }] : [];
+    return node ? [{ node, weight, pose: new THREE.Quaternion() }] : [];
   });
   if (bones.length === 0) return null;
   const length = hips
@@ -176,6 +179,7 @@ function AvatarModel({
     updateBlink(delta);
     updateLipSync(delta, audioLevel, speaking || bodySpeaking);
 
+    let leaned: Torso | null = null;
     if (dragInertia) {
       const torso = (torsoRef.current ??= readTorso(vrm));
       const { camera } = state;
@@ -212,6 +216,7 @@ function AvatarModel({
       advanceDragInertia(dragInertia, delta);
 
       if (torso && !isDragInertiaAtRest(dragInertia)) {
+        leaned = torso;
         // The lag is screen-relative, so it rides the camera basis. Held in
         // world axes it would swing along the view direction once the user had
         // orbited a quarter turn, and read as barely moving at all.
@@ -238,7 +243,8 @@ function AvatarModel({
           horizontal > 0 ? torsoLeanAngle(horizontal, torso.length) : 0;
         if (lean !== 0) LEAN_AXIS.divideScalar(horizontal);
 
-        for (const { node, weight } of torso.bones) {
+        for (const { node, weight, pose } of torso.bones) {
+          pose.copy(node.quaternion);
           if (lean !== 0) {
             node.quaternion.premultiply(
               LEAN.setFromAxisAngle(LEAN_AXIS, lean * weight),
@@ -255,6 +261,14 @@ function AvatarModel({
     }
 
     vrm.update(delta);
+
+    // `vrm.update` has copied the lean onto the render skeleton and the springs
+    // have answered it, so it is delivered. Take it back off: three-vrm never
+    // resets the normalized rig, so a lean left in place is layered on again
+    // every frame a clip is not driving that joint.
+    if (leaned) {
+      for (const { node, pose } of leaned.bones) node.quaternion.copy(pose);
+    }
   });
 
   return vrm ? <primitive object={vrm.scene} /> : null;

--- a/src/drag-inertia.test.ts
+++ b/src/drag-inertia.test.ts
@@ -80,6 +80,22 @@ describe('torsoLeanAngle', () => {
     expect(torsoLeanAngle(1e6, 0.6)).toBeLessThan(Math.PI / 2);
   });
 
+  it('caps the angle, so a stubby torso cannot fold the body over', () => {
+    // A rig a tenth the usual height asks for atan(10), most of a right
+    // angle, for a lag that leans an adult torso by a few degrees.
+    expect(torsoLeanAngle(0.25, 0.025)).toBe(DEFAULT_DRAG_INERTIA.maxLean);
+    expect(torsoLeanAngle(-0.25, 0.025)).toBe(-DEFAULT_DRAG_INERTIA.maxLean);
+  });
+
+  it('leaves an adult torso at the largest lag the clamps allow alone', () => {
+    // `maxOffset` bounds each screen axis on its own, so the longest lag the
+    // caller can hand over is a saturated diagonal, not `maxOffset` itself.
+    const worst = DEFAULT_DRAG_INERTIA.maxOffset * Math.SQRT2;
+    const full = torsoLeanAngle(worst, 0.55);
+    expect(full).toBeLessThan(DEFAULT_DRAG_INERTIA.maxLean);
+    expect(full).toBeCloseTo(Math.atan(worst / 0.55));
+  });
+
   it('keeps sign, so the body trails whichever way the drag went', () => {
     expect(torsoLeanAngle(-0.2, 0.6)).toBeCloseTo(-torsoLeanAngle(0.2, 0.6));
   });
@@ -231,11 +247,13 @@ describe('drag inertia', () => {
     expect(Math.abs(state.x)).toBeLessThanOrEqual(DEFAULT_DRAG_INERTIA.maxOffset);
   });
 
-  it('twists opposite an orbit sweep and unwinds to the original facing', () => {
+  it('trails an orbit sweep and unwinds to the original facing', () => {
     const state = createDragInertiaState();
     queueOrbitRadians(state, 0.1);
     applyPendingOrbit(state);
-    expect(state.yaw).toBeCloseTo(-0.1 * DEFAULT_DRAG_INERTIA.yawGain);
+    // A sweep makes the stationary model appear to rotate by the negative of
+    // it, so trailing means turning with the sweep, not against it.
+    expect(state.yaw).toBeCloseTo(0.1 * DEFAULT_DRAG_INERTIA.yawGain);
 
     expect(settle(state)).toBeGreaterThan(0);
     // Facing must return exactly, or orbiting would slowly rotate the model.
@@ -248,14 +266,14 @@ describe('drag inertia', () => {
       queueOrbitRadians(state, 0.5);
       applyPendingOrbit(state);
     }
-    expect(state.yaw).toBeCloseTo(-DEFAULT_DRAG_INERTIA.maxYaw);
+    expect(state.yaw).toBeCloseTo(DEFAULT_DRAG_INERTIA.maxYaw);
   });
 
-  it('holds a visible twist while an orbit gesture is sustained', () => {
+  it('holds a steady twist while an orbit gesture is sustained', () => {
     // A steady drag: about 2 rad/s for a second, at 60fps. The spring eats
     // the lag as fast as the sweep adds it, so this settles at an equilibrium
-    // rather than accumulating. That equilibrium is what has to be visible;
-    // at a low gain it collapsed to a degree or two and read as nothing.
+    // rather than accumulating, and the equilibrium has to be a real angle
+    // rather than collapsing to nothing.
     const state = createDragInertiaState();
     let smallest = Infinity;
     for (let frame = 0; frame < 60; frame += 1) {
@@ -265,6 +283,45 @@ describe('drag inertia', () => {
       if (frame > 10) smallest = Math.min(smallest, Math.abs(state.yaw));
     }
     expect(smallest).toBeGreaterThan(0.1);
+  });
+
+  it('swings the body sideways as well as twisting it, both trailing', () => {
+    // The twist turns the body about a vertical axis through the spine and the
+    // head sits on that axis, so on its own it hardly moves the spring roots
+    // at all. The sideways swing is what the springs actually answer.
+    const state = createDragInertiaState();
+    queueOrbitRadians(state, 0.1);
+    applyPendingOrbit(state);
+    expect(state.x).toBeCloseTo(0.1 * DEFAULT_DRAG_INERTIA.orbitLeanGain);
+    expect(state.y).toBe(0);
+
+    // Same gesture, both routes: dragging right moves the window right and
+    // sweeps the azimuth negative, and the body has to trail the same way for
+    // either. Asserting the magnitude alone would pin whatever sign it has.
+    const swept = createDragInertiaState();
+    queueOrbitRadians(swept, -0.1);
+    applyPendingOrbit(swept);
+    const dragged = createDragInertiaState();
+    queueDragPixels(dragged, 100, 0);
+    applyPendingDrag(dragged, WORLD_PER_PIXEL);
+    expect(Math.sign(swept.x)).toBe(Math.sign(dragged.x));
+    // And the twist has to lag the same gesture, not lead it: the apparent
+    // rotation is the negative of the sweep, so the body turns with the sweep.
+    expect(Math.sign(swept.yaw)).toBe(Math.sign(-0.1));
+
+    expect(settle(state)).toBeGreaterThan(0);
+    // Both channels must return exactly, or orbiting would walk the model.
+    expect(state.x).toBe(0);
+    expect(state.yaw).toBe(0);
+  });
+
+  it('clamps the orbit swing to the same maximum lag as a drag', () => {
+    const state = createDragInertiaState();
+    for (let i = 0; i < 40; i += 1) {
+      queueOrbitRadians(state, 0.5);
+      applyPendingOrbit(state);
+    }
+    expect(state.x).toBeCloseTo(DEFAULT_DRAG_INERTIA.maxOffset);
   });
 
   it('reports rest only when the twist has settled too', () => {

--- a/src/drag-inertia.ts
+++ b/src/drag-inertia.ts
@@ -25,12 +25,23 @@ export interface DragInertiaSettings {
   stiffness: number;
   /** Velocity damping; below 2*sqrt(stiffness) the body overshoots. */
   damping: number;
-  /** Maximum lag in world units, so a fast drag cannot fling the model away. */
+  /**
+   * Maximum lag in world units, clamped per screen axis, so a fast drag cannot
+   * fling the model away. A saturated diagonal lags by `maxOffset * sqrt(2)`.
+   */
   maxOffset: number;
   /** Fraction of an orbit sweep the body twists before catching up. */
   yawGain: number;
   /** Maximum twist in radians. */
   maxYaw: number;
+  /** World units the body swings sideways per radian of orbit sweep. */
+  orbitLeanGain: number;
+  /**
+   * Maximum lean in radians, whatever the lag and however short the torso.
+   * `maxOffset` is a world distance and a torso is not, so the shorter the
+   * torso the steeper the angle the same lag asks for, without limit.
+   */
+  maxLean: number;
 }
 
 export const DEFAULT_DRAG_INERTIA: DragInertiaSettings = {
@@ -40,12 +51,19 @@ export const DEFAULT_DRAG_INERTIA: DragInertiaSettings = {
   maxOffset: 0.25,
   // A sustained gesture settles at roughly
   //   rate * gain * damping / stiffness
-  // because the spring eats the lag as fast as the gesture adds it. Orbiting
-  // sweeps a couple of radians per second at most, an order of magnitude less
-  // than a window drag covers in world units, so the angular gain has to be
-  // correspondingly larger to land in the same visible range.
+  // because the spring eats the lag as fast as the gesture adds it. That is
+  // what sizes both orbit gains: a sweep is a couple of radians per second at
+  // most, an order of magnitude less than a window drag covers in world units.
   yawGain: 1.0,
   maxYaw: 0.3,
+  // Sized so an ordinary orbit swings the body about as far as a solid window
+  // drag does, since that is the response already known to read on screen.
+  orbitLeanGain: 0.18,
+  // Above anything an adult torso is asked for -- the largest lag the clamps
+  // allow is a saturated diagonal, so atan(0.25 * sqrt(2) / 0.55) = 0.57 -- so
+  // this stays a backstop against a rig short enough to be folded rather than
+  // a second knob on the proportions the rest was tuned against.
+  maxLean: 0.6,
 };
 
 export interface DragInertiaState {
@@ -160,14 +178,16 @@ export function worldPerPixel(
 /**
  * Angle to tip the torso by so its top trails the gesture by `lagDistance`.
  * Saturates instead of growing without bound, so a long torso and a short one
- * lean by a comparable amount for the same drag.
+ * lean by a comparable amount for the same drag, and is capped outright at
+ * `maxLean` so a short torso cannot turn a legal lag into a fold in half.
  */
 export function torsoLeanAngle(
   lagDistance: number,
   torsoLength: number,
+  settings: DragInertiaSettings = DEFAULT_DRAG_INERTIA,
 ): number {
   if (!Number.isFinite(lagDistance) || !(torsoLength > 0)) return 0;
-  return Math.atan(lagDistance / torsoLength);
+  return clamp(Math.atan(lagDistance / torsoLength), Math.abs(settings.maxLean));
 }
 
 /**
@@ -204,8 +224,8 @@ export function leanWeightsFor(
 /**
  * Records an orbit sweep in radians. Orbiting moves the camera rather than
  * the character, so on its own it gives the spring bones nothing to react to.
- * The body answers with a brief twist that unwinds back to zero, which leaves
- * the character's facing unchanged once it settles.
+ * The body answers with a brief twist and a sideways swing, both of which
+ * unwind to zero, so a sweep leaves the character neither turned nor moved.
  */
 export function queueOrbitRadians(
   state: DragInertiaState,
@@ -222,7 +242,18 @@ export function applyPendingOrbit(
   const { pendingYaw } = state;
   state.pendingYaw = 0;
   if (pendingYaw === 0) return;
-  state.yaw = clamp(state.yaw - pendingYaw * settings.yawGain, settings.maxYaw);
+  // Sweeping the azimuth by `pendingYaw` makes the stationary model appear to
+  // rotate by the negative of it, so the body trails by turning with the sweep.
+  state.yaw = clamp(state.yaw + pendingYaw * settings.yawGain, settings.maxYaw);
+  // The twist alone barely reaches the springs: it turns the body about a
+  // vertical axis through the spine, and the head -- which the hair hangs off
+  // -- sits on that axis, so at the full `maxYaw` it displaces a hair root by
+  // about a third of what the gentlest window drag displaces the whole head.
+  // Sweeping the view also swings the body sideways, which does move it.
+  state.x = clamp(
+    state.x + pendingYaw * settings.orbitLeanGain,
+    settings.maxOffset,
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes #41.

## The lean compounded and never came off

`Avatar.tsx` layered the lean onto the normalized humanoid rig with
`premultiply` and never took it off. The only thing that removed it was the
`AnimationMixer` overwriting the same joint on the next frame, and three-vrm
never resets that rig — `VRMHumanoidRig.update()` reads each normalized joint,
writes the raw one, and writes nothing back. On any frame where no clip was
driving `spine` / `chest` / `upperChest`, that frame's lean stayed and the next
was layered on top of it, sixty times a second.

Frames where that happens: before the first clip has finished loading, after a
`playback: 'once'` action is stopped, on a clip with no track for a torso joint
(the bundled `.vrma` all have them, a custom animation set need not), and after
a failed load.

The lag itself is clamped, so drag *distance* was never what drove this.
Duration was — a long window move is simply more frames.

The lean is now taken back off in the same frame, once `vrm.update` has copied
it onto the render skeleton and the springs have simulated against it. It is
delivered either way, and correctness no longer rests on an external system
happening to overwrite the joint.

## An orbit could not reach the spring bones

The twist turns the body about a vertical axis through the spine, and the head
the hair hangs off sits on that axis. Measured on a 0.55 m hips-to-head:

| | spring-root travel |
|---|---|
| twist at the full `maxYaw` (17.2°) | head **0 mm**, hair root 24 mm |
| lean 3.3° — the gentlest window drag | head **32 mm** |
| lean 8.7° — a solid window drag | head **83 mm** |

So an orbit at its cap excited the springs less than the weakest window drag.
Raising `yawGain` cannot fix a rotation about the axis the springs sit on, and
past a point it stops reading as inertia and starts reading as the character
deliberately turning to face you — the gain had already been raised once for
this reason, with the existing test noting it "read as nothing" below it.

An orbit sweep now also feeds the lean channel, which puts an ordinary orbit at
77 mm of head travel, alongside the response already known to read on screen.
It rides the same clamps and the same self-restoring write as the drag lean and
settles to exact rest, so a sweep still leaves the character neither turned nor
moved.

## The twist was leading rather than trailing

Only visible once the swing gave the two channels something to disagree about.
A sweep makes the stationary model appear to rotate by the negative of it, so a
body that lags has to turn *with* the sweep; it was turning against it, adding
to the apparent rotation rather than resisting it — opposite to the convention
`applyPendingDrag` already follows. Verified against real `three` projection
rather than by inspection:

```
drag right      -> nose screen x  0.0000 -> 0.1884   (surface sweeps right)
twist yaw=-0.10 -> nose screen x  0.1884 -> 0.0000   (pulls back: trails)
swing x =-0.018 -> torso tips screen-left             (trails)
```

The tests now pin the *direction* of both channels, not only their size, which
is what let the sign sit there unnoticed.

## Also

- `maxLean` caps the lean angle. `maxOffset` is a world distance and a torso is
  not, so the shorter the torso the steeper the angle the same lag asks for,
  without limit. Sized off the largest lag the clamps can produce — `maxOffset`
  bounds each screen axis separately, so a saturated diagonal is
  `maxOffset * sqrt(2)` — which keeps it a backstop against a rig short enough
  to be folded rather than a second knob on the usual proportions.
- Two comments that had gone stale are corrected rather than left: the `yawGain`
  note claiming the angular gain was sized to be visible, and the test comment
  resting on the same claim.
- The release smoke-test list gains a line for secondary motion. This bug
  shipped, and a pass over the checklist would have caught it.

## Testing

`npm test` (91 passing), `tsc --noEmit`, and `eslint src/` are clean. Both
gestures were exercised by hand on Windows 11: a long Alt+drag no longer skews
the model and settles back to rest, and an orbit now visibly moves the hair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
