### PR TITLE
Fix/gate settings ipc sender

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,9 @@ Keep these architectural constraints intact:
   process, shell, or raw-audio access.
 - Renderer navigation and imported media stay within Persona's validated local
   protocols.
+- Settings mutations and VRoid Hub operations stay restricted to the Settings
+  window; both windows share one preload, so new channels register through
+  `electron/settings-ipc.cjs`.
 - The integration and MCP server remain loopback-only and accept bounded,
   validated inputs.
 - MCP tools describe Persona actions, not arbitrary Electron or operating

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,9 @@ separate authorization design.
 
 The renderer is sandboxed with context isolation and no Node.js integration. A
 restrictive content security policy is applied, renderer popups are denied, and
-navigation outside the local renderer entry is blocked.
+navigation outside the local renderer entry is blocked. The avatar and Settings
+windows share one preload, so settings changes and VRoid Hub operations are
+additionally rejected unless the request comes from the Settings window.
 
 Imported VRM and VRMA files are copied into Persona's per-user application-data
 directory. They are available to the sandboxed renderer only through a local

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,7 +9,7 @@ Persona has four intentionally narrow layers:
 2. The Electron main process owns lifecycle, window behavior, tray commands,
    URL handling, the local adapter, and Persona's MCP controls.
 3. The sandboxed preload exposes only normalized Persona events and narrow
