### PR TITLE
fix: allow unsigned macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
   package:
     name: Package ${{ matrix.name }}
     needs: release-gate
+    env:
+      MAC_SIGNING_AVAILABLE: ${{ secrets.MAC_CSC_LINK != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -79,16 +81,28 @@ jobs:
       - name: Lint and test
         run: npm run check
 
-      - name: Build native installer
+      - name: Build signed macOS installer
+        if: matrix.platform == 'macos' && env.MAC_SIGNING_AVAILABLE == 'true'
         run: ${{ matrix.command }}
         env:
-          CSC_LINK: ${{ matrix.platform == 'macos' && secrets.MAC_CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.platform == 'macos' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
-          APPLE_ID: ${{ matrix.platform == 'macos' && secrets.APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'macos' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.platform == 'macos' && secrets.APPLE_TEAM_ID || '' }}
-          WIN_CSC_LINK: ${{ matrix.platform == 'windows' && secrets.WIN_CSC_LINK || '' }}
-          WIN_CSC_KEY_PASSWORD: ${{ matrix.platform == 'windows' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Build unsigned macOS installer
+        if: matrix.platform == 'macos' && env.MAC_SIGNING_AVAILABLE != 'true'
+        run: ${{ matrix.command }}
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Build non-macOS installer
+        if: matrix.platform != 'macos'
+        run: ${{ matrix.command }}
+        env:
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
       - name: Upload installers
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Detect whether macOS signing credentials are available and preserve the existing signed/notarized build path when they are.
- Disable Electron signing identity auto-discovery for unsigned macOS validation builds, while keeping non-macOS packaging on its own step.
- Avoid passing empty signing variables that electron-builder interprets as an invalid signing file.

## Test plan
- [x] `npm run check`
- [x] `npm run assets:release`
- [x] Rebased onto current `main`; `git diff --check` passes
- [x] Validated the same workflow change through the private [`v0.1.0-beta.1`](https://github.com/xikhar/persona-ci/releases/tag/v0.1.0-beta.1) release: Linux x64, Windows x64, macOS arm64, macOS x64, checksums, and release publication all succeeded

No public release was triggered.

Made with [Cursor](https://cursor.com)