### PR TITLE
feat: split VRoid Hub picker into owned and hearted groups

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -229,7 +229,9 @@ Otherwise the feature stays disabled rather than storing either in plaintext.
 With no credentials configured, "Connect VRoid Hub account" in Settings stays
 disabled. When configured, Settings opens the VRoid Hub authorization page in
 your system browser (PKCE + confidential client), then lists characters the
-signed-in account owns or has hearted and marked available to other users.
+signed-in account owns, plus the ones it has hearted whose creator marked
+them available to other users, under separate "Your models" and "Hearted
+models" headings.
 Selecting one fetches its VRM bytes through VRoid Hub's licensed
 `download_licenses` flow and holds them in memory for the running session —
 Persona does not write a hub-sourced model to disk as an ordinary, freely

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -170,6 +170,83 @@ function VroidCharacterPortrait({
   );
 }
 
+function VroidCharacterCard({
+  busy,
+  character,
+  onSelect,
+  portraitEpoch,
+}: {
+  busy: boolean;
+  character: PersonaVroidHubCharacter;
+  onSelect: () => void;
+  // Used as the portrait's key: a refresh remounts it to retry a failed load.
+  portraitEpoch: number;
+}) {
+  return (
+    <article className="asset-card">
+      <VroidCharacterPortrait character={character} key={portraitEpoch} />
+      <span className="asset-card-main">
+        <span>
+          <strong>{character.name}</strong>
+          <small>
+            {character.is_downloadable ? 'Downloadable on Hub' : 'Hub only'}
+          </small>
+        </span>
+      </span>
+      <div className="asset-card-footer">
+        <button disabled={busy} onClick={onSelect} type="button">
+          Use this character
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function VroidCharacterGroup({
+  busy,
+  characters,
+  emptyNote,
+  note,
+  onSelect,
+  portraitEpoch,
+  title,
+}: {
+  busy: boolean;
+  characters: PersonaVroidHubCharacter[];
+  emptyNote: string;
+  note?: string;
+  onSelect: (character: PersonaVroidHubCharacter) => void;
+  portraitEpoch: number;
+  title: string;
+}) {
+  return (
+    <div className="vroid-character-group">
+      <h3>
+        {title}
+        <span className="count-badge">{characters.length}</span>
+      </h3>
+      {characters.length === 0 ? (
+        <p className="desktop-note">{emptyNote}</p>
+      ) : (
+        <>
+          {note && <p className="desktop-note">{note}</p>}
+          <div className="asset-grid">
+            {characters.map((character) => (
+              <VroidCharacterCard
+                busy={busy}
+                character={character}
+                key={character.id}
+                onSelect={() => onSelect(character)}
+                portraitEpoch={portraitEpoch}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 function vroidConditionsOfUse(
   character: PersonaVroidHubCharacter,
   onOpenHubPage: (() => void) | null,
@@ -646,6 +723,17 @@ export function SettingsPage() {
     if (vroidStatus?.connected) void refreshVroidCharacters();
     else setVroidCharacters(null);
   }, [vroidStatus?.connected, refreshVroidCharacters]);
+
+  const ownVroidCharacters = useMemo(
+    () => vroidCharacters?.filter((character) => character.origin === 'own') ?? [],
+    [vroidCharacters],
+  );
+  const heartedVroidCharacters = useMemo(
+    () =>
+      vroidCharacters?.filter((character) => character.origin === 'hearted') ??
+      [],
+    [vroidCharacters],
+  );
 
   useEffect(() => {
     setVoiceMode(settings.voice_source.mode);
@@ -1844,48 +1932,41 @@ export function SettingsPage() {
                 )}
                 {vroidHubBridge && vroidStatus?.connected && (
                   <>
-                    <div className="asset-grid">
-                      {vroidLoading && <p>Loading your characters…</p>}
-                      {!vroidLoading && vroidCharacters?.length === 0 && (
-                        <div className="empty-library">
-                          <strong>No characters available yet</strong>
-                          <p>
-                            Mark a character available to other users on
-                            VRoid Hub, or heart one that already is, then
-                            refresh.
-                          </p>
-                        </div>
-                      )}
-                      {vroidCharacters?.map((character) => (
-                        <article className="asset-card" key={character.id}>
-                          <VroidCharacterPortrait
-                            character={character}
-                            key={vroidPortraitEpoch}
-                          />
-                          <span className="asset-card-main">
-                            <span>
-                              <strong>{character.name}</strong>
-                              <small>
-                                {character.is_downloadable
-                                  ? 'Downloadable on Hub'
-                                  : 'Hub only'}
-                              </small>
-                            </span>
-                          </span>
-                          <div className="asset-card-footer">
-                            <button
-                              disabled={busy}
-                              onClick={() =>
-                                void selectVroidCharacter(character)
-                              }
-                              type="button"
-                            >
-                              Use this character
-                            </button>
-                          </div>
-                        </article>
-                      ))}
-                    </div>
+                    {vroidLoading && <p>Loading your characters…</p>}
+                    {/* Neither branch below is gated on !vroidLoading: a
+                        refresh returns what's already on screen, so leaving it
+                        up avoids collapsing the panel under the user. */}
+                    {vroidCharacters?.length === 0 && (
+                      <div className="empty-library">
+                        <strong>No characters available yet</strong>
+                        <p>
+                          Upload a model to VRoid Hub, or heart one that its
+                          creator marked available to other users, then
+                          refresh.
+                        </p>
+                      </div>
+                    )}
+                    {(vroidCharacters?.length ?? 0) > 0 && (
+                      <>
+                        <VroidCharacterGroup
+                          busy={busy}
+                          characters={ownVroidCharacters}
+                          emptyNote="You haven’t uploaded any models to VRoid Hub yet."
+                          onSelect={selectVroidCharacter}
+                          portraitEpoch={vroidPortraitEpoch}
+                          title="Your models"
+                        />
+                        <VroidCharacterGroup
+                          busy={busy}
+                          characters={heartedVroidCharacters}
+                          emptyNote="Heart a model another creator marked available to other users and it shows up here."
+                          note="These belong to other creators. Persona asks you to confirm a model’s conditions of use before it downloads one."
+                          onSelect={selectVroidCharacter}
+                          portraitEpoch={vroidPortraitEpoch}
+                          title="Hearted models"
+                        />
+                      </>
+                    )}
                     <div className="form-actions">
                       <button
                         className="secondary-button"

--- a/src/styles.css
+++ b/src/styles.css
@@ -781,7 +781,8 @@ button {
 /* --- Badges -------------------------------------------------------------- */
 
 .file-pill,
-.default-badge {
+.default-badge,
+.count-badge {
   display: inline-flex;
   align-items: center;
   height: 22px;
@@ -800,6 +801,12 @@ button {
   border-color: var(--accent-border);
   color: var(--accent-text);
   background: var(--accent-soft);
+}
+
+.count-badge {
+  height: 20px;
+  padding: 0 7px;
+  color: var(--text-tertiary);
 }
 
 /* --- Fields -------------------------------------------------------------- */
@@ -1095,6 +1102,30 @@ button {
   min-height: 40px;
   padding: 6px 10px;
   border-top: 1px solid var(--border);
+}
+
+/* --- VRoid Hub character groups ------------------------------------------ */
+
+.vroid-character-group {
+  margin-top: 22px;
+}
+
+.vroid-character-group > h3 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  letter-spacing: -0.004em;
+}
+
+.vroid-character-group > .desktop-note {
+  margin-top: 0;
+}
+
+.vroid-character-group > .desktop-note + .asset-grid {
+  margin-top: 12px;
 }
 
 /* --- Animation action cards ---------------------------------------------- */


### PR DESCRIPTION
Closes #52

## What changed

The VRoid Hub picker in Settings rendered owned and hearted models in one
flat grid. This splits it into two headed groups — "Your models" and
"Hearted models" — each with its own count and grid, sharing one connection
status and one set of Refresh / Disconnect controls.

- `VroidCharacterCard` and `VroidCharacterGroup` are extracted so the card
  and group markup are each defined once.
- Each group carries its own empty state, so an account with hearts but no
  uploads gets an accurate explanation instead of one message covering both
  cases.
- The hearted group states that those models belong to other creators and
  will ask for conditions-of-use confirmation, making an existing behaviour
  predictable before the click rather than after it.

## Why

`origin` already distinguishes the two, and the distinction already drives
behaviour: selecting a hearted model opens the Model Data Conditions of Use
confirmation that VRoid Hub's third-party integration guidelines require,
while an owned model is used directly. Nothing in the UI signalled that.

## Scope

Presentation only. `origin` is already on the IPC payload, so no API, IPC,
or `vroid-hub-client` changes were needed. The conditions-of-use gate itself
is untouched and still fires for exactly the models under "Hearted models".

## Copy correction

The empty-state text implied owned models need `is_other_users_available`
to be listed. They do not — `listCharacters` filters only hearts on that
flag and lists owned models unfiltered. `docs/INTEGRATIONS.md` carried the
same conflation and is corrected alongside.

## Validation

`npm run check` passes: lint, 161 Node tests, 99 renderer tests, the asset
contract, a clean production audit, and the renderer build.

No test references the changed markup, so the passing suites show no
regression rather than coverage of the new grouping.

## Screenshots

Not included — the panel only renders with a connected VRoid Hub account and
OAuth app credentials, which this environment does not have. Happy to add
one if a maintainer wants it before merge.
