### PR TITLE
refactor: share expression fields between animation forms

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -312,6 +312,104 @@ function MillisecondRangeSlider({
   );
 }
 
+function expressionWeightFrom(input: HTMLInputElement): number | null {
+  const weight = input.valueAsNumber;
+  return Number.isFinite(weight) && weight >= 0 && weight <= 1 ? weight : null;
+}
+
+/** The expression overlay fields shared by the create and edit action forms. */
+function ExpressionFields({
+  metadata,
+  onChange,
+}: {
+  metadata: CustomAnimationMetadata;
+  onChange: (patch: Partial<CustomAnimationMetadata>) => void;
+}) {
+  return (
+    <>
+      <label>
+        Expression <code>expression_name</code>
+        <select
+          onChange={(event) =>
+            onChange({
+              expression_name:
+                (event.target.value as PersonaExpressionName) || null,
+            })
+          }
+          value={metadata.expression_name ?? ''}
+        >
+          <option value="">None</option>
+          {EXPRESSION_OPTIONS.map((expression) => (
+            <option key={expression} value={expression}>
+              {expression}
+            </option>
+          ))}
+        </select>
+        <small>
+          Blends a VRM expression over the face while the action plays.
+        </small>
+      </label>
+      {metadata.expression_name && (
+        <div className="expression-weight-field">
+          <div className="expression-weight-row">
+            <label>
+              <span>
+                Expression weight <code>expression_weight</code>
+              </span>
+              <input
+                className="single-range-slider"
+                max="1"
+                min="0"
+                onChange={(event) =>
+                  onChange({ expression_weight: Number(event.target.value) })
+                }
+                step="0.05"
+                style={singleRangeStyle(metadata.expression_weight, 0, 1)}
+                type="range"
+                value={metadata.expression_weight}
+              />
+              <div className="slider-labels">
+                <span>0.00</span>
+                <span>0.50</span>
+                <span>1.00</span>
+              </div>
+            </label>
+            {/* Out-of-range and half-typed values are ignored while editing,
+                then the field snaps back to the stored weight on blur. */}
+            <input
+              aria-label="Expression weight value"
+              className="expression-weight-value"
+              max="1"
+              min="0"
+              onBlur={(event) => {
+                const weight = expressionWeightFrom(event.currentTarget);
+                if (weight == null) {
+                  event.currentTarget.value = String(
+                    metadata.expression_weight,
+                  );
+                }
+              }}
+              onChange={(event) => {
+                const weight = expressionWeightFrom(event.currentTarget);
+                if (weight != null) onChange({ expression_weight: weight });
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') event.currentTarget.blur();
+              }}
+              step="0.05"
+              type="number"
+              value={metadata.expression_weight}
+            />
+          </div>
+          <small className="field-hint">
+            Between 0.00 (expression off) and 1.00 (full strength).
+          </small>
+        </div>
+      )}
+    </>
+  );
+}
+
 const SECTION_ICONS: Record<SettingsSection, ReactNode> = {
   models: (
     <Icon>
@@ -1839,6 +1937,19 @@ export function SettingsPage() {
                             <b>Trigger:</b>{' '}
                             {animation.animation_trigger_scenario}
                           </small>
+                          <small className="animation-card-expression">
+                            <b>Expression:</b>{' '}
+                            {animation.expression_name ? (
+                              <>
+                                {animation.expression_name}
+                                <span className="expression-weight-tag">
+                                  {animation.expression_weight.toFixed(2)}
+                                </span>
+                              </>
+                            ) : (
+                              'None'
+                            )}
+                          </small>
                         </div>
                         <div className="animation-card-actions">
                           {animation.editable && (
@@ -2016,44 +2127,15 @@ export function SettingsPage() {
                         }
                       />
                     </label>
-                    <label>
-                      Expression <code>expression_name</code>
-                      <select
-                        value={editingAnimationMetadata.expression_name ?? ''}
-                        onChange={(event) =>
-                          setEditingAnimationMetadata((current) => ({
-                            ...current,
-                            expression_name:
-                              (event.target.value as PersonaExpressionName) || null,
-                          }))
-                        }
-                      >
-                        <option value="">None</option>
-                        {EXPRESSION_OPTIONS.map((expression) => (
-                          <option key={expression} value={expression}>
-                            {expression}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    {editingAnimationMetadata.expression_name && (
-                      <label>
-                        Expression weight <code>expression_weight</code>
-                        <input
-                          type="number"
-                          min="0"
-                          max="1"
-                          step="0.05"
-                          value={editingAnimationMetadata.expression_weight}
-                          onChange={(event) =>
-                            setEditingAnimationMetadata((current) => ({
-                              ...current,
-                              expression_weight: Number(event.target.value),
-                            }))
-                          }
-                        />
-                      </label>
-                    )}
+                    <ExpressionFields
+                      metadata={editingAnimationMetadata}
+                      onChange={(patch) =>
+                        setEditingAnimationMetadata((current) => ({
+                          ...current,
+                          ...patch,
+                        }))
+                      }
+                    />
                   </div>
                   <div className="form-actions">
                     <button
@@ -2142,44 +2224,15 @@ export function SettingsPage() {
                       value={animationMetadata.animation_trigger_scenario}
                     />
                   </label>
-                  <label>
-                    Expression <code>expression_name</code>
-                    <select
-                      value={animationMetadata.expression_name ?? ''}
-                      onChange={(event) =>
-                        setAnimationMetadata((current) => ({
-                          ...current,
-                          expression_name:
-                            (event.target.value as PersonaExpressionName) || null,
-                        }))
-                      }
-                    >
-                      <option value="">None</option>
-                      {EXPRESSION_OPTIONS.map((expression) => (
-                        <option key={expression} value={expression}>
-                          {expression}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  {animationMetadata.expression_name && (
-                    <label>
-                      Expression weight <code>expression_weight</code>
-                      <input
-                        type="number"
-                        min="0"
-                        max="1"
-                        step="0.05"
-                        value={animationMetadata.expression_weight}
-                        onChange={(event) =>
-                          setAnimationMetadata((current) => ({
-                            ...current,
-                            expression_weight: Number(event.target.value),
-                          }))
-                        }
-                      />
-                    </label>
-                  )}
+                  <ExpressionFields
+                    metadata={animationMetadata}
+                    onChange={(patch) =>
+                      setAnimationMetadata((current) => ({
+                        ...current,
+                        ...patch,
+                      }))
+                    }
+                  />
                 </div>
                 <button
                   className="primary-button"

--- a/src/styles.css
+++ b/src/styles.css
@@ -114,6 +114,8 @@
   --slider-thumb-shadow:
     0 1px 3px rgba(0, 0, 0, 0.45),
     0 0 0 1px rgba(0, 0, 0, 0.25);
+  /* Select chevron, drawn as an image so the stroke follows the theme. */
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1.2 5 4.8 9 1.2' fill='none' stroke='%238d93a4' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   --backdrop: rgba(6, 7, 10, 0.6);
 
   /* Elevation */
@@ -185,6 +187,7 @@
   --slider-thumb-shadow:
     0 1px 2px rgba(19, 22, 28, 0.28),
     0 0 0 1px rgba(19, 22, 28, 0.16);
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1.2 5 4.8 9 1.2' fill='none' stroke='%235e646f' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   --backdrop: rgba(22, 25, 32, 0.34);
 
   --shadow-card: 0 1px 2px rgba(19, 22, 28, 0.06);
@@ -823,8 +826,10 @@ button {
   font-weight: 400;
 }
 
-.import-panel input,
-.form-stack input,
+/* Range inputs bring their own chrome — see .single-range-slider. */
+.import-panel input:not([type="range"]),
+.form-stack input:not([type="range"]),
+.form-stack select,
 .form-stack textarea {
   width: 100%;
   border: 1px solid var(--border-strong);
@@ -839,10 +844,22 @@ button {
     box-shadow var(--dur) var(--ease);
 }
 
-.import-panel input,
-.form-stack input {
+.import-panel input:not([type="range"]),
+.form-stack input:not([type="range"]),
+.form-stack select {
   height: 34px;
   padding: 0 11px;
+}
+
+.form-stack select {
+  padding-right: 32px;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: var(--select-chevron);
+  background-repeat: no-repeat;
+  background-position: right 11px center;
+  background-size: 10px 6px;
+  cursor: pointer;
 }
 
 .form-stack textarea {
@@ -858,26 +875,69 @@ button {
   color: var(--text-tertiary);
 }
 
-.import-panel input:hover,
-.form-stack input:hover,
+.import-panel input:not([type="range"]):hover,
+.form-stack input:not([type="range"]):hover,
+.form-stack select:hover,
 .form-stack textarea:hover {
   border-color: var(--border-strong);
 }
 
-.import-panel input:focus,
-.form-stack input:focus,
+.import-panel input:not([type="range"]):focus,
+.form-stack input:not([type="range"]):focus,
+.form-stack select:focus,
 .form-stack textarea:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 /* Hint text under a field. */
-.form-stack label > small {
+.form-stack label > small,
+.form-stack .field-hint {
   max-width: 62ch;
   color: var(--text-tertiary);
   font-size: var(--fs-xs);
   font-weight: 400;
   line-height: 1.55;
+}
+
+/* Slider field: drag on the left, type an exact value on the right. */
+.expression-weight-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.expression-weight-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.expression-weight-field label {
+  flex: 1;
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+.expression-weight-field .single-range-slider,
+.expression-weight-field .slider-labels {
+  width: 100%;
+}
+
+.expression-weight-field .single-range-slider {
+  margin-top: 0;
+}
+
+.expression-weight-field input.expression-weight-value {
+  flex: 0 0 auto;
+  width: 76px;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 /* --- Empty states -------------------------------------------------------- */
@@ -1119,6 +1179,17 @@ button {
 .animation-card-copy b {
   color: var(--text-secondary);
   font-weight: 500;
+}
+
+.animation-card-expression .expression-weight-tag {
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  background: var(--fill-subtle);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-variant-numeric: tabular-nums;
 }
 
 .animation-clips {


### PR DESCRIPTION
Refs #35

## Summary
- Extract the duplicated `expression_name` / `expression_weight` fields from the create and edit action forms into a shared `ExpressionFields` component
- Add a numeric input alongside the weight slider for entering exact values
- Style form `<select>` elements (custom chevron, consistent height/padding) to match the rest of the form-stack

## Test plan
- [x] Open Settings → create a new animation action, pick an expression, verify slider and numeric input stay in sync and reject out-of-range/invalid values on blur
- [x] Edit an existing action's expression the same way
- [x] Verify the animation card shows the expression name + weight tag correctly
- [x] Check select dropdown styling in both light and dark themes