### PR TITLE
feat: desktop-pet click-through and in-renderer lip-sync (mic + system audio)

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -96,6 +96,12 @@ let hyprlandConfigurationTimer = null;
 let hyprlandLastPosition = null;
 let hyprlandConfigurationGeneration = 0;
 let rendererLoadHookAttached = false;
+// Overlay interaction modes. Click-through lets the frameless transparent
+// window float over the desktop while the renderer momentarily re-enables input
+// over the character silhouette. Microphone lip-sync is an in-renderer Web
+// Audio fallback that drives the avatar without the native audio helper.
+let clickThroughEnabled = true;
+let microphoneLipSyncEnabled = false;
 let animationCommandRequestId = 0;
 let modelConfigured = false;
 let mcpServerError = null;
@@ -215,6 +221,7 @@ function showOverlay({ focus = false } = {}) {
   } else if (!window.isVisible()) {
     window.showInactive();
   }
+  emitOverlayModes();
   scheduleHyprlandWindowConfiguration();
 }
 
@@ -312,6 +319,11 @@ function createWindow() {
   window.setAlwaysOnTop(true, "floating");
   window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
   window.setOpacity(1);
+  // Start click-through so the transparent, always-on-top window never blocks
+  // the desktop beneath it before the renderer's silhouette hit-test loads.
+  // { forward: true } keeps mousemove flowing to the renderer so it can detect
+  // the cursor over the character and re-enable input for that region.
+  window.setIgnoreMouseEvents(clickThroughEnabled, { forward: true });
   window.once("ready-to-show", () => {
     if (window.isDestroyed()) return;
     positionWindow(window);
@@ -713,6 +725,43 @@ function emitToRenderer(event) {
   pendingRendererEvents.delete(event.type);
 }
 
+// Mode events tell the renderer how to behave rather than what the voice is
+// doing, so they are queued and flushed like other renderer events but never
+// become the get-snapshot "last event" that App reads for the initial voice
+// state.
+function sendOverlayMode(event) {
+  pendingRendererEvents.set(event.type, event);
+  if (!avatarWindow || avatarWindow.isDestroyed()) return;
+  if (avatarWindow.webContents.isLoading()) {
+    ensureRendererLoadHook();
+    return;
+  }
+  avatarWindow.webContents.send("persona:event", event);
+  pendingRendererEvents.delete(event.type);
+}
+
+function emitOverlayModes() {
+  sendOverlayMode({ type: "click-through", enabled: clickThroughEnabled });
+  sendOverlayMode({ type: "mic-lip-sync", enabled: microphoneLipSyncEnabled });
+}
+
+function setClickThroughEnabled(enabled) {
+  clickThroughEnabled = enabled;
+  if (avatarWindow && !avatarWindow.isDestroyed() && !enabled) {
+    // Locking to interactive: stop ignoring immediately rather than waiting for
+    // the renderer's next hit-test, so the whole window is clickable at once.
+    avatarWindow.setIgnoreMouseEvents(false);
+  }
+  sendOverlayMode({ type: "click-through", enabled });
+  refreshTrayMenu();
+}
+
+function setMicrophoneLipSyncEnabled(enabled) {
+  microphoneLipSyncEnabled = enabled;
+  sendOverlayMode({ type: "mic-lip-sync", enabled });
+  refreshTrayMenu();
+}
+
 function handleBridgeEvent(event) {
   if (event.type !== "audio-level" || event.level > 0.025) debugLog("event", event);
   const canShowAvatar = hasConfiguredModel();
@@ -813,6 +862,19 @@ function refreshTrayMenu() {
         {
           label: "Preview speaking",
           click: () => handleBridgeEvent(voiceState("speaking")),
+        },
+        { type: "separator" },
+        {
+          label: "Click-through (float over windows)",
+          type: "checkbox",
+          checked: clickThroughEnabled,
+          click: (item) => setClickThroughEnabled(item.checked),
+        },
+        {
+          label: "Microphone lip-sync",
+          type: "checkbox",
+          checked: microphoneLipSyncEnabled,
+          click: (item) => setMicrophoneLipSyncEnabled(item.checked),
         },
         { type: "separator" },
         quitItem,
@@ -1233,6 +1295,16 @@ if (!app.requestSingleInstanceLock()) {
         Math.round(bounds.x + dx),
         Math.round(bounds.y + dy),
       );
+    });
+    // The renderer owns the fine-grained click-through decision: it forwards a
+    // hit-test result as the cursor crosses the character silhouette. Only the
+    // avatar window may drive it, and only with a boolean.
+    ipcMain.on("persona:set-mouse-passthrough", (event, ignore) => {
+      if (!avatarWindow || avatarWindow.isDestroyed()) return;
+      if (event.sender !== avatarWindow.webContents) return;
+      if (typeof ignore !== "boolean") return;
+      if (!clickThroughEnabled) return;
+      avatarWindow.setIgnoreMouseEvents(ignore, { forward: true });
     });
     // The resolved theme lives in renderer storage, so the window chrome can
     // only be corrected once the settings renderer reports it. Accepts the two

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -5,6 +5,7 @@ const { pathToFileURL } = require("node:url");
 const {
   app,
   BrowserWindow,
+  desktopCapturer,
   dialog,
   globalShortcut,
   ipcMain,
@@ -15,6 +16,7 @@ const {
   protocol,
   safeStorage,
   screen,
+  session,
   shell,
   Tray,
 } = require("electron");
@@ -98,10 +100,12 @@ let hyprlandConfigurationGeneration = 0;
 let rendererLoadHookAttached = false;
 // Overlay interaction modes. Click-through lets the frameless transparent
 // window float over the desktop while the renderer momentarily re-enables input
-// over the character silhouette. Microphone lip-sync is an in-renderer Web
-// Audio fallback that drives the avatar without the native audio helper.
+// over the character silhouette. The lip-sync source is an in-renderer Web
+// Audio fallback that drives the avatar without the native audio helper:
+// "microphone" reacts to your voice, "system" to desktop/app output audio.
+const LIP_SYNC_SOURCES = new Set(["off", "microphone", "system"]);
 let clickThroughEnabled = true;
-let microphoneLipSyncEnabled = false;
+let lipSyncSource = "off";
 let animationCommandRequestId = 0;
 let modelConfigured = false;
 let mcpServerError = null;
@@ -742,7 +746,7 @@ function sendOverlayMode(event) {
 
 function emitOverlayModes() {
   sendOverlayMode({ type: "click-through", enabled: clickThroughEnabled });
-  sendOverlayMode({ type: "mic-lip-sync", enabled: microphoneLipSyncEnabled });
+  sendOverlayMode({ type: "lip-sync-source", source: lipSyncSource });
 }
 
 function setClickThroughEnabled(enabled) {
@@ -756,9 +760,10 @@ function setClickThroughEnabled(enabled) {
   refreshTrayMenu();
 }
 
-function setMicrophoneLipSyncEnabled(enabled) {
-  microphoneLipSyncEnabled = enabled;
-  sendOverlayMode({ type: "mic-lip-sync", enabled });
+function setLipSyncSource(source) {
+  if (!LIP_SYNC_SOURCES.has(source)) return;
+  lipSyncSource = source;
+  sendOverlayMode({ type: "lip-sync-source", source });
   refreshTrayMenu();
 }
 
@@ -871,10 +876,27 @@ function refreshTrayMenu() {
           click: (item) => setClickThroughEnabled(item.checked),
         },
         {
-          label: "Microphone lip-sync",
-          type: "checkbox",
-          checked: microphoneLipSyncEnabled,
-          click: (item) => setMicrophoneLipSyncEnabled(item.checked),
+          label: "Lip-sync source",
+          submenu: [
+            {
+              label: "Off",
+              type: "radio",
+              checked: lipSyncSource === "off",
+              click: () => setLipSyncSource("off"),
+            },
+            {
+              label: "Microphone (your voice)",
+              type: "radio",
+              checked: lipSyncSource === "microphone",
+              click: () => setLipSyncSource("microphone"),
+            },
+            {
+              label: "System / app audio (assistant output)",
+              type: "radio",
+              checked: lipSyncSource === "system",
+              click: () => setLipSyncSource("system"),
+            },
+          ],
         },
         { type: "separator" },
         quitItem,
@@ -1357,6 +1379,27 @@ if (!app.requestSingleInstanceLock()) {
       );
       bridge = null;
     }
+
+    // System/app-output lip-sync captures desktop audio inside Chromium via
+    // getDisplayMedia, so it needs no spawned helper. The renderer only wants
+    // the loopback audio track; a screen source is supplied because the capture
+    // API still requires a video source, and the renderer drops that track at
+    // once. Selection is automatic so no picker interrupts the desktop pet.
+    session.defaultSession.setDisplayMediaRequestHandler(
+      (_request, callback) => {
+        desktopCapturer
+          .getSources({ types: ["screen"] })
+          .then((sources) => {
+            if (sources.length === 0) {
+              callback({});
+              return;
+            }
+            callback({ video: sources[0], audio: "loopback" });
+          })
+          .catch(() => callback({}));
+      },
+      { useSystemPicker: false },
+    );
 
     createTray();
     globalShortcut.register("CommandOrControl+Shift+A", toggleOverlay);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -6,6 +6,8 @@ contextBridge.exposeInMainWorld("personaBridge", {
   getSnapshot: () => ipcRenderer.invoke("persona:get-snapshot"),
   hide: () => ipcRenderer.send("persona:hide"),
   moveBy: (dx, dy) => ipcRenderer.send("persona:move-by", dx, dy),
+  setMousePassthrough: (ignore) =>
+    ipcRenderer.send("persona:set-mouse-passthrough", ignore),
   subscribe: (listener) => {
     const handler = (_event, payload) => listener(payload);
     ipcRenderer.on("persona:event", handler);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import {
   SETTINGS_FALLBACK,
 } from './settings-defaults';
 import { useWindowDrag } from './hooks/useWindowDrag';
-import { useMicrophoneLevel } from './hooks/useMicrophoneLevel';
+import { useCaptureLevel } from './hooks/useCaptureLevel';
 import { createDragInertiaState, queueDragPixels } from './drag-inertia';
 import {
   BODY_SPEECH_LEVEL_THRESHOLD,
@@ -48,7 +48,7 @@ export function App() {
   const [audioLevel, setAudioLevel] = useState(0);
   const [hasObservedAudioLevel, setHasObservedAudioLevel] = useState(false);
   const [clickThrough, setClickThrough] = useState(true);
-  const [micLipSync, setMicLipSync] = useState(false);
+  const [lipSyncSource, setLipSyncSource] = useState<LipSyncSource>('off');
   const [voiceAnimation, setVoiceAnimation] = useState<AnimationType>('IDLE');
   const [bodyOverride, setBodyOverride] =
     useState<BodyAnimationOverride | null>(null);
@@ -89,8 +89,8 @@ export function App() {
         }
       } else if (event.type === 'click-through') {
         setClickThrough(event.enabled);
-      } else if (event.type === 'mic-lip-sync') {
-        setMicLipSync(event.enabled);
+      } else if (event.type === 'lip-sync-source') {
+        setLipSyncSource(event.source);
       }
     });
   }, []);
@@ -105,19 +105,20 @@ export function App() {
     return settingsBridge.subscribe(setSettings);
   }, []);
 
-  // Microphone lip-sync runs in the renderer, so it drives the avatar without
+  // In-renderer lip-sync (microphone or system audio) drives the avatar without
   // the native audio helper. Its level joins the bridge level (only one is ever
   // active on a given machine) and marks the signal observed so the scheduler
   // treats it like any other live output level.
-  const micLevel = useMicrophoneLevel(micLipSync);
-  const effectiveAudioLevel = Math.max(audioLevel, micLevel);
+  const captureLevel = useCaptureLevel(lipSyncSource);
+  const captureActive = lipSyncSource !== 'off';
+  const effectiveAudioLevel = Math.max(audioLevel, captureLevel);
   const effectiveAudioObserved =
-    hasObservedAudioLevel || (micLipSync && micLevel > 0);
+    hasObservedAudioLevel || (captureActive && captureLevel > 0);
   useEffect(() => {
-    if (micLipSync && micLevel > BODY_SPEECH_LEVEL_THRESHOLD) {
+    if (captureActive && captureLevel > BODY_SPEECH_LEVEL_THRESHOLD) {
       setVoiceAnimation('TALK');
     }
-  }, [micLipSync, micLevel]);
+  }, [captureActive, captureLevel]);
 
   const speaking =
     voice.phase === 'active' &&

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
   SETTINGS_FALLBACK,
 } from './settings-defaults';
 import { useWindowDrag } from './hooks/useWindowDrag';
+import { useMicrophoneLevel } from './hooks/useMicrophoneLevel';
 import { createDragInertiaState, queueDragPixels } from './drag-inertia';
 import {
   BODY_SPEECH_LEVEL_THRESHOLD,
@@ -46,6 +47,8 @@ export function App() {
   const [voice, setVoice] = useState<VoiceState>(INITIAL_STATE);
   const [audioLevel, setAudioLevel] = useState(0);
   const [hasObservedAudioLevel, setHasObservedAudioLevel] = useState(false);
+  const [clickThrough, setClickThrough] = useState(true);
+  const [micLipSync, setMicLipSync] = useState(false);
   const [voiceAnimation, setVoiceAnimation] = useState<AnimationType>('IDLE');
   const [bodyOverride, setBodyOverride] =
     useState<BodyAnimationOverride | null>(null);
@@ -84,6 +87,10 @@ export function App() {
         } else if (event.animation !== 'CUSTOM') {
           setVoiceAnimation(event.animation);
         }
+      } else if (event.type === 'click-through') {
+        setClickThrough(event.enabled);
+      } else if (event.type === 'mic-lip-sync') {
+        setMicLipSync(event.enabled);
       }
     });
   }, []);
