### PR TITLE
feat: support model-specific VRM expressions

### DIFF
--- a/electron/library-catalog.cjs
+++ b/electron/library-catalog.cjs
@@ -15,14 +15,6 @@ const ANIMATION_TYPES = new Set([
   "DANCE",
 ]);
 
-const EXPRESSION_NAMES = new Set([
-  'happy',
-  'angry',
-  'sad',
-  'relaxed',
-  'surprised',
-]);
-
 const SYSTEM_ANIMATIONS = Object.freeze([
   Object.freeze({
     id: "system-idle",
@@ -147,7 +139,11 @@ function validatePackagedLibrary(value) {
     const expression_name = animation?.expression_name ?? null;
     if (
       expression_name !== null &&
-      !EXPRESSION_NAMES.has(expression_name)
+      (
+        typeof expression_name !== 'string' ||
+        expression_name.trim().length === 0 ||
+        expression_name.length > 120
+      )
     ) {
       throw new Error(
         `Invalid packaged expression name: ${expression_name}.`,

--- a/electron/library-catalog.test.cjs
+++ b/electron/library-catalog.test.cjs
@@ -276,7 +276,7 @@ test("rejects invalid packaged animation expression metadata", () => {
         animations: [
           {
             ...animation,
-            expression_name: "smirk",
+            expression_name: "x".repeat(121),
           },
         ],
       }),

--- a/electron/settings-store.cjs
+++ b/electron/settings-store.cjs
@@ -44,13 +44,6 @@ const DEFAULT_SPEAKING_DEBOUNCE_MS = 350;
 const DEFAULT_IDLE_INTERIM_MS = 350;
 const MIN_SCHEDULER_DELAY_MS = 0;
 const MAX_SCHEDULER_DELAY_MS = 3000;
-const STANDARD_VRM_EXPRESSIONS = new Set([
-  "happy",
-  "angry",
-  "sad",
-  "relaxed",
-  "surprised",
-]);
 const ASSET_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DEFAULT_MODEL_LIGHTING = Object.freeze({
@@ -207,14 +200,22 @@ function singleLine(value, field, maxLength) {
 
 function optionalExpressionName(value) {
   if (value == null || value === "") return null;
+
   if (typeof value !== "string") {
     throw new Error("Expression must be a string.");
   }
-  const normalized = value.trim().toLowerCase();
-  if (!STANDARD_VRM_EXPRESSIONS.has(normalized)) {
-    throw new Error("Expression must be happy, angry, sad, relaxed, or surprised.");
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
   }
-  return normalized;
+
+  if (trimmed.length > 120) {
+    throw new Error("Expression must be 120 characters or fewer.");
+  }
+
+  return trimmed;
 }
 
 function expressionWeight(value) {

--- a/electron/settings-store.test.cjs
+++ b/electron/settings-store.test.cjs
@@ -878,14 +878,40 @@ test("validates animation expression metadata", () => {
     },
   );
 
+  assert.deepEqual(
+    validateAnimationMetadata({
+      ...base,
+      expression_name: "Blush",
+      expression_weight: 1,
+    }),
+    {
+      ...base,
+      expression_name: "Blush",
+      expression_weight: 1,
+    },
+  );
+
+  assert.deepEqual(
+    validateAnimationMetadata({
+      ...base,
+      expression_name: "   ",
+      expression_weight: 1,
+    }),
+    {
+      ...base,
+      expression_name: null,
+      expression_weight: 1,
+    },
+  );
+
   assert.throws(
     () =>
       validateAnimationMetadata({
         ...base,
-        expression_name: "smirk",
+        expression_name: "x".repeat(121),
         expression_weight: 1,
       }),
-    /Expression must be/,
+    /120 characters or fewer/,
   );
 
   assert.throws(
@@ -917,19 +943,19 @@ test("persists animation expression metadata", (context) => {
   });
 
   let snapshot = store.createAnimation({
-    animation_name: "sad-action",
-    animation_description: "A sad action.",
-    animation_trigger_scenario: "Use when sad.",
-    expression_name: "sad",
+    animation_name: "embarrassed",
+    animation_description: "An embarrassed action.",
+    animation_trigger_scenario: "Use when embarrassed.",
+    expression_name: "Blush",
     expression_weight: 0.8,
   });
 
   let animation = snapshot.animations.find(
-    (candidate) => candidate.animation_name === "sad-action",
+    (candidate) => candidate.animation_name === "embarrassed",
   );
 
   assert.ok(animation);
-  assert.equal(animation.expression_name, "sad");
+  assert.equal(animation.expression_name, "Blush");
   assert.equal(animation.expression_weight, 0.8);
 
   const reloaded = createSettingsStore({
@@ -938,10 +964,10 @@ test("persists animation expression metadata", (context) => {
   }).getSnapshot();
 
   animation = reloaded.animations.find(
-    (candidate) => candidate.animation_name === "sad-action",
+    (candidate) => candidate.animation_name === "embarrassed",
   );
 
   assert.ok(animation);
-  assert.equal(animation.expression_name, "sad");
+  assert.equal(animation.expression_name, "Blush");
   assert.equal(animation.expression_weight, 0.8);
 });

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -95,7 +95,10 @@ interface AvatarProps {
   modelUrl: string;
   onAnimationComplete: () => void;
 
-  onExpressionsChange?: (expressions: readonly string[]) => void;
+  onExpressionsChange?: (
+    modelUrl: string,
+    expressions: readonly string[],
+  ) => void;
 
   playback: 'loop' | 'once';
   speaking: boolean;
@@ -152,8 +155,8 @@ function AvatarModel({
         (expression) => expression.expressionName,
       ) ?? [];
 
-    onExpressionsChange?.(expressions);
-  }, [onExpressionsChange, vrm]);
+    onExpressionsChange?.(modelUrl, expressions);
+  }, [modelUrl, onExpressionsChange, vrm]);
 
   const animationUrlsKey = animationUrlSignature(animationUrls);
   const stableAnimationUrls = useMemo(

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -94,6 +94,9 @@ interface AvatarProps {
   dragInertia?: DragInertiaState;
   modelUrl: string;
   onAnimationComplete: () => void;
+
+  onExpressionsChange?: (expressions: readonly string[]) => void;
+
   playback: 'loop' | 'once';
   speaking: boolean;
   bodyTransitionMs: number;
@@ -116,6 +119,7 @@ function AvatarModel({
   dragInertia,
   modelUrl,
   onAnimationComplete,
+  onExpressionsChange,
   playback,
   speaking,
   bodyTransitionMs,
@@ -141,6 +145,15 @@ function AvatarModel({
     expressionName,
     expressionWeight,
   );
+
+  useEffect(() => {
+    const expressions =
+      vrm?.expressionManager?.expressions.map(
+        (expression) => expression.expressionName,
+      ) ?? [];
+
+    onExpressionsChange?.(expressions);
+  }, [onExpressionsChange, vrm]);
 
   const animationUrlsKey = animationUrlSignature(animationUrls);
   const stableAnimationUrls = useMemo(

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -23,7 +23,10 @@ interface SceneProps {
   expressionWeight?: number;
   audioLevel: number;
   bodySpeaking: boolean;
-  onExpressionsChange?: (expressions: readonly string[]) => void;
+  onExpressionsChange?: (
+    modelUrl: string,
+    expressions: readonly string[],
+  ) => void;
   characterSize: number;
   dragInertia?: DragInertiaState;
   enablePan?: boolean;

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -23,6 +23,7 @@ interface SceneProps {
   expressionWeight?: number;
   audioLevel: number;
   bodySpeaking: boolean;
+  onExpressionsChange?: (expressions: readonly string[]) => void;
   characterSize: number;
   dragInertia?: DragInertiaState;
   enablePan?: boolean;

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -55,13 +55,21 @@ const LIGHTING_NUMBER_RANGES: Record<
   ambient_intensity: [0, 4],
 };
 
-const EXPRESSION_OPTIONS: PersonaExpressionName[] = [
-  'happy',
-  'angry',
-  'sad',
-  'relaxed',
-  'surprised',
-];
+const SYSTEM_EXPRESSION_NAMES = new Set([
+  'neutral',
+  'aa',
+  'ih',
+  'ou',
+  'ee',
+  'oh',
+  'blink',
+  'blinkLeft',
+  'blinkRight',
+  'lookUp',
+  'lookDown',
+  'lookLeft',
+  'lookRight',
+]);
 
 interface ConfirmationRequest {
   confirmLabel: string;
@@ -321,10 +329,17 @@ function expressionWeightFrom(input: HTMLInputElement): number | null {
 function ExpressionFields({
   metadata,
   onChange,
+  availableExpressions,
 }: {
   metadata: CustomAnimationMetadata;
   onChange: (patch: Partial<CustomAnimationMetadata>) => void;
+  availableExpressions: readonly string[];
 }) {
+
+  const expressionOptions = availableExpressions.filter(
+    (expression) => !SYSTEM_EXPRESSION_NAMES.has(expression),
+  );
+
   return (
     <>
       <label>
@@ -332,14 +347,13 @@ function ExpressionFields({
         <select
           onChange={(event) =>
             onChange({
-              expression_name:
-                (event.target.value as PersonaExpressionName) || null,
+              expression_name: event.target.value || null,
             })
           }
           value={metadata.expression_name ?? ''}
         >
           <option value="">None</option>
-          {EXPRESSION_OPTIONS.map((expression) => (
+          {expressionOptions.map((expression) => (
             <option key={expression} value={expression}>
               {expression}
             </option>
@@ -506,6 +520,8 @@ export function SettingsPage() {
   );
   const [previewAnimation, setPreviewAnimation] =
     useState<PersonaAnimationSettings | null>(null);
+  const [availableExpressions, setAvailableExpressions] =
+    useState<readonly string[]>([]);
   const [previewClipId, setPreviewClipId] = useState<string | null>(null);
   const [previewRequest, setPreviewRequest] = useState(0);
   const [modelName, setModelName] = useState('');
@@ -2135,6 +2151,7 @@ export function SettingsPage() {
                           ...patch,
                         }))
                       }
+                      availableExpressions={availableExpressions}
                     />
                   </div>
                   <div className="form-actions">
@@ -2232,6 +2249,7 @@ export function SettingsPage() {
                         ...patch,
                       }))
                     }
+                    availableExpressions={availableExpressions}
                   />
                 </div>
                 <button
@@ -3541,6 +3559,7 @@ export function SettingsPage() {
                   fallbackAnimationUrls={idleAnimationUrls}
                   expressionName={previewExpression.expressionName}
                   expressionWeight={previewExpression.expressionWeight}
+                  onExpressionsChange={setAvailableExpressions}
                   audioLevel={0}
                   bodySpeaking={previewType === 'TALK'}
                   characterSize={settings.character_size}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -31,6 +31,10 @@ import {
   type ThemePreference,
 } from '../theme';
 import { vroidLicenseRows } from '../vroid-license-fields';
+import {
+  expressionsForModel,
+  type ModelExpressionReport,
+} from '../model-expression-catalog';
 
 type SettingsSection =
   | 'models'
@@ -520,8 +524,8 @@ export function SettingsPage() {
   );
   const [previewAnimation, setPreviewAnimation] =
     useState<PersonaAnimationSettings | null>(null);
-  const [availableExpressions, setAvailableExpressions] =
-    useState<readonly string[]>([]);
+  const [expressionReport, setExpressionReport] =
+    useState<ModelExpressionReport | null>(null);
   const [previewClipId, setPreviewClipId] = useState<string | null>(null);
   const [previewRequest, setPreviewRequest] = useState(0);
   const [modelName, setModelName] = useState('');
@@ -676,6 +680,16 @@ export function SettingsPage() {
     settings.models.find((model) => model.id === selectedModelId) ??
     settings.models.find((model) => model.id === settings.default_model_id) ??
     settings.models[0];
+  const availableExpressions = expressionsForModel(
+    expressionReport,
+    selectedModel?.asset_url ?? null,
+  );
+  const handleExpressionsChange = useCallback(
+    (modelUrl: string, expressions: readonly string[]) => {
+      setExpressionReport({ modelUrl, expressions });
+    },
+    [],
+  );
 
   const customModelCount = settings.models.filter(
     (model) => model.origin === 'user',
@@ -3559,7 +3573,7 @@ export function SettingsPage() {
                   fallbackAnimationUrls={idleAnimationUrls}
                   expressionName={previewExpression.expressionName}
                   expressionWeight={previewExpression.expressionWeight}
-                  onExpressionsChange={setAvailableExpressions}
+                  onExpressionsChange={handleExpressionsChange}
                   audioLevel={0}
                   bodySpeaking={previewType === 'TALK'}
                   characterSize={settings.character_size}

--- a/src/model-expression-catalog.test.ts
+++ b/src/model-expression-catalog.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { expressionsForModel } from './model-expression-catalog';
+
+describe('expressionsForModel', () => {
+  it('only exposes expressions reported by the selected model', () => {
+    const report = {
+      modelUrl: 'persona-library://models/first',
+      expressions: ['happy', 'surprised'],
+    };
+
+    expect(
+      expressionsForModel(report, 'persona-library://models/first'),
+    ).toEqual(['happy', 'surprised']);
+    expect(
+      expressionsForModel(report, 'persona-library://models/second'),
+    ).toEqual([]);
+  });
+
+  it('keeps a stale report hidden until the newly selected model reports', () => {
+    const staleReport = {
+      modelUrl: 'persona-library://models/first',
+      expressions: ['customFirst'],
+    };
+
+    expect(
+      expressionsForModel(staleReport, 'persona-library://models/second'),
+    ).toEqual([]);
+
+    const currentReport = {
+      modelUrl: 'persona-library://models/second',
+      expressions: ['customSecond'],
+    };
+    expect(
+      expressionsForModel(currentReport, 'persona-library://models/second'),
+    ).toEqual(['customSecond']);
+  });
+});

--- a/src/model-expression-catalog.ts
+++ b/src/model-expression-catalog.ts
@@ -1,0 +1,11 @@
+export interface ModelExpressionReport {
+  expressions: readonly string[];
+  modelUrl: string;
+}
+
+export function expressionsForModel(
+  report: ModelExpressionReport | null,
+  modelUrl: string | null,
+): readonly string[] {
+  return report?.modelUrl === modelUrl ? report.expressions : [];
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -44,12 +44,7 @@ type PersonaAnimationType =
   | 'DANCE';
 
 
-type PersonaExpressionName =
-  | 'happy'
-  | 'angry'
-  | 'sad'
-  | 'relaxed'
-  | 'surprised';
+type PersonaExpressionName = string;
 
 interface PersonaModelSettings {
   id: string;


### PR DESCRIPTION
## Summary

Adds support for model-specific VRM expressions in animation actions.

Instead of limiting actions to a fixed set of standard VRM expressions, Persona now reads the expressions available from the currently selected VRM and exposes them in Settings.

## Changes

- Read available expressions from the loaded VRM.
- Expose model-specific expressions in the action expression selector.
- Filter system-controlled expressions such as mouth shapes, blink, and look directions.
- Preserve the exact expression name and casing provided by the VRM.
- Allow custom expressions such as `Blush`.
- Allow settings and packaged-library metadata to preserve model-specific expression names.
- Preserve custom expression names across save/reload.
- Add tests covering custom expression validation and persistence.

## Example

A model that provides `Blush` can now use that expression on an action such as `embarrassed`.

A different model without `Blush` can still use the same action without relying on a fixed expression preset list.

## Validation

- `electron/settings-store.test.cjs`: 17/17 passed
- `electron/library-catalog.test.cjs`: 8/8 passed
- `npm run check` passes locally
- Manually verified expression discovery and action playback with both the packaged default VRM and a custom VRM.