### PR TITLE
Keep the VRoid Hub session through a transient refresh failure

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -277,7 +277,8 @@ discovery and tool calls, the bridge boundary, URL protocol, Hyprland rules,
 PipeWire selection and PCM normalization, process discovery on macOS and
 Windows, native NDJSON parsing, shared pause smoothing, listener lifecycle,
 asset safety, release checksums, and VRoid Hub OAuth — including which refresh
-failures are allowed to discard the saved session and which must preserve it.
+failures are allowed to discard the saved session and which must preserve it,
+and the forced refresh that tells a revoked authorization apart from an outage.
 
 Vitest covers animation priority and configured animation selection, speech
 signal gating, motion compatibility and variety, transition timing, async

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -276,7 +276,8 @@ The Node suite covers settings persistence and imported-media boundaries, MCP
 discovery and tool calls, the bridge boundary, URL protocol, Hyprland rules,
 PipeWire selection and PCM normalization, process discovery on macOS and
 Windows, native NDJSON parsing, shared pause smoothing, listener lifecycle,
-asset safety, and release checksums.
+asset safety, release checksums, and VRoid Hub OAuth — including which refresh
+failures are allowed to discard the saved session and which must preserve it.
 
 Vitest covers animation priority and configured animation selection, speech
 signal gating, motion compatibility and variety, transition timing, async

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -234,3 +234,15 @@ Selecting one fetches its VRM bytes through VRoid Hub's licensed
 `download_licenses` flow and holds them in memory for the running session —
 Persona does not write a hub-sourced model to disk as an ordinary, freely
 reusable local file, and it disappears on the next launch until reselected.