@@ -98,13 +105,27 @@ export function App() {
     return settingsBridge.subscribe(setSettings);
   }, []);
 
+  // Microphone lip-sync runs in the renderer, so it drives the avatar without
+  // the native audio helper. Its level joins the bridge level (only one is ever
+  // active on a given machine) and marks the signal observed so the scheduler
+  // treats it like any other live output level.
+  const micLevel = useMicrophoneLevel(micLipSync);
+  const effectiveAudioLevel = Math.max(audioLevel, micLevel);
+  const effectiveAudioObserved =
+    hasObservedAudioLevel || (micLipSync && micLevel > 0);
+  useEffect(() => {
+    if (micLipSync && micLevel > BODY_SPEECH_LEVEL_THRESHOLD) {
+      setVoiceAnimation('TALK');
+    }
+  }, [micLipSync, micLevel]);
+
   const speaking =
     voice.phase === 'active' &&
     voice.activity === 'speaking' &&
     !voice.outputMuted;
   const bodySpeaking = bodySpeechSignalActive({
-    audioLevel,
-    audioLevelObserved: hasObservedAudioLevel,
+    audioLevel: effectiveAudioLevel,
+    audioLevelObserved: effectiveAudioObserved,
     voiceSpeaking: speaking,
   });
   useEffect(() => {
@@ -155,9 +176,10 @@ export function App() {
         animationUrls={animationUrls}
         fallbackAnimationUrls={idleAnimationUrls}
         preloadAnimationUrls={preloadAnimationUrls}
-        audioLevel={audioLevel}
+        audioLevel={effectiveAudioLevel}
         bodySpeaking={bodySpeaking}
         characterSize={settings.character_size}
+        clickThrough={clickThrough}
         dragInertia={dragInertia}
         lighting={settings.model_lighting[defaultModel.id]}
         modelUrl={defaultModel.asset_url}

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import {
   ContactShadows,
@@ -35,6 +35,7 @@ interface SceneProps {
   speakingDebounceMs: number;
   idleInterimMs: number;
   speakingTransition: PersonaSpeakingTransitionSettings;
+  clickThrough?: boolean;
 }
 
 interface TargetControls {
@@ -142,6 +143,104 @@ function FullBodyCamera({
   return null;
 }
 
+/**
+ * Drives the avatar window's click-through so it floats over the desktop like a
+ * desktop pet: the window ignores the mouse everywhere except over the
+ * character. While the window is ignoring input, Electron still forwards
+ * mousemove (setIgnoreMouseEvents(true, { forward: true })), so this raycasts
+ * the cursor against the character silhouette each move and re-enables input
+ * only while the cursor is over an actual mesh — transparent gaps stay
+ * click-through. A held button never flips to passthrough mid-orbit/drag.
+ */
+function PassthroughController({
+  enabled,
+  object,
+}: {
+  enabled: boolean;
+  object: THREE.Object3D | null;
+}) {
+  const camera = useThree((state) => state.camera);
+  const gl = useThree((state) => state.gl);
+
+  useEffect(() => {
+    const bridge = window.personaBridge;
+    if (!bridge?.setMousePassthrough) return;
+
+    if (!enabled) {
+      // Locked to interactive: the whole window takes the mouse.
+      bridge.setMousePassthrough(false);
+      return;
+    }
+
+    const canvas = gl.domElement;
+    const raycaster = new THREE.Raycaster();
+    const ndc = new THREE.Vector2();
+    let passthrough = true;
+    let buttonDown = false;
+    let clientX = 0;
+    let clientY = 0;
+    let frame = 0;
+    let scheduled = false;
+
+    const apply = (next: boolean) => {
+      if (next === passthrough) return;
+      passthrough = next;
+      bridge.setMousePassthrough(next);
+    };
+
+    const hitTest = () => {
+      scheduled = false;
+      if (buttonDown) {
+        apply(false);
+        return;
+      }
+      if (!object) {
+        apply(true);
+        return;
+      }
+      const rect = canvas.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+      ndc.x = ((clientX - rect.left) / rect.width) * 2 - 1;
+      ndc.y = -((clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(ndc, camera);
+      apply(raycaster.intersectObject(object, true).length === 0);
+    };
+
+    const onMove = (event: MouseEvent) => {
+      clientX = event.clientX;
+      clientY = event.clientY;
+      if (!scheduled) {
+        scheduled = true;
+        frame = requestAnimationFrame(hitTest);
+      }
+    };
+    const onDown = () => {
+      buttonDown = true;
+      apply(false);
+    };
+    const onUp = () => {
+      buttonDown = false;
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mousedown', onDown, { capture: true });
+    window.addEventListener('mouseup', onUp, { capture: true });
+    // Match the window's initial ignoring state set by the main process.
+    bridge.setMousePassthrough(true);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mousedown', onDown, { capture: true });
+      window.removeEventListener('mouseup', onUp, { capture: true });
+      // Leave the window interactive so a later mount is never stuck ignoring.
+      bridge.setMousePassthrough(false);
+    };
+  }, [camera, enabled, gl, object]);
+
+  return null;
+}
+
 export function Scene(props: SceneProps) {
   const lighting = resolveLightingSettings(props.lighting);
   const [avatarScene, setAvatarScene] = useState<THREE.Object3D | null>(null);
@@ -201,6 +300,10 @@ export function Scene(props: SceneProps) {
         object={avatarScene}
       />
       <Avatar {...props} onReady={handleAvatarReady} />
+      <PassthroughController
+        enabled={props.clickThrough ?? true}
+        object={avatarScene}
+      />
       {props.groundShadow && grounding && (
         <ContactShadows
           blur={2.4}

--- a/src/hooks/useCaptureLevel.ts
+++ b/src/hooks/useCaptureLevel.ts
@@ -1,28 +1,50 @@
 import { useEffect, useRef, useState } from 'react';
 
-// RMS below this is treated as room noise and clamped to silence; the span above
-// it maps onto 0..1. Tuned for ordinary speech into a laptop microphone.
+// RMS below this is treated as noise and clamped to silence; the span above it
+// maps onto 0..1. Tuned for ordinary speech through a laptop mic or loopback.
 const NOISE_FLOOR = 0.01;
 const LEVEL_SPAN = 0.2;
 
+async function acquireStream(
+  source: Exclude<LipSyncSource, 'off'>,
+): Promise<MediaStream | null> {
+  const media = navigator.mediaDevices;
+  try {
+    if (source === 'microphone') {
+      if (!media?.getUserMedia) return null;
+      return await media.getUserMedia({ audio: true, video: false });
+    }
+    if (!media?.getDisplayMedia) return null;
+    // The capture API still requires a video source; the main process supplies
+    // a screen source for loopback audio and we keep only the audio track.
+    const stream = await media.getDisplayMedia({ audio: true, video: true });
+    stream.getVideoTracks().forEach((track) => track.stop());
+    return stream;
+  } catch {
+    // Permission denied, no device, or capture blocked: stay silent.
+    return null;
+  }
+}
+
 /**
- * In-renderer microphone lip-sync source. Runs entirely inside Chromium's Web
- * Audio API, so it needs no native helper process — a way to animate the avatar
- * on machines where the packaged audio listener cannot be spawned. Returns a
- * normalized 0..1 level, or a steady 0 while disabled or permission is denied.
+ * In-renderer lip-sync level meter. Runs entirely inside Chromium's Web Audio
+ * API, so it needs no native helper process — a way to animate the avatar on
+ * machines where the packaged audio listener cannot be spawned. "microphone"
+ * reacts to your voice; "system" reacts to desktop/app output (for example a
+ * voice assistant's speech). Returns a normalized 0..1 level, or a steady 0
+ * while off or when capture is unavailable.
  */
-export function useMicrophoneLevel(enabled: boolean): number {
+export function useCaptureLevel(source: LipSyncSource): number {
   const [level, setLevel] = useState(0);
   // Read inside the animation frame without re-subscribing the effect.
   const levelRef = useRef(0);
 
   useEffect(() => {
-    if (!enabled) {
+    if (source === 'off') {
       setLevel(0);
       levelRef.current = 0;
       return;
     }
-    if (!navigator.mediaDevices?.getUserMedia) return;
 
     let cancelled = false;
     let stream: MediaStream | null = null;
@@ -30,27 +52,19 @@ export function useMicrophoneLevel(enabled: boolean): number {
     let frame = 0;
 
     const start = async () => {
-      let captured: MediaStream;
-      try {
-        captured = await navigator.mediaDevices.getUserMedia({
-          audio: true,
-          video: false,
-        });
-      } catch {
-        // Permission denied or no input device: stay silent rather than throw.
-        return;
-      }
-      if (cancelled) {
+      const captured = await acquireStream(source);
+      if (!captured) return;
+      if (cancelled || captured.getAudioTracks().length === 0) {
         captured.getTracks().forEach((track) => track.stop());
         return;
       }
       stream = captured;
       audioContext = new AudioContext();
-      const source = audioContext.createMediaStreamSource(stream);
+      const analyserSource = audioContext.createMediaStreamSource(stream);
       const analyser = audioContext.createAnalyser();
       analyser.fftSize = 1024;
       analyser.smoothingTimeConstant = 0.6;
-      source.connect(analyser);
+      analyserSource.connect(analyser);
       const samples = new Float32Array(analyser.fftSize);
 
       const tick = () => {
@@ -78,7 +92,7 @@ export function useMicrophoneLevel(enabled: boolean): number {
       setLevel(0);
       levelRef.current = 0;
     };
-  }, [enabled]);
+  }, [source]);
 
   return level;
 }

--- a/src/hooks/useMicrophoneLevel.ts
+++ b/src/hooks/useMicrophoneLevel.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from 'react';
+
+// RMS below this is treated as room noise and clamped to silence; the span above
+// it maps onto 0..1. Tuned for ordinary speech into a laptop microphone.
+const NOISE_FLOOR = 0.01;
+const LEVEL_SPAN = 0.2;
+
+/**
+ * In-renderer microphone lip-sync source. Runs entirely inside Chromium's Web
+ * Audio API, so it needs no native helper process — a way to animate the avatar
+ * on machines where the packaged audio listener cannot be spawned. Returns a
+ * normalized 0..1 level, or a steady 0 while disabled or permission is denied.
+ */
+export function useMicrophoneLevel(enabled: boolean): number {
+  const [level, setLevel] = useState(0);
+  // Read inside the animation frame without re-subscribing the effect.
+  const levelRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLevel(0);
+      levelRef.current = 0;
+      return;
+    }
+    if (!navigator.mediaDevices?.getUserMedia) return;
+
+    let cancelled = false;
+    let stream: MediaStream | null = null;
+    let audioContext: AudioContext | null = null;
+    let frame = 0;
+
+    const start = async () => {
+      let captured: MediaStream;
+      try {
+        captured = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+          video: false,
+        });
+      } catch {
+        // Permission denied or no input device: stay silent rather than throw.
+        return;
+      }
+      if (cancelled) {
+        captured.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      stream = captured;
+      audioContext = new AudioContext();
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 1024;
+      analyser.smoothingTimeConstant = 0.6;
+      source.connect(analyser);
+      const samples = new Float32Array(analyser.fftSize);
+
+      const tick = () => {
+        analyser.getFloatTimeDomainData(samples);
+        let sum = 0;
+        for (let i = 0; i < samples.length; i += 1) sum += samples[i] * samples[i];
+        const rms = Math.sqrt(sum / samples.length);
+        const normalized = Math.min(1, Math.max(0, (rms - NOISE_FLOOR) / LEVEL_SPAN));
+        // Only re-render on a meaningful change to avoid a 60fps setState storm.
+        if (Math.abs(normalized - levelRef.current) > 0.01) {
+          levelRef.current = normalized;
+          setLevel(normalized);
+        }
+        frame = requestAnimationFrame(tick);
+      };
+      tick();
+    };
+    void start();
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+      if (stream) stream.getTracks().forEach((track) => track.stop());
+      if (audioContext) void audioContext.close();
+      setLevel(0);
+      levelRef.current = 0;
+    };
+  }, [enabled]);
+
+  return level;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -211,13 +211,16 @@ type AvatarBridgeEvent =
       requestId?: number;
     }
   | { type: 'listener-status'; status: AudioListenerStatus }
-  | { type: 'bridge-status'; connected: boolean };
+  | { type: 'bridge-status'; connected: boolean }
+  | { type: 'click-through'; enabled: boolean }
+  | { type: 'mic-lip-sync'; enabled: boolean };
 
 interface Window {
   personaBridge?: {
     getSnapshot(): Promise<AvatarBridgeEvent | null>;
     hide(): void;
     moveBy(dx: number, dy: number): void;
+    setMousePassthrough(ignore: boolean): void;
     subscribe(listener: (event: AvatarBridgeEvent) => void): () => void;
   };
   personaSettings?: {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -199,6 +199,8 @@ interface PersonaVroidHubCharacter {
   license: PersonaVroidHubCharacterLicense | null;
 }
 
+type LipSyncSource = 'off' | 'microphone' | 'system';
+
 type AvatarBridgeEvent =
   | { type: 'state'; state: VoiceState }
   | { type: 'audio-level'; level: number; bands?: Record<string, number> }
@@ -213,7 +215,7 @@ type AvatarBridgeEvent =
   | { type: 'listener-status'; status: AudioListenerStatus }
   | { type: 'bridge-status'; connected: boolean }
   | { type: 'click-through'; enabled: boolean }
-  | { type: 'mic-lip-sync'; enabled: boolean };
+  | { type: 'lip-sync-source'; source: LipSyncSource };
 
 interface Window {
   personaBridge?: {


### PR DESCRIPTION
## Summary

Two additions that let Persona run as a free-floating desktop pet and animate on machines where the native audio helper cannot be spawned.

### 1. Desktop-pet click-through
The transparent, always-on-top avatar window now floats over the desktop without blocking it. The window starts with `setIgnoreMouseEvents(true, { forward: true })`; a renderer `PassthroughController` raycasts the cursor against the character silhouette on each move and re-enables input only while the cursor is over a mesh — transparent gaps stay click-through. A held button never flips to passthrough mid-orbit/drag. Toggle from the tray ("Click-through").

### 2. In-renderer lip-sync (microphone or system audio)
A Web Audio fallback that drives the avatar without the native listener, selectable from a tray submenu (Off / Microphone / System audio):
- **Microphone** — `getUserMedia`, reacts to your voice.
- **System / app audio** — `getDisplayMedia` with a main-process `setDisplayMediaRequestHandler` that auto-selects a screen source with `audio: 'loopback'` (no picker); the renderer keeps only the audio track. Reacts to a voice assistant's output.

Both run entirely inside Chromium (no spawned helper) and feed the existing `audio-level` pipeline.

## Testing
- `npm run lint` — clean
- `npm run build` — clean (tsc + vite)
- `npm test` — node 128/128, renderer 91/91
- Launched from source on Windows: character loads, app starts cleanly.

## Notes
- New IPC `persona:set-mouse-passthrough`; new renderer events `click-through` and `lip-sync-source`.
- No changes to packaged catalogs or assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)