-   settings operations.
+   settings operations, the privileged ones gated to the Settings window.
 4. React and Three.js render the model, blend VRMA motion, and drive VRM
    expressions.
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -50,6 +50,7 @@ const {
 const { createAudioListener } = require("./audio-listener.cjs");
 const { listVoiceSources } = require("./voice-source-discovery.cjs");
 const { isAllowedRendererNavigation } = require("./navigation-policy.cjs");
+const { createSettingsIpcGate } = require("./settings-ipc.cjs");
 const { snapshotHasConfiguredModel } = require("./model-readiness.cjs");
 const { parseProtocolUrl, voiceState } = require("./protocol-actions.cjs");
 const {
@@ -514,14 +515,10 @@ function vroidHubSecureStorageAvailable(snapshot = settingsStore?.getSnapshot())
   return safeStorage.getSelectedStorageBackend?.() !== "basic_text";
 }
 
-function requireSettingsSender(event) {
-  if (!settingsWindow || settingsWindow.isDestroyed()) {
-    throw new Error("The Settings window is not available.");
-  }
-  if (event.sender !== settingsWindow.webContents) {
-    throw new Error("This request must come from the Settings window.");
-  }
-}
+const { handleFromSettings, isSettingsSender } = createSettingsIpcGate({
+  ipcMain,
+  getSettingsWindow: () => settingsWindow,
+});
 
 function vroidHubStatus() {
   return {
@@ -914,19 +911,19 @@ if (!app.requestSingleInstanceLock()) {
 
     ipcMain.handle("persona:get-snapshot", () => latestEvent);
     ipcMain.handle("persona:settings-get", () => settingsStore.getSnapshot());
-    ipcMain.handle("persona:settings-import-model", async (_event, metadata) => {
+    handleFromSettings("persona:settings-import-model", async (metadata) => {
       const filePath = await selectAssetFile("model");
       if (!filePath) return null;
       return publishSettings(
         settingsStore.importModel({ filePath, model_name: metadata?.model_name }),
       );
     });
-    ipcMain.handle("persona:settings-create-animation", (_event, metadata) =>
+    handleFromSettings("persona:settings-create-animation", (metadata) =>
       publishSettings(settingsStore.createAnimation(metadata)),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-add-animation-clips",
-      async (_event, animationId) => {
+      async (animationId) => {
         const filePaths = await selectAssetFile("animation", true);
         if (filePaths.length === 0) return null;
         return publishSettings(
@@ -934,32 +931,32 @@ if (!app.requestSingleInstanceLock()) {
         );
       },
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-update-animation",
-      (_event, animationId, metadata) =>
+      (animationId, metadata) =>
         publishSettings(
           settingsStore.updateAnimation(animationId, metadata),
         ),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-delete-animation",
-      (_event, animationId) =>
+      (animationId) =>
         publishSettings(settingsStore.deleteAnimation(animationId)),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-delete-animation-clip",
-      (_event, animationId, clipId) =>
+      (animationId, clipId) =>
         publishSettings(
           settingsStore.deleteAnimationClip(animationId, clipId),
         ),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-reset-packaged-animations",
       () => publishSettings(settingsStore.resetPackagedAnimations()),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-delete-model",
-      (_event, modelId) => {
+      (modelId) => {
         const model = settingsStore
           .getSnapshot()
           .models.find((candidate) => candidate.id === modelId);
@@ -969,15 +966,15 @@ if (!app.requestSingleInstanceLock()) {
         return publishSettings(settingsStore.deleteModel(modelId));
       },
     );
-    ipcMain.handle("persona:settings-set-default-model", (_event, modelId) =>
+    handleFromSettings("persona:settings-set-default-model", (modelId) =>
       publishSettings(settingsStore.setDefaultModel(modelId)),
     );
-    ipcMain.handle("persona:settings-set-character-size", (_event, size) =>
+    handleFromSettings("persona:settings-set-character-size", (size) =>
       publishSettings(settingsStore.setCharacterSize(size)),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-set-avatar-window-size",
-      (_event, width, height) => {
+      (width, height) => {
         const snapshot = publishSettings(
           settingsStore.setAvatarWindowSize(width, height),
         );
@@ -985,38 +982,38 @@ if (!app.requestSingleInstanceLock()) {
         return snapshot;
       },
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-set-speaking-transition",
-      (_event, transition) =>
+      (transition) =>
         publishSettings(settingsStore.setSpeakingTransition(transition)),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-set-body-transition-ms",
-      (_event, milliseconds) =>
+      (milliseconds) =>
         publishSettings(settingsStore.setBodyTransitionMs(milliseconds)),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-set-speaking-debounce-ms",
-      (_event, milliseconds) =>
+      (milliseconds) =>
         publishSettings(settingsStore.setSpeakingDebounceMs(milliseconds)),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-set-idle-interim-ms",
-      (_event, milliseconds) =>
+      (milliseconds) =>
         publishSettings(settingsStore.setIdleInterimMs(milliseconds)),
     );
-    ipcMain.handle("persona:settings-enable-developer", () =>
+    handleFromSettings("persona:settings-enable-developer", () =>
       publishSettings(settingsStore.enableDeveloperSettings()),
     );
-    ipcMain.handle("persona:settings-reset-developer", () => {
+    handleFromSettings("persona:settings-reset-developer", () => {
       const snapshot = publishSettings(settingsStore.resetDeveloperSettings());
       refreshVroidHubStoragePolicy(snapshot);
       broadcastVroidHubStatus();
       return settingsStore.getSnapshot();
     });
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-set-vroid-plaintext-storage",
-      (_event, allowed) => {
+      (allowed) => {
         const snapshot = publishSettings(
           settingsStore.setVroidHubPlaintextStorageAllowed(allowed),
         );
@@ -1043,12 +1040,12 @@ if (!app.requestSingleInstanceLock()) {
         return settingsStore.getSnapshot();
       },
     );
-    ipcMain.handle("persona:settings-set-voice-source", (_event, voiceSource) => {
+    handleFromSettings("persona:settings-set-voice-source", (voiceSource) => {
       const snapshot = publishSettings(settingsStore.setVoiceSource(voiceSource));
       restartAudioListener();
       return snapshot;
     });
-    ipcMain.handle("persona:settings-list-voice-sources", async () => {
+    handleFromSettings("persona:settings-list-voice-sources", async () => {
       try {
         return {
           ...(await listVoiceSources()),
@@ -1066,17 +1063,17 @@ if (!app.requestSingleInstanceLock()) {
         };
       }
     });
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-set-model-lighting",
-      (_event, modelId, lighting) =>
+      (modelId, lighting) =>
         publishSettings(settingsStore.setModelLighting(modelId, lighting)),
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:settings-reset-model-lighting",
-      (_event, modelId) =>
+      (modelId) =>
         publishSettings(settingsStore.resetModelLighting(modelId)),
     );
-    ipcMain.handle("persona:settings-get-mcp-status", () =>
+    handleFromSettings("persona:settings-get-mcp-status", () =>
       createMcpSettingsStatus({
         error: mcpServerError,
         health: mcpServerHealth,
@@ -1084,12 +1081,8 @@ if (!app.requestSingleInstanceLock()) {
         settingsSnapshot: settingsStore.getSnapshot(),
       }),
     );
-    ipcMain.handle("persona:vroid-get-status", (event) => {
-      requireSettingsSender(event);
-      return vroidHubStatus();
-    });
-    ipcMain.handle("persona:vroid-get-credentials", (event) => {
-      requireSettingsSender(event);
+    handleFromSettings("persona:vroid-get-status", () => vroidHubStatus());
+    handleFromSettings("persona:vroid-get-credentials", () => {
       if (!vroidHubSecureStorageAvailable()) {
         return { clientId: null, hasClientSecret: false };
       }
@@ -1103,10 +1096,9 @@ if (!app.requestSingleInstanceLock()) {
         hasClientSecret: credentials != null,
       };
     });
-    ipcMain.handle(
+    handleFromSettings(
       "persona:vroid-set-credentials",
-      (event, clientId, clientSecret) => {
-        requireSettingsSender(event);
+      (clientId, clientSecret) => {
         if (!vroidHubSecureStorageAvailable()) {
           throw new Error(
             "This OS has no secure credential storage available, so VRoid Hub credentials cannot be saved.",
@@ -1127,8 +1119,7 @@ if (!app.requestSingleInstanceLock()) {
         return vroidHubStatus();
       },
     );
-    ipcMain.handle("persona:vroid-clear-credentials", (event) => {
-      requireSettingsSender(event);
+    handleFromSettings("persona:vroid-clear-credentials", () => {
       clearVroidHubCredentials({ credentialsFilePath: vroidCredentialsFilePath });
       vroidHubAuth?.disconnect();
       vroidHubAuth = null;
@@ -1137,8 +1128,7 @@ if (!app.requestSingleInstanceLock()) {
       broadcastVroidHubStatus();
       return vroidHubStatus();
     });
-    ipcMain.handle("persona:vroid-connect", (event) => {
-      requireSettingsSender(event);
+    handleFromSettings("persona:vroid-connect", () => {
       if (!vroidHubAuth) {
         throw new Error(
           "VRoid Hub is not configured. Add your VRoid Hub app credentials in Settings first.",
@@ -1147,14 +1137,12 @@ if (!app.requestSingleInstanceLock()) {
       void shell.openExternal(vroidHubAuth.buildAuthorizeUrl());
       return vroidHubStatus();
     });
-    ipcMain.handle("persona:vroid-disconnect", (event) => {
-      requireSettingsSender(event);
+    handleFromSettings("persona:vroid-disconnect", () => {
       vroidHubAuth?.disconnect();
       publishSettings(settingsStore.clearActiveHubModel());
       return vroidHubStatus();
     });
-    ipcMain.handle("persona:vroid-list-characters", async (event) => {
-      requireSettingsSender(event);
+    handleFromSettings("persona:vroid-list-characters", async () => {
       if (!vroidHubAuth?.isConnected()) {
         throw new Error("Connect your VRoid Hub account first.");
       }
@@ -1166,20 +1154,18 @@ if (!app.requestSingleInstanceLock()) {
     // Only ids from the last listing resolve to a URL (see the client), and a
     // missing portrait is a null, not an error — the card just keeps its
     // placeholder icon.
-    ipcMain.handle(
+    handleFromSettings(
       "persona:vroid-character-portrait",
-      async (event, characterId) => {
-        requireSettingsSender(event);
+      async (characterId) => {
         if (typeof characterId !== "string" || characterId === "") {
           throw new Error("A character id is required.");
         }
         return (await vroidHubClient?.loadCharacterPortrait(characterId)) ?? null;
       },
     );
-    ipcMain.handle(
+    handleFromSettings(
       "persona:vroid-select-character",
-      async (event, characterId, characterName) => {
-        requireSettingsSender(event);
+      async (characterId, characterName) => {
         if (!vroidHubAuth?.isConnected()) {
           throw new Error("Connect your VRoid Hub account first.");
         }
@@ -1202,10 +1188,9 @@ if (!app.requestSingleInstanceLock()) {
     // Builds the model's Hub page from bare ids rather than trusting a full
     // URL from the renderer. characterModelPageUrl validates both ids and
     // owns the path's shape, where it can be tested — this handler can't.
-    ipcMain.handle(
+    handleFromSettings(
       "persona:vroid-open-character-page",
-      (event, characterId, characterModelId) => {
-        requireSettingsSender(event);
+      (characterId, characterModelId) => {
         void shell.openExternal(
           characterModelPageUrl(characterId, characterModelId),
         );
@@ -1239,8 +1224,9 @@ if (!app.requestSingleInstanceLock()) {
     // known theme names and never a caller-supplied colour.
     ipcMain.on("persona:settings-set-window-theme", (event, theme) => {
       if (theme !== "dark" && theme !== "light") return;
-      if (!settingsWindow || settingsWindow.isDestroyed()) return;
-      if (event.sender !== settingsWindow.webContents) return;
+      // A send has no reply channel to reject through, so an unexpected sender
+      // is dropped rather than thrown at the main process.
+      if (!isSettingsSender(event)) return;
       const background = settingsWindowBackground(theme);
       settingsWindow.setBackgroundColor(background);
       debugLog("settings window background", theme, background);

--- a/electron/settings-ipc.cjs
+++ b/electron/settings-ipc.cjs
@@ -1,0 +1,33 @@
+"use strict";
+
+// Both windows load the same preload, so the avatar window holds the same IPC
+// surface as Settings. Gating registration rather than each handler's first
+// line is deliberate: ~20 settings channels were once added without the guard.
+function createSettingsIpcGate({ ipcMain, getSettingsWindow }) {
+  function isSettingsSender(event) {
+    const settingsWindow = getSettingsWindow();
+    if (!settingsWindow || settingsWindow.isDestroyed()) return false;
+    return event.sender === settingsWindow.webContents;
+  }
+
+  function requireSettingsSender(event) {
+    const settingsWindow = getSettingsWindow();
+    if (!settingsWindow || settingsWindow.isDestroyed()) {
+      throw new Error("The Settings window is not available.");
+    }
+    if (event.sender !== settingsWindow.webContents) {
+      throw new Error("This request must come from the Settings window.");
+    }
+  }
+
+  function handleFromSettings(channel, handler) {
+    ipcMain.handle(channel, (event, ...args) => {
+      requireSettingsSender(event);
+      return handler(...args);
+    });
+  }
+
+  return { handleFromSettings, isSettingsSender };
+}
+
+module.exports = { createSettingsIpcGate };

--- a/electron/settings-ipc.cjs
+++ b/electron/settings-ipc.cjs
@@ -4,18 +4,25 @@
 // surface as Settings. Gating registration rather than each handler's first
 // line is deliberate: ~20 settings channels were once added without the guard.
 function createSettingsIpcGate({ ipcMain, getSettingsWindow }) {
-  function isSettingsSender(event) {
+  // The one place the sender rule is derived, so tightening it later cannot
+  // reach one caller and miss the other.
+  function settingsWebContents() {
     const settingsWindow = getSettingsWindow();
-    if (!settingsWindow || settingsWindow.isDestroyed()) return false;
-    return event.sender === settingsWindow.webContents;
+    if (!settingsWindow || settingsWindow.isDestroyed()) return null;
+    return settingsWindow.webContents;
+  }
+
+  function isSettingsSender(event) {
+    const settings = settingsWebContents();
+    return settings != null && event.sender === settings;
   }
 
   function requireSettingsSender(event) {
-    const settingsWindow = getSettingsWindow();
-    if (!settingsWindow || settingsWindow.isDestroyed()) {
+    const settings = settingsWebContents();
+    if (!settings) {
       throw new Error("The Settings window is not available.");
     }
-    if (event.sender !== settingsWindow.webContents) {
+    if (event.sender !== settings) {
       throw new Error("This request must come from the Settings window.");
     }
   }

--- a/electron/settings-ipc.test.cjs
+++ b/electron/settings-ipc.test.cjs
@@ -1,0 +1,139 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const { createSettingsIpcGate } = require("./settings-ipc.cjs");
+
+function createGateHarness() {
+  const handlers = new Map();
+  const ipcMain = {
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+  const settingsWebContents = { name: "settings" };
+  let settingsWindow = {
+    isDestroyed: () => false,
+    webContents: settingsWebContents,
+  };
+  const gate = createSettingsIpcGate({
+    ipcMain,
+    getSettingsWindow: () => settingsWindow,
+  });
+  return {
+    ...gate,
+    handlers,
+    fromAvatar: { sender: { name: "avatar" } },
+    fromSettings: { sender: settingsWebContents },
+    closeSettingsWindow() {
+      settingsWindow = null;
+    },
+    destroySettingsWindow() {
+      settingsWindow = { isDestroyed: () => true, webContents: settingsWebContents };
+    },
+  };
+}
+
+test("runs a gated handler on the Settings window's own arguments", async () => {
+  const harness = createGateHarness();
+  const calls = [];
+  harness.handleFromSettings("persona:settings-set-model-lighting", (...args) => {
+    calls.push(args);
+    return "snapshot";
+  });
+
+  const result = await harness.handlers.get(
+    "persona:settings-set-model-lighting",
+  )(harness.fromSettings, "model-id", { exposure: 1.2 });
+
+  assert.equal(result, "snapshot");
+  assert.deepEqual(calls, [["model-id", { exposure: 1.2 }]]);
+});
+
+test("rejects a gated handler invoked from the avatar window", async () => {
+  const harness = createGateHarness();
+  let called = false;
+  harness.handleFromSettings("persona:settings-delete-model", () => {
+    called = true;
+  });
+
+  await assert.rejects(
+    async () =>
+      harness.handlers.get("persona:settings-delete-model")(
+        harness.fromAvatar,
+        "model-id",
+      ),
+    /must come from the Settings window/,
+  );
+  assert.equal(called, false);
+});
+
+test("rejects a gated handler while no Settings window exists", async () => {
+  for (const shutSettingsWindow of ["closeSettingsWindow", "destroySettingsWindow"]) {
+    const harness = createGateHarness();
+    let called = false;
+    harness.handleFromSettings("persona:settings-enable-developer", () => {
+      called = true;
+    });
+    harness[shutSettingsWindow]();
+
+    await assert.rejects(
+      async () =>
+        harness.handlers.get("persona:settings-enable-developer")(
+          harness.fromSettings,
+        ),
+      /Settings window is not available/,
+    );
+    assert.equal(called, false);
+  }
+});
+
+test("recognises only the Settings window as a settings sender", () => {
+  const harness = createGateHarness();
+  assert.equal(harness.isSettingsSender(harness.fromSettings), true);
+  assert.equal(harness.isSettingsSender(harness.fromAvatar), false);
+  harness.destroySettingsWindow();
+  assert.equal(harness.isSettingsSender(harness.fromSettings), false);
+  harness.closeSettingsWindow();
+  assert.equal(harness.isSettingsSender(harness.fromSettings), false);
+});
+
+// Pins the channels any renderer can reach, so a mutator registered through a
+// bare ipcMain.handle/on fails here rather than in review.
+test("main registers every settings and VRoid Hub channel behind the gate", () => {
+  const source = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  const channels = (pattern) =>
+    [...source.matchAll(pattern)].map((match) => match[1]).sort();
+
+  const ungated = channels(/ipcMain\.(?:handle|on)\(\s*"([^"]+)"/g);
+  const gated = channels(/handleFromSettings\(\s*"([^"]+)"/g);
+
+  assert.deepEqual(ungated, [
+    "persona:get-snapshot",
+    "persona:hide",
+    "persona:move-by",
+    "persona:settings-get",
+    "persona:settings-set-window-theme",
+  ]);
+  assert.match(
+    source.slice(source.indexOf('ipcMain.on("persona:settings-set-window-theme"')),
+    /^[^)]*\)[\s\S]{0,600}?isSettingsSender\(event\)/,
+    "the one ungated settings channel must still check its sender by hand",
+  );
+  assert.ok(
+    gated.filter((channel) => channel.startsWith("persona:settings-")).length >
+      15,
+    "expected the settings mutators to be registered through the gate",
+  );
+  for (const channel of gated) {
+    assert.match(channel, /^persona:(settings|vroid)-/);
+  }
+  assert.ok(
+    gated.includes("persona:settings-set-vroid-plaintext-storage") &&
+      gated.includes("persona:settings-delete-model") &&
+      gated.includes("persona:settings-enable-developer") &&
+      gated.includes("persona:vroid-get-credentials"),
+  );
+});

--- a/electron/settings-ipc.test.cjs
+++ b/electron/settings-ipc.test.cjs
@@ -107,9 +107,16 @@ test("main registers every settings and VRoid Hub channel behind the gate", () =
   const channels = (pattern) =>
     [...source.matchAll(pattern)].map((match) => match[1]).sort();
 
-  const ungated = channels(/ipcMain\.(?:handle|on)\(\s*"([^"]+)"/g);
-  const gated = channels(/handleFromSettings\(\s*"([^"]+)"/g);
+  const ungated = channels(/ipcMain\.\w+\(\s*['"]([^'"]+)['"]/g);
+  const gated = channels(/handleFromSettings\(\s*['"]([^'"]+)['"]/g);
 
+  // Any ipcMain method, any quote style, and the channel named inline, so a
+  // handleOnce or a single-quoted registration cannot slip past the pin.
+  assert.equal(
+    [...source.matchAll(/ipcMain\.\w+\(/g)].length,
+    ungated.length,
+    "every ipcMain registration must name its channel as a literal",
+  );
   assert.deepEqual(ungated, [
     "persona:get-snapshot",
     "persona:hide",


### PR DESCRIPTION
## What

`electron/main.cjs` exposed ~20 `persona:settings-*` handlers with no sender
check, while every `persona:vroid-*` handler validated `event.sender`. Both
windows load the same preload, so the avatar window — which renders untrusted
VRM/VRMA files — held the full `personaSettings` surface: model deletion, the
developer flag, and the Linux plaintext-credential-storage switch.

Closes #43.

## Severity

Hardening, not an exploitable bug. Nothing reaches those handlers today: CSP
allows no script source but `'self'`, navigation is pinned to the renderer
entry, Electron does not load preloads into sub-frame
reaches `GLTFLoader`, which parses rather than executes. What holds the line is
the perimeter, not the handlers — and a KTX2/Draco lo
a sink.

## Approach

The check applies at registration through `createSettingsIpcGate` instead of as
a first line each handler has to remember, which is how these were missed.
`persona:vroid-*` moves onto the same wrapper and sheds its per-body guards;
handler bodies no longer see the event at all. `main.cjs` is net -14 lines.

A blanket guard would have broken the app: the avatar renderer calls
`persona:settings-get` and subscribes to updates, and the check throws when no
Settings window exists — the normal state with only the avatar open. So
`persona:settings-get` and the update broadcast stay open, and
`persona:settings-set-window-theme` keeps its silent drop, a `send` having no
reply channel to reject through.

## Tests

Both directions per channel, plus a pin that reads `main.cjs` and asserts the
exact set of channels reachable through a bare `ipcMain` registration — a
mutator added outside the gate now fails CI rather than review. Verified
non-vacuous against single quotes, `handleOnce`, and variable channel names.

Docs updated where `SECURITY.md`, `CONTRIBUTING.md`, and `docs/DEVELOPMENT.md`
each described a single sandboxed renderer.