+
+The connection then stays signed in on its own. VRoid Hub's access tokens last
+about an hour, so Persona trades its stored refresh token for a new one
+whenever you use the picker with a stale one — there is no background activity
+between launches, and closing Persona changes nothing. You are only asked to
+reconnect when the authorization itself is gone: you revoked Persona from your
+VRoid Hub account, or you replaced the OAuth app credentials in Settings.
+VRoid Hub being unreachable — an outage, rate limiting — fails the action you
+were taking and says so, but leaves the connection intact, so retrying once
+it recovers costs nothing. Revoking from
+[`hub.vroid.com`](https://hub.vroid.com) takes effect on the next action rather
+than immediately, since Persona only learns about it by being turned away.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -541,14 +541,34 @@ function broadcastVroidHubStatus() {
 // getValidAccessToken drops the saved session when VRoid Hub rejects it, so
 // the Settings page has to be told or it keeps offering a connected account
 // that no longer exists.
-async function vroidHubAccessToken() {
+async function vroidHubAccessToken(options) {
   if (!vroidHubAuth?.isConnected()) {
     throw new Error("Connect your VRoid Hub account first.");
   }
   try {
-    return await vroidHubAuth.getValidAccessToken();
+    return await vroidHubAuth.getValidAccessToken(options);
   } finally {
     if (!vroidHubAuth?.isConnected()) broadcastVroidHubStatus();
+  }
+}
+
+// Runs an API call with the current access token, and on a 401 runs it once
+// more behind a forced refresh.
+//
+// Revoking Persona on hub.vroid.com invalidates the access token immediately,
+// but nothing tells the app: expires_at still looks fine, so no refresh is due
+// and every call just answers 401. Forcing the refresh puts the question to
+// the token endpoint, which is the only authority on whether the whole
+// authorization is gone — it answers invalid_grant, the session is cleared,
+// and the user finally gets "reconnect your account" instead of a bare 401.
+// Deciding that from the API's 401 alone would be the mistake this path exists
+// to avoid: destroying credentials on the say-so of one resource-server reply.
+async function withVroidHubAuthRetry(call) {
+  try {
+    return await call(await vroidHubAccessToken());
+  } catch (error) {
+    if (error?.status !== 401) throw error;
+    return call(await vroidHubAccessToken({ forceRefresh: true }));
   }
 }
 
@@ -1157,8 +1177,9 @@ if (!app.requestSingleInstanceLock()) {
       return vroidHubStatus();
     });
     handleFromSettings("persona:vroid-list-characters", async () => {
-      const token = await vroidHubAccessToken();
-      return vroidHubClient.listCharacters(token);
+      return withVroidHubAuthRetry((token) =>
+        vroidHubClient.listCharacters(token),
+      );
     });
     // Portraits load one card at a time after the list renders, so a slow or
     // unreachable image CDN delays a thumbnail rather than the whole picker.
@@ -1177,14 +1198,14 @@ if (!app.requestSingleInstanceLock()) {
     handleFromSettings(
       "persona:vroid-select-character",
       async (characterId, characterName) => {
-        const token = await vroidHubAccessToken();
         // No re-fetch of the character list to check characterId is in it:
         // that's not a real gate anyway, since /api/download_licenses below
         // is VRoid Hub's own authority on whether this id is licensable, and
         // the renderer already has this id from the list it just rendered.
-        const buffer = await vroidHubClient.loadCharacterModel(
-          token,
-          characterId,
+        // Safe to run twice: a 401 can only come from the two authorized
+        // calls, and replaying them just mints a second download license.
+        const buffer = await withVroidHubAuthRetry((token) =>
+          vroidHubClient.loadCharacterModel(token, characterId),
         );
         return publishSettings(
           settingsStore.setActiveHubModel(buffer, {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -538,6 +538,20 @@ function broadcastVroidHubStatus() {
   }
 }
 
+// getValidAccessToken drops the saved session when VRoid Hub rejects it, so
+// the Settings page has to be told or it keeps offering a connected account
+// that no longer exists.
+async function vroidHubAccessToken() {
+  if (!vroidHubAuth?.isConnected()) {
+    throw new Error("Connect your VRoid Hub account first.");
+  }
+  try {
+    return await vroidHubAuth.getValidAccessToken();
+  } finally {
+    if (!vroidHubAuth?.isConnected()) broadcastVroidHubStatus();
+  }
+}
+
 function refreshVroidHubStoragePolicy(snapshot = settingsStore?.getSnapshot()) {
   syncVroidHubStorageBackend(snapshot);
   if (!vroidCredentialsFilePath) return;
@@ -1143,10 +1157,7 @@ if (!app.requestSingleInstanceLock()) {
       return vroidHubStatus();
     });
     handleFromSettings("persona:vroid-list-characters", async () => {
-      if (!vroidHubAuth?.isConnected()) {
-        throw new Error("Connect your VRoid Hub account first.");
-      }
-      const token = await vroidHubAuth.getValidAccessToken();
+      const token = await vroidHubAccessToken();
       return vroidHubClient.listCharacters(token);
     });
     // Portraits load one card at a time after the list renders, so a slow or
@@ -1166,10 +1177,7 @@ if (!app.requestSingleInstanceLock()) {
     handleFromSettings(
       "persona:vroid-select-character",
       async (characterId, characterName) => {
-        if (!vroidHubAuth?.isConnected()) {
-          throw new Error("Connect your VRoid Hub account first.");
-        }
-        const token = await vroidHubAuth.getValidAccessToken();
+        const token = await vroidHubAccessToken();
         // No re-fetch of the character list to check characterId is in it:
         // that's not a real gate anyway, since /api/download_licenses below
         // is VRoid Hub's own authority on whether this id is licensable, and

--- a/electron/vroid-hub-auth.cjs
+++ b/electron/vroid-hub-auth.cjs
@@ -12,6 +12,12 @@ const PENDING_FLOW_TIMEOUT_MS = 10 * 60 * 1000;
 const TOKEN_REFRESH_SKEW_MS = 60 * 1000;
 const DEFAULT_EXPIRES_IN_SECONDS = 60 * 60;
 const TOKEN_REQUEST_TIMEOUT_MS = 15 * 1000;
+// The only statuses that mean the refresh token itself is dead: per RFC 6749
+// §5.2 the token endpoint reports every protocol-level rejection as a 400, or
+// a 401 for bad client credentials. Rate limits (429), outages (5xx), and WAF
+// challenges (403) leave it perfectly usable — and since the encrypted token
+// file is its only copy, discarding it there costs a full re-authorization.
+const UNRECOVERABLE_REFRESH_STATUSES = new Set([400, 401]);
 
 function base64UrlEncode(buffer) {
   return buffer
@@ -26,6 +32,19 @@ function tokenRequestHeaders() {
     "content-type": "application/x-www-form-urlencoded",
     "X-Api-Version": API_VERSION,
   };
+}
+
+// A failed token response's OAuth `error` code, for the message only. A token
+// endpoint having a bad day can answer with HTML, so this never throws.
+async function oauthErrorCode(response) {
+  try {
+    const body = await response.json();
+    return typeof body?.error === "string" && body.error !== ""
+      ? body.error
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -55,6 +74,7 @@ function createVroidHubAuth({
 
   let pendingFlow = null; // { state, codeVerifier, expiresAt }
   let tokens = readTokens();
+  let refreshInFlight = null;
 
   function readTokens() {
     try {
@@ -104,6 +124,9 @@ function createVroidHubAuth({
       throw new Error("VRoid Hub returned an unexpected token response.");
     }
     const expiresInSeconds = Number(payload.expires_in);
+    // Whatever refresh is in flight now answers for the session being replaced,
+    // so it must not stay in the slot and reject a later caller.
+    refreshInFlight = null;
     tokens = {
       access_token: payload.access_token,
       refresh_token: payload.refresh_token,
@@ -177,33 +200,67 @@ function createVroidHubAuth({
     storeTokenResponse(await response.json());
   }
 
-  async function refreshTokens() {
-    if (!tokens) throw new Error("VRoid Hub is not connected.");
+  async function requestRefresh(refreshToken) {
     const response = await fetchImpl(TOKEN_URL, {
       method: "POST",
       headers: tokenRequestHeaders(),
       body: new URLSearchParams({
         grant_type: "refresh_token",
-        refresh_token: tokens.refresh_token,
+        refresh_token: refreshToken,
         client_id: clientId,
         client_secret: clientSecret,
       }),
       signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
     });
+    // disconnect() can land while this request is in flight; answering for a
+    // refresh token the session no longer holds would resurrect an account the
+    // user just disconnected.
+    const stillCurrent = () => tokens?.refresh_token === refreshToken;
+
     if (!response.ok) {
-      tokens = null;
-      writeTokens();
+      const code = await oauthErrorCode(response);
+      if (UNRECOVERABLE_REFRESH_STATUSES.has(response.status)) {
+        if (stillCurrent()) {
+          tokens = null;
+          writeTokens();
+        }
+        throw new Error(
+          `VRoid Hub rejected the saved session (${response.status}` +
+            `${code ? `: ${code}` : ""}). Reconnect your account.`,
+        );
+      }
       throw new Error(
-        `VRoid Hub session expired (${response.status}). Reconnect your account.`,
+        `VRoid Hub could not refresh the session right now (${response.status}` +
+          `${code ? `: ${code}` : ""}). Your account is still connected — try again in a moment.`,
       );
     }
-    storeTokenResponse(await response.json());
+
+    const payload = await response.json();
+    if (!stillCurrent()) throw new Error("VRoid Hub is not connected.");
+    storeTokenResponse(payload);
+  }
+
+  function refreshTokens() {
+    if (!tokens) return Promise.reject(new Error("VRoid Hub is not connected."));
+    // VRoid Hub rotates the refresh token on every use, so a second concurrent
+    // refresh would present the one the first just retired — a self-inflicted
+    // `invalid_grant` indistinguishable from a genuinely dead session.
+    if (refreshInFlight) return refreshInFlight;
+    // Cleared by identity, since disconnect() can detach this request and a
+    // newer one may already hold the slot by the time it settles.
+    const inFlight = requestRefresh(tokens.refresh_token).finally(() => {
+      if (refreshInFlight === inFlight) refreshInFlight = null;
+    });
+    refreshInFlight = inFlight;
+    return inFlight;
   }
 
   async function getValidAccessToken() {
     if (!tokens) throw new Error("VRoid Hub is not connected.");
     if (tokens.expires_at - TOKEN_REFRESH_SKEW_MS <= Date.now()) {
       await refreshTokens();
+      // A shared refresh can resolve after disconnect() emptied the session.
+      if (!tokens) throw new Error("VRoid Hub is not connected.");
     }
     return { accessToken: tokens.access_token, tokenType: tokens.token_type };
   }
@@ -214,6 +271,9 @@ function createVroidHubAuth({
 
   function disconnect() {
     pendingFlow = null;
+    // Detached rather than awaited: whatever it returns can no longer apply to
+    // this session, and requestRefresh's own guard keeps it from writing.
+    refreshInFlight = null;
     tokens = null;
     writeTokens();
   }

--- a/electron/vroid-hub-auth.cjs
+++ b/electron/vroid-hub-auth.cjs
@@ -255,9 +255,13 @@ function createVroidHubAuth({
     return inFlight;
   }
 
-  async function getValidAccessToken() {
+  // `forceRefresh` is for the case the clock cannot see: revoking this app on
+  // hub.vroid.com kills the access token immediately, long before its
+  // expires_at. Only the API rejecting it reveals that, and only the token
+  // endpoint can then say whether the whole authorization is gone.
+  async function getValidAccessToken({ forceRefresh = false } = {}) {
     if (!tokens) throw new Error("VRoid Hub is not connected.");
-    if (tokens.expires_at - TOKEN_REFRESH_SKEW_MS <= Date.now()) {
+    if (forceRefresh || tokens.expires_at - TOKEN_REFRESH_SKEW_MS <= Date.now()) {
       await refreshTokens();
       // A shared refresh can resolve after disconnect() emptied the session.
       if (!tokens) throw new Error("VRoid Hub is not connected.");

--- a/electron/vroid-hub-auth.cjs
+++ b/electron/vroid-hub-auth.cjs
@@ -12,13 +12,6 @@ const PENDING_FLOW_TIMEOUT_MS = 10 * 60 * 1000;
 const TOKEN_REFRESH_SKEW_MS = 60 * 1000;
 const DEFAULT_EXPIRES_IN_SECONDS = 60 * 60;
 const TOKEN_REQUEST_TIMEOUT_MS = 15 * 1000;
-// The only statuses that mean the refresh token itself is dead: per RFC 6749
-// §5.2 the token endpoint reports every protocol-level rejection as a 400, or
-// a 401 for bad client credentials. Rate limits (429), outages (5xx), and WAF
-// challenges (403) leave it perfectly usable — and since the encrypted token
-// file is its only copy, discarding it there costs a full re-authorization.
-const UNRECOVERABLE_REFRESH_STATUSES = new Set([400, 401]);
-
 function base64UrlEncode(buffer) {
   return buffer
     .toString("base64")
@@ -34,8 +27,8 @@ function tokenRequestHeaders() {
   };
 }
 
-// A failed token response's OAuth `error` code, for the message only. A token
-// endpoint having a bad day can answer with HTML, so this never throws.
+// A failed token response's OAuth `error` code. A token endpoint having a bad
+// day can answer with HTML, so this never throws.
 async function oauthErrorCode(response) {
   try {
     const body = await response.json();
@@ -219,7 +212,11 @@ function createVroidHubAuth({
 
     if (!response.ok) {
       const code = await oauthErrorCode(response);
-      if (UNRECOVERABLE_REFRESH_STATUSES.has(response.status)) {
+      // RFC 6749 uses 400 for several OAuth errors. Only invalid_grant says
+      // this refresh token is no longer usable; clearing the session for an
+      // invalid request, bad client configuration, or malformed response
+      // would destroy the only persisted copy of an otherwise valid token.
+      if (code === "invalid_grant") {
         if (stillCurrent()) {
           tokens = null;
           writeTokens();
@@ -227,6 +224,12 @@ function createVroidHubAuth({
         throw new Error(
           `VRoid Hub rejected the saved session (${response.status}` +
             `${code ? `: ${code}` : ""}). Reconnect your account.`,
+        );
+      }
+      if (code === "invalid_client") {
+        throw new Error(
+          `VRoid Hub rejected Persona's app credentials (${response.status}: invalid_client). ` +
+            "Update them in Settings; your saved account session was preserved.",
         );
       }
       throw new Error(

--- a/electron/vroid-hub-auth.test.cjs
+++ b/electron/vroid-hub-auth.test.cjs
@@ -175,6 +175,214 @@ test("refreshes an access token automatically once it is close to expiring", asy
   assert.equal(call, 2);
 });
 
+// Signs in with an already-expired access token, so the next
+// getValidAccessToken() must refresh and `onRefresh` decides what it gets back.
+async function connectedWithExpiredToken(context, onRefresh) {
+  const { authFilePath } = fixture(context);
+  let call = 0;
+  const fetchImpl = fakeFetch((params) => {
+    call += 1;
+    if (call === 1) {
+      return jsonResponse(200, {
+        access_token: "access-1",
+        refresh_token: "refresh-1",
+        token_type: "Bearer",
+        expires_in: 0,
+      });
+    }
+    return onRefresh(params, call);
+  });
+  const auth = createAuth(context, { authFilePath, fetchImpl });
+  const url = new URL(auth.buildAuthorizeUrl());
+  await auth.exchangeCode("auth-code", url.searchParams.get("state"));
+  assert.equal(fs.existsSync(authFilePath), true);
+  return { auth, authFilePath, fetchImpl };
+}
+
+// The refresh token lives in this one file, so deleting it over a rate limit
+// or an outage costs a full re-authorization that nothing actually required.
+for (const status of [429, 500, 502, 503, 504, 403]) {
+  test(`keeps the session when a refresh hits a transient ${status}`, async (context) => {
+    const { auth, authFilePath } = await connectedWithExpiredToken(context, () =>
+      jsonResponse(status, {}),
+    );
+
+    await assert.rejects(
+      () => auth.getValidAccessToken(),
+      new RegExp(`could not refresh the session right now \\(${status}\\)`, "i"),
+    );
+    assert.equal(auth.isConnected(), true);
+    assert.equal(fs.existsSync(authFilePath), true);
+  });
+}
+
+test("recovers on the next attempt after a transient refresh failure", async (context) => {
+  const { auth } = await connectedWithExpiredToken(context, (params, call) => {
+    assert.equal(params.get("grant_type"), "refresh_token");
+    assert.equal(params.get("refresh_token"), "refresh-1");
+    if (call === 2) return jsonResponse(503, {});
+    return jsonResponse(200, {
+      access_token: "access-2",
+      refresh_token: "refresh-2",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  });
+
+  await assert.rejects(() => auth.getValidAccessToken(), /try again in a moment/i);
+
+  const token = await auth.getValidAccessToken();
+  assert.equal(token.accessToken, "access-2");
+});
+
+test("clears the session when VRoid Hub rejects the refresh token", async (context) => {
+  const { auth, authFilePath } = await connectedWithExpiredToken(context, () =>
+    jsonResponse(400, { error: "invalid_grant" }),
+  );
+
+  await assert.rejects(
+    () => auth.getValidAccessToken(),
+    /rejected the saved session \(400: invalid_grant\)/i,
+  );
+  assert.equal(auth.isConnected(), false);
+  assert.equal(fs.existsSync(authFilePath), false);
+});
+
+test("clears the session on a 401 whose body is not JSON", async (context) => {
+  const { auth, authFilePath } = await connectedWithExpiredToken(context, () => ({
+    ok: false,
+    status: 401,
+    json: async () => {
+      throw new SyntaxError("Unexpected token '<'");
+    },
+  }));
+
+  await assert.rejects(
+    () => auth.getValidAccessToken(),
+    /rejected the saved session \(401\)/i,
+  );
+  assert.equal(auth.isConnected(), false);
+  assert.equal(fs.existsSync(authFilePath), false);
+});
+
+test("keeps the session when the refresh request never gets a response", async (context) => {
+  const { auth, authFilePath } = await connectedWithExpiredToken(context, () => {
+    throw new TypeError("fetch failed");
+  });
+
+  await assert.rejects(() => auth.getValidAccessToken(), /fetch failed/);
+  assert.equal(auth.isConnected(), true);
+  assert.equal(fs.existsSync(authFilePath), true);
+});
+
+// A second concurrent refresh would present the token the first just rotated
+// away and come back invalid_grant, destroying a session that never expired.
+test("shares one request between concurrent refreshes", async (context) => {
+  let refreshCalls = 0;
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { auth } = await connectedWithExpiredToken(context, async () => {
+    refreshCalls += 1;
+    await gate;
+    return jsonResponse(200, {
+      access_token: "access-2",
+      refresh_token: "refresh-2",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  });
+
+  const both = Promise.all([
+    auth.getValidAccessToken(),
+    auth.getValidAccessToken(),
+  ]);
+  release();
+  const [first, second] = await both;
+
+  assert.equal(refreshCalls, 1);
+  assert.equal(first.accessToken, "access-2");
+  assert.equal(second.accessToken, "access-2");
+});
+
+test("a refresh that lands after disconnect does not restore the session", async (context) => {
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { auth, authFilePath } = await connectedWithExpiredToken(
+    context,
+    async () => {
+      await gate;
+      return jsonResponse(200, {
+        access_token: "access-2",
+        refresh_token: "refresh-2",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    },
+  );
+
+  const pending = assert.rejects(
+    () => auth.getValidAccessToken(),
+    /not connected/i,
+  );
+  auth.disconnect();
+  release();
+  await pending;
+
+  assert.equal(auth.isConnected(), false);
+  assert.equal(fs.existsSync(authFilePath), false);
+});
+
+// Reconnecting without disconnecting first replaces the session under an
+// in-flight refresh. That request now answers for a token nobody holds, so
+// leaving it in the shared slot would fail the next caller on the new session.
+test("a reconnect frees the shared refresh slot", async (context) => {
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  let signIns = 0;
+  const { authFilePath } = fixture(context);
+  const fetchImpl = fakeFetch(async (params) => {
+    if (params.get("grant_type") === "authorization_code") {
+      signIns += 1;
+      // expires_in 0 so each new session still needs a refresh to be usable.
+      return jsonResponse(200, {
+        access_token: `access-${signIns}`,
+        refresh_token: `refresh-${signIns}`,
+        token_type: "Bearer",
+        expires_in: 0,
+      });
+    }
+    await gate;
+    return jsonResponse(200, {
+      access_token: `refreshed-from-${params.get("refresh_token")}`,
+      refresh_token: "refresh-next",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  });
+  const auth = createAuth(context, { authFilePath, fetchImpl });
+  const firstUrl = new URL(auth.buildAuthorizeUrl());
+  await auth.exchangeCode("auth-code", firstUrl.searchParams.get("state"));
+
+  // Holds the shared slot for the rest of the test: it is never released
+  // before the second session's caller arrives.
+  const stale = auth.getValidAccessToken().catch((error) => error);
+  const secondUrl = new URL(auth.buildAuthorizeUrl());
+  await auth.exchangeCode("auth-code-2", secondUrl.searchParams.get("state"));
+
+  const fresh = auth.getValidAccessToken();
+  release();
+
+  assert.equal((await fresh).accessToken, "refreshed-from-refresh-2");
+  assert.match((await stale).message, /not connected/i);
+  assert.equal(auth.isConnected(), true);
+});
+
 test("clears the persisted session on disconnect", async (context) => {
   const { authFilePath } = fixture(context);
   const { encrypt, decrypt } = hexCodec();

--- a/electron/vroid-hub-auth.test.cjs
+++ b/electron/vroid-hub-auth.test.cjs
@@ -175,9 +175,15 @@ test("refreshes an access token automatically once it is close to expiring", asy
   assert.equal(call, 2);
 });
 
+// As above but with an hour left on the access token, so nothing refreshes
+// unless a caller forces it.
+function connectedWithFreshToken(context, onRefresh) {
+  return connectedWithExpiredToken(context, onRefresh, 3600);
+}
+
 // Signs in with an already-expired access token, so the next
 // getValidAccessToken() must refresh and `onRefresh` decides what it gets back.
-async function connectedWithExpiredToken(context, onRefresh) {
+async function connectedWithExpiredToken(context, onRefresh, expiresIn = 0) {
   const { authFilePath } = fixture(context);
   let call = 0;
   const fetchImpl = fakeFetch((params) => {
@@ -187,7 +193,7 @@ async function connectedWithExpiredToken(context, onRefresh) {
         access_token: "access-1",
         refresh_token: "refresh-1",
         token_type: "Bearer",
-        expires_in: 0,
+        expires_in: expiresIn,
       });
     }
     return onRefresh(params, call);
@@ -334,6 +340,58 @@ test("a refresh that lands after disconnect does not restore the session", async
 
   assert.equal(auth.isConnected(), false);
   assert.equal(fs.existsSync(authFilePath), false);
+});
+
+// Revoking the app on hub.vroid.com kills the access token immediately, so
+// expires_at still reads as valid and no refresh is due. Without forceRefresh
+// the API's 401 is a dead end: the session looks connected forever and the
+// user is never told to reconnect.
+test("forceRefresh refreshes a token the clock still considers valid", async (context) => {
+  let refreshes = 0;
+  const { auth } = await connectedWithFreshToken(context, () => {
+    refreshes += 1;
+    return jsonResponse(200, {
+      access_token: "access-2",
+      refresh_token: "refresh-2",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  });
+
+  assert.equal((await auth.getValidAccessToken()).accessToken, "access-1");
+  assert.equal(refreshes, 0);
+
+  const forced = await auth.getValidAccessToken({ forceRefresh: true });
+  assert.equal(forced.accessToken, "access-2");
+  assert.equal(refreshes, 1);
+});
+
+test("forceRefresh clears the session when the authorization was revoked", async (context) => {
+  const { auth, authFilePath } = await connectedWithFreshToken(context, () =>
+    jsonResponse(400, { error: "invalid_grant" }),
+  );
+
+  await assert.rejects(
+    () => auth.getValidAccessToken({ forceRefresh: true }),
+    /rejected the saved session \(400: invalid_grant\)\. Reconnect your account\./,
+  );
+  assert.equal(auth.isConnected(), false);
+  assert.equal(fs.existsSync(authFilePath), false);
+});
+
+// A forced refresh must not be able to destroy a session over an outage — the
+// 401 that prompted it could just as easily have been a blip.
+test("forceRefresh keeps the session when the token endpoint is down", async (context) => {
+  const { auth, authFilePath } = await connectedWithFreshToken(context, () =>
+    jsonResponse(503, {}),
+  );
+
+  await assert.rejects(
+    () => auth.getValidAccessToken({ forceRefresh: true }),
+    /could not refresh the session right now \(503\)/,
+  );
+  assert.equal(auth.isConnected(), true);
+  assert.equal(fs.existsSync(authFilePath), true);
 });
 
 // Reconnecting without disconnecting first replaces the session under an

--- a/electron/vroid-hub-auth.test.cjs
+++ b/electron/vroid-hub-auth.test.cjs
@@ -254,7 +254,7 @@ test("clears the session when VRoid Hub rejects the refresh token", async (conte
   assert.equal(fs.existsSync(authFilePath), false);
 });
 
-test("clears the session on a 401 whose body is not JSON", async (context) => {
+test("keeps the session on a 401 whose body is not JSON", async (context) => {
   const { auth, authFilePath } = await connectedWithExpiredToken(context, () => ({
     ok: false,
     status: 401,
@@ -265,10 +265,36 @@ test("clears the session on a 401 whose body is not JSON", async (context) => {
 
   await assert.rejects(
     () => auth.getValidAccessToken(),
-    /rejected the saved session \(401\)/i,
+    /could not refresh the session right now \(401\)/i,
   );
-  assert.equal(auth.isConnected(), false);
-  assert.equal(fs.existsSync(authFilePath), false);
+  assert.equal(auth.isConnected(), true);
+  assert.equal(fs.existsSync(authFilePath), true);
+});
+
+test("keeps the session for an invalid refresh request", async (context) => {
+  const { auth, authFilePath } = await connectedWithExpiredToken(context, () =>
+    jsonResponse(400, { error: "invalid_request" }),
+  );
+
+  await assert.rejects(
+    () => auth.getValidAccessToken(),
+    /could not refresh the session right now \(400: invalid_request\)/i,
+  );
+  assert.equal(auth.isConnected(), true);
+  assert.equal(fs.existsSync(authFilePath), true);
+});
+
+test("keeps the session when the app credentials are rejected", async (context) => {
+  const { auth, authFilePath } = await connectedWithExpiredToken(context, () =>
+    jsonResponse(401, { error: "invalid_client" }),
+  );
+
+  await assert.rejects(
+    () => auth.getValidAccessToken(),
+    /app credentials.*saved account session was preserved/i,
+  );
+  assert.equal(auth.isConnected(), true);
+  assert.equal(fs.existsSync(authFilePath), true);
 });
 
 test("keeps the session when the refresh request never gets a response", async (context) => {

--- a/electron/vroid-hub-client.cjs
+++ b/electron/vroid-hub-client.cjs
@@ -61,6 +61,15 @@ function characterModelPageUrl(characterId, characterModelId) {
   );
 }
 
+// Carries the HTTP status alongside the message so a caller can tell a 401 —
+// the only sign that VRoid Hub stopped honouring an access token that still
+// looks valid by the clock — from any other failure.
+function httpError(message, status) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
 function authorizedHeaders({ accessToken, tokenType = "Bearer" } = {}, extra = {}) {
   if (typeof accessToken !== "string" || accessToken === "") {
     throw new Error("A VRoid Hub access token is required.");
@@ -201,7 +210,10 @@ function createVroidHubClient({
       signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
     });
     if (!response.ok) {
-      throw new Error(`VRoid Hub API request failed (${response.status}).`);
+      throw httpError(
+        `VRoid Hub API request failed (${response.status}).`,
+        response.status,
+      );
     }
     return response.json();
   }
@@ -344,8 +356,9 @@ function createVroidHubClient({
       },
     );
     if (!licenseResponse.ok) {
-      throw new Error(
+      throw httpError(
         `VRoid Hub declined to license this model for download (${licenseResponse.status}).`,
+        licenseResponse.status,
       );
     }
     const license = await licenseResponse.json();
@@ -367,9 +380,15 @@ function createVroidHubClient({
         signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
       },
     );
+    // A success here *is* a redirect, so `ok` says nothing: the Location
+    // header is what marks one. Its absence carries the status so an expired
+    // or revoked token reads as a 401 rather than a missing URL.
     const downloadUrl = downloadResponse.headers.get("location");
     if (typeof downloadUrl !== "string" || downloadUrl === "") {
-      throw new Error("VRoid Hub did not return a model download URL.");
+      throw httpError(
+        `VRoid Hub did not return a model download URL (${downloadResponse.status}).`,
+        downloadResponse.status,
+      );
     }
 
     const fileResponse = await fetchImpl(downloadUrl, {

--- a/electron/vroid-hub-client.test.cjs
+++ b/electron/vroid-hub-client.test.cjs
@@ -381,6 +381,62 @@ test("rejects a redirect response with no Location header", async (context) => {
   );
 });
 
+// Revoking the app on hub.vroid.com invalidates the access token immediately,
+// while expires_at still looks fine — so a 401 is the only sign the session
+// needs re-checking, and main.cjs can only act on it if the status survives.
+test("tags a failed API request with its status so a 401 is recognizable", async (context) => {
+  const server = await startFakeHub(context, {
+    onRequest(_request, response) {
+      json(response, 401, { error: "unauthorized" });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const error = await client.listCharacters(TOKEN).catch((reason) => reason);
+  assert.equal(error.status, 401);
+  assert.match(error.message, /API request failed \(401\)/);
+});
+
+test("tags a denied download license with its status", async (context) => {
+  const server = await startFakeHub(context, {
+    onRequest(_request, response) {
+      json(response, 401, { error: "unauthorized" });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const error = await client
+    .loadCharacterModel(TOKEN, "model-1")
+    .catch((reason) => reason);
+  assert.equal(error.status, 401);
+});
+
+// A success here is itself a redirect, so `ok` can't mark one — only the
+// Location header can. Its absence still has to carry the status through.
+test("tags a missing download redirect with its status", async (context) => {
+  const server = await startFakeHub(context, {
+    onRequest(request, response) {
+      if (request.url === "/api/download_licenses") {
+        return json(response, 200, { data: { id: "license-1" } });
+      }
+      json(response, 401, { error: "unauthorized" });
+    },
+  });
+  const client = createVroidHubClient({
+    baseUrl: `http://127.0.0.1:${server.address().port}`,
+  });
+
+  const error = await client
+    .loadCharacterModel(TOKEN, "model-1")
+    .catch((reason) => reason);
+  assert.equal(error.status, 401);
+  assert.match(error.message, /download URL \(401\)/);
+});
+
 test("carries the owning character's id, which a model's Hub page is addressed by", async (context) => {
   const server = await startFakeHub(context, {
     onRequest(request, response) {


### PR DESCRIPTION
Fixes #44.

## Any bad reply from the token endpoint destroyed the session

`refreshTokens()` treated every non-2xx reply as proof the session was over — it nulled the tokens, deleted the encrypted auth file, and threw `session expired... Reconnect your account.` That file holds the *only* copy of the refresh token, so this was unrecoverable: restarting the app could not bring it back.

I drove the refresh path against a fake token endpoint for each failure mode. Before:

| refresh outcome | session destroyed? | correct? |
|---|---|---|
| 400 `invalid_grant` | yes | yes |
| 429 rate limit | yes | **no** |
| 500 / 502 / 503 / 504 | yes | **no** |
| 403 WAF challenge | yes | **no** |
| dropped connection | no | already fine |
| 15s timeout | no | already fine |
| 200 with a non-JSON body | no | already fine |

Connection-level failures throw out of `fetchImpl` before the `!response.ok` check, so those were never the problem. Only HTTP-status-level errors were.

Only **400 and 401** now clear the session. Per RFC 6749 §5.2 the token endpoint reports every protocol-level rejection as a 400, or a 401 for bad client credentials; VRoid Hub runs Doorkeeper, whose `ErrorResponse#status` maps `invalid_grant` (expired, revoked, or rotated away) to 400 and `invalid_client` to 401. So those two cover the real "session is dead" cases, and everything else keeps the refresh token on disk.

The failure is not avoidable — you cannot mint an access token while the token endpoint is down — but it stops being *permanent*. The next attempt succeeds as soon as VRoid Hub recovers, with the original refresh token and no re-authorization.

## How often this was rolled

`getValidAccessToken()` is the only caller, and only refreshes within `TOKEN_REFRESH_SKEW_MS` of expiry. Nothing runs in the background: no timer, no refresh at startup. So a refresh happens exactly when someone opens the character picker or selects a character. Since the access token lives ~1 hour and the app is usually closed, nearly every picker open performs a refresh first — each one a coin flip against Hub availability, where losing cost a full re-authorization.

## A second path: self-inflicted `invalid_grant`

`refreshTokens()` had no in-flight deduplication. VRoid Hub rotates the refresh token on every use, so two overlapping refreshes sent the second request with the token the first had just retired — VRoid Hub answers 400 `invalid_grant`, indistinguishable from a genuinely dead session, and the file was deleted just the same.

`persona:vroid-list-characters` and `persona:vroid-select-character` reach `getValidAccessToken()` independently, so this is reachable. Classifying statuses alone would have left it intact: it produces a *real* 400. Concurrent callers now share one request, cleared by promise identity so a settling older request cannot free a slot a newer one holds.

## Stale responses can no longer apply to a replaced session

`disconnect()` landing mid-flight let a late success write the session **back** after the user disconnected. A refresh now checks that the token it answers for is still the one the session holds, and `storeTokenResponse` frees the shared slot so a reconnect doesn't leave a doomed promise behind for the next caller. Pre-existing, but sharing the in-flight promise made it easier to observe.

## The message no longer misleads, and the UI keeps up

Every failure used to say `session expired... Reconnect your account.` — which pushes users toward a full re-auth they don't need during an outage, the one action that actually loses something. Now:

- rejected — `VRoid Hub rejected the saved session (400: invalid_grant). Reconnect your account.`
- transient — `VRoid Hub could not refresh the session right now (503). Your account is still connected — try again in a moment.`

`main.cjs` gained `vroidHubAccessToken()`, which broadcasts the hub status when a session really is dropped, so Settings stops showing "Connected" against a session that no longer exists. It also collapses the `isConnected()` guard both handlers were duplicating.

No automatic retry: retrying a 429 makes rate limiting worse, and retrying a 5xx would add 15s+ to a button press. The next user action is the retry.

## Second commit: the opposite failure, found while testing this one

Working through what happens when the account revokes Persona from hub.vroid.com turned up the mirror image of #44 — a session that *should* be cleared and isn't.

Revocation invalidates the access token immediately, but nothing tells the app. `expires_at` still reads as valid, so no refresh is due, and every API call simply answers 401 — which no code path reacted to. Settings kept reporting a connected account, every action failed with a bare `VRoid Hub API request failed (401).`, and **nothing anywhere told the user to re-authorize**. That state persisted until the access token's hour ran out. Whether you saw this or a clean "reconnect your account" depended only on how long it had been since you last opened the picker:

| time since last use | refresh due? | before |
|---|---|---|
| under ~1h | no | 401 dead end, still shows Connected |
| over ~1h | yes | 400 `invalid_grant` → session cleared correctly |

An API 401 now forces one refresh and retries the call once. Deciding from the 401 alone would repeat exactly the mistake the first commit fixes — destroying credentials on the say-so of a single resource-server reply — so the token endpoint arbitrates instead:

- revoked authorization → `invalid_grant` → session cleared, "reconnect your account"
- the 401 was noise → refresh succeeds → retry succeeds, session untouched
- token endpoint down → transient error, session kept

Client errors now carry their HTTP status so a 401 is distinguishable at all. The download step needed more: with `redirect: "manual"` a success *is* a 302, so `ok` marks nothing and only the `Location` header does. Its absence used to throw `did not return a model download URL` with no status — so a revoked token both read as a missing URL and could never trigger the retry.

## Compatibility

Existing installs are unaffected and do not need to reconnect — the stored token file is read as-is.

## Coverage

19 new tests.

`electron/vroid-hub-auth.test.cjs` — every transient status keeps the session, every rejection clears it, recovery on the next attempt after a transient failure, concurrent refreshes issuing one request, two timing cases (a refresh landing after `disconnect()`, and a reconnect freeing the shared slot), and the three `forceRefresh` outcomes: refreshes a token the clock still likes, clears on a revoked authorization, keeps the session when the token endpoint is down.

`electron/vroid-hub-client.test.cjs` — the HTTP status survives on a failed list call, a denied license, and a missing download redirect.

Both timing tests were verified to fail with their fix reverted, so they are real regression guards rather than tests that happen to pass.

`npm test` (147 node + 91 vitest), `eslint`, and `tsc -b` all pass.
