### PR TITLE
feat(settings): polish the settings interface

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -24,6 +24,7 @@ import { useThemePreference } from '../hooks/useThemePreference';
 import { errorMessage } from '../settings-errors';
 import {
   SECTIONS,
+  sectionSummary,
   settingsSection,
   type SettingsSection,
 } from '../settings-sections';
@@ -242,13 +243,6 @@ export function SettingsPage() {
     },
     [],
   );
-
-  const customModelCount = settings.models.filter(
-    (model) => model.origin === 'user',
-  ).length;
-  const customAnimationCount = settings.animations.filter(
-    (animation) => animation.origin === 'user',
-  ).length;
 
   const previewType: PlayableAnimationType =
     previewAnimation?.animation_type ??
@@ -471,28 +465,32 @@ export function SettingsPage() {
     }
   };
 
-  const importModel = async () => {
-    if (!bridge) return;
+  const importModel = async (): Promise<boolean> => {
+    if (!bridge) return false;
     const existingModelIds = new Set(settings.models.map((model) => model.id));
     const snapshot = await run(
       () => bridge.importModel({ model_name: modelName }),
       'Model added to your library.',
     );
-    if (!snapshot) return;
+    // `null` is a cancelled file picker, not a failure: keep the dialog open
+    // with the typed name so choosing again does not start over.
+    if (!snapshot) return false;
     const imported = snapshot.models.find(
       (model) => !existingModelIds.has(model.id),
     );
     if (imported) setSelectedModelId(imported.id);
     setModelName('');
+    return true;
   };
 
-  const createAnimation = async () => {
-    if (!bridge) return;
+  const createAnimation = async (): Promise<boolean> => {
+    if (!bridge) return false;
     const snapshot = await run(
       () => bridge.createAnimation(animationMetadata),
       'Animation action created. Add one or more VRMA clips to make it playable.',
     );
-    if (!snapshot) return;
+    // A rejected name keeps the dialog open so it can be corrected in place.
+    if (!snapshot) return false;
     setAnimationMetadata({
       animation_name: '',
       animation_description: '',
@@ -500,6 +498,7 @@ export function SettingsPage() {
       expression_name: null,
       expression_weight: 1,
     });
+    return true;
   };
 
   const addAnimationClips = async (animation: PersonaAnimationSettings) => {
@@ -1062,18 +1061,26 @@ export function SettingsPage() {
       ),
     );
 
-  const headingSummary =
-    section === 'mcp'
-      ? mcpStatus
-        ? `${mcpStatus.tools.length} tools · ${mcpStatus.playable_actions.length} playable actions`
-        : 'Local agent connection'
-      : section === 'voice'
-        ? voiceHeading
-        : section === 'developer'
-          ? settings.developer_settings_enabled
-            ? 'Developer settings enabled'
-            : 'Developer settings locked'
-        : `${customModelCount} custom models · ${customAnimationCount} custom actions`;
+  const headingSummary = sectionSummary(section, {
+    avatarWindow: settings.avatar_window,
+    characterSize: settings.character_size,
+    clipCount: settings.animations.reduce(
+      (total, animation) => total + animation.clips.length,
+      0,
+    ),
+    developerEnabled: settings.developer_settings_enabled,
+    mcp: mcpStatus
+      ? {
+          playableActions: mcpStatus.playable_actions.length,
+          tools: mcpStatus.tools.length,
+        }
+      : null,
+    modelCount: settings.models.length,
+    playableActionCount: settings.animations.filter(
+      (animation) => animation.asset_urls.length > 0,
+    ).length,
+    voiceHeading,
+  });
   const mcpHealth = mcpStatus?.health ?? (mcpLoading ? 'starting' : 'unavailable');
   const mcpServerUrl =
     mcpStatus?.server_url ?? 'http://127.0.0.1:47831/mcp';
@@ -1118,7 +1125,6 @@ export function SettingsPage() {
         </nav>
 
         <div className="settings-sidebar-status">
-          <span className="status-dot" />
           <span className="settings-status-copy">Changes save automatically</span>
         </div>
       </aside>
@@ -1129,11 +1135,13 @@ export function SettingsPage() {
         tabIndex={-1}
       >
         <header className="settings-heading">
-          <div>
-            <span className="eyebrow">{settingsSection(section).eyebrow}</span>
-            <h1>{settingsSection(section).label}</h1>
+          <div className="settings-heading-inner">
+            <div>
+              <span className="eyebrow">{settingsSection(section).eyebrow}</span>
+              <h1>{settingsSection(section).label}</h1>
+            </div>
+            <span className="library-count">{headingSummary}</span>
           </div>
-          <span className="library-count">{headingSummary}</span>
         </header>
 
         {notice && (
@@ -1313,14 +1321,8 @@ export function SettingsPage() {
         {!previewCollapsed && (
           <>
             <div className="preview-header">
-              <div>
-                <span className="eyebrow">Live preview</span>
-                <strong>{selectedModel?.model_name ?? 'Persona'}</strong>
-              </div>
-              <span className="preview-live">
-                <i />
-                Live
-              </span>
+              <strong>{selectedModel?.model_name ?? 'Persona'}</strong>
+              <span className="chip chip-success">Live</span>
             </div>
             <div className="preview-stage" data-testid="settings-preview">
               {selectedModel && (
@@ -1356,13 +1358,15 @@ export function SettingsPage() {
                 Drag to rotate · Scroll to zoom
               </div>
             </div>
-            <div className="preview-now-playing">
-              <span>Now previewing</span>
-              <strong>{previewTitle}</strong>
-              {previewAnimation && (
-                <small>{previewAnimation.animation_description}</small>
-              )}
-            </div>
+            {previewClip && (
+              <div className="preview-now-playing">
+                <span>Now playing</span>
+                <strong>{previewTitle}</strong>
+                {previewAnimation && (
+                  <small>{previewAnimation.animation_description}</small>
+                )}
+              </div>
+            )}
           </>
         )}
       </aside>
@@ -1381,7 +1385,7 @@ export function SettingsPage() {
             aria-describedby="settings-confirmation-detail"
             aria-labelledby="settings-confirmation-title"
             aria-modal="true"
-            className="settings-dialog"
+            className="settings-dialog settings-dialog-confirmation"
             onKeyDown={(event) => {
               if (event.key === 'Escape' && !confirming) {
                 event.preventDefault();
@@ -1423,7 +1427,7 @@ export function SettingsPage() {
             </div>
             <div className="settings-dialog-actions">
               <button
-                className="secondary-button"
+                className="btn btn-secondary"
                 disabled={confirming}
                 onClick={closeConfirmation}
                 ref={confirmationCancelRef}

--- a/src/components/settings/ActionFormDialog.tsx
+++ b/src/components/settings/ActionFormDialog.tsx
@@ -1,0 +1,131 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { ExpressionFields } from './ExpressionFields';
+import { SettingsDialog } from './SettingsDialog';
+
+/**
+ * Creating an action and editing one ask for exactly the same details, so they
+ * are one dialog with a different title and submit label. Anything that
+ * differs between them is a prop, not a second form to keep in sync.
+ */
+export function ActionFormDialog({
+  availableExpressions,
+  busy,
+  metadata,
+  mode,
+  onCancel,
+  onChange,
+  onSubmit,
+}: {
+  availableExpressions: readonly string[];
+  busy: boolean;
+  metadata: CustomAnimationMetadata;
+  mode: 'create' | 'edit';
+  onCancel: () => void;
+  onChange: Dispatch<SetStateAction<CustomAnimationMetadata>>;
+  onSubmit: () => void;
+}) {
+  const creating = mode === 'create';
+  const complete =
+    metadata.animation_name.trim() !== '' &&
+    metadata.animation_description.trim() !== '' &&
+    metadata.animation_trigger_scenario.trim() !== '';
+
+  const patch = (fields: Partial<CustomAnimationMetadata>) =>
+    onChange((current) => ({ ...current, ...fields }));
+
+  return (
+    <SettingsDialog
+      busy={busy}
+      eyebrow={creating ? 'Motion library' : 'Edit action'}
+      footer={
+        <>
+          <button
+            className="btn btn-secondary"
+            disabled={busy}
+            onClick={onCancel}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            disabled={busy || !complete}
+            onClick={onSubmit}
+            type="button"
+          >
+            {creating ? 'Create action' : 'Save changes'}
+          </button>
+        </>
+      }
+      onClose={onCancel}
+      title={creating ? 'New action' : 'Edit action details'}
+      wide
+    >
+      <p className="dialog-lede">
+        {creating
+          ? 'These details are what a connected agent reads to decide when to play the action. Add its VRMA clips from the action’s card afterwards.'
+          : 'These details describe the action to the Persona MCP tool. Clips stay grouped under the action if its name changes.'}
+      </p>
+
+      <div className="fields">
+        <div className="field">
+          <label className="field-label" htmlFor="action-name">
+            Action name
+            <code>animation_name</code>
+          </label>
+          <input
+            id="action-name"
+            maxLength={48}
+            onChange={(event) => patch({ animation_name: event.target.value })}
+            placeholder="e.g. wave-hello"
+            value={metadata.animation_name}
+          />
+          <p className="field-hint">
+            Lowercase letters, numbers, and hyphens. Clips are named from it
+            automatically, such as wave-hello1 and wave-hello2.
+          </p>
+        </div>
+
+        <div className="field">
+          <label className="field-label" htmlFor="action-description">
+            Description
+            <code>animation_description</code>
+          </label>
+          <textarea
+            id="action-description"
+            maxLength={240}
+            onChange={(event) =>
+              patch({ animation_description: event.target.value })
+            }
+            placeholder="Describe what the movement looks and feels like."
+            rows={3}
+            value={metadata.animation_description}
+          />
+        </div>
+
+        <div className="field">
+          <label className="field-label" htmlFor="action-trigger">
+            Trigger scenario
+            <code>animation_trigger_scenario</code>
+          </label>
+          <textarea
+            id="action-trigger"
+            maxLength={240}
+            onChange={(event) =>
+              patch({ animation_trigger_scenario: event.target.value })
+            }
+            placeholder="Explain when an agent should choose this action."
+            rows={3}
+            value={metadata.animation_trigger_scenario}
+          />
+        </div>
+
+        <ExpressionFields
+          availableExpressions={availableExpressions}
+          metadata={metadata}
+          onChange={patch}
+        />
+      </div>
+    </SettingsDialog>
+  );
+}

--- a/src/components/settings/AnimationsSection.tsx
+++ b/src/components/settings/AnimationsSection.tsx
@@ -1,4 +1,6 @@
-import { ExpressionFields } from './ExpressionFields';
+import { useState } from 'react';
+import { ActionFormDialog } from './ActionFormDialog';
+import { PencilIcon, PlayIcon, PlusIcon, TrashIcon } from './icons';
 
 interface AnimationsSectionProps {
   addAnimationClips: (animation: PersonaAnimationSettings) => Promise<void>;
@@ -7,7 +9,7 @@ interface AnimationsSectionProps {
   beginEditingAnimation: (animation: PersonaAnimationSettings) => void;
   bridge: Window['personaSettings'];
   busy: boolean;
-  createAnimation: () => Promise<void>;
+  createAnimation: () => Promise<boolean>;
   deleteAnimation: (animation: PersonaAnimationSettings) => void;
   deleteAnimationClip: (
     animation: PersonaAnimationSettings,
@@ -53,8 +55,41 @@ export function AnimationsSection({
   setEditingAnimationMetadata,
   settings,
 }: AnimationsSectionProps) {
+  const [creatingAction, setCreatingAction] = useState(false);
+  const editingAnimation = settings.animations.find(
+    (animation) => animation.id === editingAnimationId,
+  );
+
   return (
     <>
+      {creatingAction && (
+        <ActionFormDialog
+          availableExpressions={availableExpressions}
+          busy={busy}
+          metadata={animationMetadata}
+          mode="create"
+          onCancel={() => setCreatingAction(false)}
+          onChange={setAnimationMetadata}
+          onSubmit={() => {
+            void createAnimation().then((created) => {
+              if (created) setCreatingAction(false);
+            });
+          }}
+        />
+      )}
+
+      {editingAnimation && (
+        <ActionFormDialog
+          availableExpressions={availableExpressions}
+          busy={busy}
+          metadata={editingAnimationMetadata}
+          mode="edit"
+          onCancel={() => setEditingAnimationId(null)}
+          onChange={setEditingAnimationMetadata}
+          onSubmit={() => void saveAnimation()}
+        />
+      )}
+
       <section className="settings-panel">
         <div className="panel-heading">
           <div>
@@ -64,366 +99,192 @@ export function AnimationsSection({
               chooses randomly between them when the action runs.
             </p>
           </div>
-          <button
-            className="secondary-button"
-            disabled={
-              busy ||
-              !bridge ||
-              settings.packaged_animation_change_count === 0
-            }
-            onClick={() => void resetPackagedAnimations()}
-            type="button"
-          >
-            Reset packaged actions
-          </button>
+          <div className="panel-actions">
+            <button
+              className="btn btn-ghost"
+              disabled={
+                busy ||
+                !bridge ||
+                settings.packaged_animation_change_count === 0
+              }
+              onClick={() => void resetPackagedAnimations()}
+              type="button"
+            >
+              Reset packaged
+            </button>
+            <button
+              className="btn btn-secondary"
+              disabled={busy || !bridge}
+              onClick={() => setCreatingAction(true)}
+              type="button"
+            >
+              <PlusIcon />
+              New action
+            </button>
+          </div>
         </div>
         <div className="animation-list">
           {settings.animations.map((animation) => (
-            <article
-              className={`animation-card ${
-                animation.system ? 'system-action-card' : ''
-              }`}
-              key={animation.id}
-            >
-              <div className="animation-card-header">
-                <div className="animation-card-copy">
-                  <div>
-                    <strong>
-                      {animation.system
-                        ? animation.animation_type === 'IDLE'
-                          ? 'Idle'
-                          : 'Speaking'
-                        : animation.animation_name}
-                    </strong>
-                    <span>
-                      {animation.system
-                        ? 'System action'
-                        : animation.origin === 'packaged'
-                          ? animation.modified
-                            ? 'Packaged · modified'
-                            : 'Packaged'
-                          : 'Custom action'}
-                    </span>
-                  </div>
-                  <p>{animation.animation_description}</p>
-                  <small>
-                    <b>Trigger:</b>{' '}
-                    {animation.animation_trigger_scenario}
-                  </small>
-                  <small className="animation-card-expression">
-                    <b>Expression:</b>{' '}
+            <article className="action-card" key={animation.id}>
+              <div className="action-head">
+                <div className="action-title">
+                  <strong>
+                    {animation.system
+                      ? animation.animation_type === 'IDLE'
+                        ? 'Idle'
+                        : 'Speaking'
+                      : animation.animation_name}
+                  </strong>
+                  <span
+                    className={`chip ${animation.system ? 'chip-accent' : ''}`}
+                  >
+                    {animation.system
+                      ? 'System'
+                      : animation.origin === 'packaged'
+                        ? animation.modified
+                          ? 'Packaged · modified'
+                          : 'Packaged'
+                        : 'Custom'}
+                  </span>
+                </div>
+                <div className="action-head-actions">
+                  {animation.editable && (
+                    <button
+                      aria-label={`Edit ${animation.animation_name}`}
+                      className="btn btn-ghost btn-icon"
+                      disabled={busy || !bridge}
+                      onClick={() => beginEditingAnimation(animation)}
+                      title="Edit details"
+                      type="button"
+                    >
+                      <PencilIcon />
+                    </button>
+                  )}
+                  {animation.removable && (
+                    <button
+                      aria-label={`Delete ${animation.animation_name}`}
+                      className="btn btn-danger btn-icon"
+                      disabled={busy || !bridge}
+                      onClick={() => void deleteAnimation(animation)}
+                      title="Delete action"
+                      type="button"
+                    >
+                      <TrashIcon />
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <p className="action-desc">{animation.animation_description}</p>
+
+              <dl className="meta-list">
+                <div>
+                  <dt>Trigger</dt>
+                  <dd>{animation.animation_trigger_scenario}</dd>
+                </div>
+                <div>
+                  <dt>Expression</dt>
+                  <dd>
                     {animation.expression_name ? (
                       <>
                         {animation.expression_name}
-                        <span className="expression-weight-tag">
+                        <span className="chip">
                           {animation.expression_weight.toFixed(2)}
                         </span>
                       </>
                     ) : (
                       'None'
                     )}
-                  </small>
+                  </dd>
                 </div>
-                <div className="animation-card-actions">
-                  {animation.editable && (
-                    <button
-                      disabled={busy || !bridge}
-                      onClick={() => beginEditingAnimation(animation)}
-                      type="button"
-                    >
-                      Edit
-                    </button>
-                  )}
-                  {animation.removable && (
-                    <button
-                      className="danger-text-button"
-                      disabled={busy || !bridge}
-                      onClick={() => void deleteAnimation(animation)}
-                      type="button"
-                    >
-                      Delete
-                    </button>
-                  )}
-                </div>
+              </dl>
+
+              <div className="subhead">
+                <span>
+                  Clips
+                  <span className="chip">{animation.clips.length}</span>
+                </span>
+                <button
+                  className="btn btn-secondary btn-sm"
+                  disabled={busy || !bridge}
+                  onClick={() => void addAnimationClips(animation)}
+                  type="button"
+                >
+                  <PlusIcon />
+                  Add clips
+                </button>
               </div>
 
-              <div className="animation-clips">
-                <div className="animation-clips-heading">
-                  <div>
-                    <strong>VRMA clips</strong>
-                    <span>
-                      {animation.clips.length === 0
-                        ? 'No clips added'
-                        : `${animation.clips.length} ${
-                            animation.clips.length === 1
-                              ? 'clip'
-                              : 'clips'
-                          }`}
-                    </span>
-                  </div>
-                  <button
-                    className="secondary-button add-clips-button"
-                    disabled={busy || !bridge}
-                    onClick={() => void addAnimationClips(animation)}
-                    type="button"
-                  >
-                    + Add VRMA files
-                  </button>
-                </div>
-                {animation.clips.length === 0 ? (
-                  <p className="empty-clips">
-                    {animation.system
-                      ? `Upload one or more clips for the ${
-                          animation.animation_type === 'IDLE'
-                            ? 'idle'
-                            : 'speaking'
-                        } state. Persona uses the model pose until then.`
-                      : 'Upload one or more clips to make this action available to MCP.'}
-                  </p>
-                ) : (
-                  <div className="clip-list">
-                    {animation.clips.map((clip) => (
+              {animation.clips.length === 0 ? (
+                <p className="empty-clips">
+                  {animation.system
+                    ? `Add one or more clips for the ${
+                        animation.animation_type === 'IDLE'
+                          ? 'idle'
+                          : 'speaking'
+                      } state. Persona holds the model's own pose until then.`
+                    : 'Add one or more clips to make this action available to MCP.'}
+                </p>
+              ) : (
+                <div className="rows rows-grid">
+                  {animation.clips.map((clip) => {
+                    const playing = previewClipId === clip.id;
+                    return (
                       <div
-                        aria-label={`Preview ${clip.animation_name}`}
-                        className={`clip-chip ${
-                          previewClipId === clip.id ? 'playing' : ''
-                        }`}
+                        className={`row-wrap ${clip.removable ? 'row-wrap-actionable' : ''}`}
                         key={clip.id}
-                        onClick={(event) => {
-                          if (
-                            (event.target as Element).closest('button')
-                          ) {
-                            return;
-                          }
-                          playAnimationClip(animation, clip);
-                        }}
-                        onKeyDown={(event) => {
-                          if (
-                            event.target !== event.currentTarget ||
-                            (event.key !== 'Enter' && event.key !== ' ')
-                          ) {
-                            return;
-                          }
-                          event.preventDefault();
-                          playAnimationClip(animation, clip);
-                        }}
-                        tabIndex={0}
-                        title={`Preview ${clip.animation_name}`}
                       >
-                        <span className="clip-file-icon">VRMA</span>
-                        <strong>{clip.animation_name}</strong>
-                        <small>
-                          {clip.origin === 'packaged'
-                            ? 'Packaged'
-                            : 'Uploaded'}
-                        </small>
+                        <button
+                          aria-label={`Preview ${clip.animation_name}`}
+                          aria-pressed={playing}
+                          className={`row row-selectable ${playing ? 'is-selected' : ''}`}
+                          onClick={() => playAnimationClip(animation, clip)}
+                          title={`Preview ${clip.animation_name}`}
+                          type="button"
+                        >
+                          <span className="row-mark row-mark-play">
+                            <PlayIcon />
+                          </span>
+                          <span className="row-copy">
+                            <strong>{clip.animation_name}</strong>
+                            <small>
+                              {clip.origin === 'packaged'
+                                ? 'Packaged'
+                                : 'Uploaded'}
+                            </small>
+                          </span>
+                          <span className="row-trailing">
+                            {playing && (
+                              <span className="chip chip-accent">Playing</span>
+                            )}
+                          </span>
+                        </button>
                         {clip.removable && (
-                          <button
-                            aria-label={`Delete ${clip.animation_name}`}
-                            className="clip-delete"
-                            disabled={busy || !bridge}
-                            onClick={() =>
-                              void deleteAnimationClip(animation, clip)
-                            }
-                            title={`Delete ${clip.animation_name}`}
-                            type="button"
-                          >
-                            ×
-                          </button>
+                          <div className="row-actions row-actions-overlay">
+                            <button
+                              aria-label={`Delete ${clip.animation_name}`}
+                              className="btn btn-danger btn-icon"
+                              disabled={busy || !bridge}
+                              onClick={() =>
+                                void deleteAnimationClip(animation, clip)
+                              }
+                              title={`Delete ${clip.animation_name}`}
+                              type="button"
+                            >
+                              <TrashIcon />
+                            </button>
+                          </div>
                         )}
                       </div>
-                    ))}
-                  </div>
-                )}
-              </div>
+                    );
+                  })}
+                </div>
+              )}
             </article>
           ))}
         </div>
       </section>
 
-      {editingAnimationId && (
-        <section className="settings-panel import-panel edit-panel">
-          <div className="panel-heading">
-            <div>
-              <h2>Edit action details</h2>
-              <p>
-                These details describe the action to the Persona MCP
-                tool. Clips remain grouped under the action if its name
-                changes.
-              </p>
-            </div>
-          </div>
-          <div className="form-stack">
-            <label>
-              Action name <code>animation_name</code>
-              <input
-                maxLength={48}
-                onChange={(event) =>
-                  setEditingAnimationMetadata((current) => ({
-                    ...current,
-                    animation_name: event.target.value,
-                  }))
-                }
-                value={editingAnimationMetadata.animation_name}
-              />
-            </label>
-            <label>
-              Description <code>animation_description</code>
-              <textarea
-                maxLength={240}
-                onChange={(event) =>
-                  setEditingAnimationMetadata((current) => ({
-                    ...current,
-                    animation_description: event.target.value,
-                  }))
-                }
-                rows={3}
-                value={
-                  editingAnimationMetadata.animation_description
-                }
-              />
-            </label>
-            <label>
-              Trigger scenario{' '}
-              <code>animation_trigger_scenario</code>
-              <textarea
-                maxLength={240}
-                onChange={(event) =>
-                  setEditingAnimationMetadata((current) => ({
-                    ...current,
-                    animation_trigger_scenario: event.target.value,
-                  }))
-                }
-                rows={3}
-                value={
-                  editingAnimationMetadata.animation_trigger_scenario
-                }
-              />
-            </label>
-            <ExpressionFields
-              metadata={editingAnimationMetadata}
-              onChange={(patch) =>
-                setEditingAnimationMetadata((current) => ({
-                  ...current,
-                  ...patch,
-                }))
-              }
-              availableExpressions={availableExpressions}
-            />
-          </div>
-          <div className="form-actions">
-            <button
-              className="primary-button"
-              disabled={
-                busy ||
-                !editingAnimationMetadata.animation_name.trim() ||
-                !editingAnimationMetadata.animation_description.trim() ||
-                !editingAnimationMetadata.animation_trigger_scenario.trim()
-              }
-              onClick={() => void saveAnimation()}
-              type="button"
-            >
-              Save changes
-            </button>
-            <button
-              className="secondary-button"
-              disabled={busy}
-              onClick={() => setEditingAnimationId(null)}
-              type="button"
-            >
-              Cancel
-            </button>
-          </div>
-        </section>
-      )}
-
-      <section className="settings-panel import-panel">
-        <div className="panel-heading">
-          <div>
-            <h2>Create a custom action</h2>
-            <p>
-              Create the MCP-visible action first, then add any number
-              of VRMA clips from its card above.
-            </p>
-          </div>
-          <span className="file-pill">Action</span>
-        </div>
-        <div className="form-stack">
-          <label>
-            Action name <code>animation_name</code>
-            <input
-              maxLength={48}
-              onChange={(event) =>
-                setAnimationMetadata((current) => ({
-                  ...current,
-                  animation_name: event.target.value,
-                }))
-              }
-              placeholder="e.g. wave-hello"
-              value={animationMetadata.animation_name}
-            />
-            <small>
-              Lowercase letters, numbers, and hyphens. Clips added to
-              this action are named automatically, such as wave-hello1
-              and wave-hello2.
-            </small>
-          </label>
-          <label>
-            Description <code>animation_description</code>
-            <textarea
-              maxLength={240}
-              onChange={(event) =>
-                setAnimationMetadata((current) => ({
-                  ...current,
-                  animation_description: event.target.value,
-                }))
-              }
-              placeholder="Describe what the movement looks and feels like."
-              rows={3}
-              value={animationMetadata.animation_description}
-            />
-          </label>
-          <label>
-            Trigger scenario <code>animation_trigger_scenario</code>
-            <textarea
-              maxLength={240}
-              onChange={(event) =>
-                setAnimationMetadata((current) => ({
-                  ...current,
-                  animation_trigger_scenario: event.target.value,
-                }))
-              }
-              placeholder="Explain when an agent should choose this action."
-              rows={3}
-              value={animationMetadata.animation_trigger_scenario}
-            />
-          </label>
-          <ExpressionFields
-            metadata={animationMetadata}
-            onChange={(patch) =>
-              setAnimationMetadata((current) => ({
-                ...current,
-                ...patch,
-              }))
-            }
-            availableExpressions={availableExpressions}
-          />
-        </div>
-        <button
-          className="primary-button"
-          disabled={
-            busy ||
-            !bridge ||
-            !animationMetadata.animation_name.trim() ||
-            !animationMetadata.animation_description.trim() ||
-            !animationMetadata.animation_trigger_scenario.trim()
-          }
-          onClick={() => void createAnimation()}
-          type="button"
-        >
-          Create action
-        </button>
-      </section>
     </>
   );
 }

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -197,20 +197,20 @@ export function AppearanceSection({
               value={avatarHeightInput}
             />
           </label>
+          <button
+            className="btn btn-primary"
+            disabled={
+              busy ||
+              !bridge ||
+              !avatarWindowSizeValid ||
+              !avatarWindowSizeChanged
+            }
+            onClick={() => void saveAvatarWindowSize()}
+            type="button"
+          >
+            Apply
+          </button>
         </div>
-        <button
-          className="primary-button"
-          disabled={
-            busy ||
-            !bridge ||
-            !avatarWindowSizeValid ||
-            !avatarWindowSizeChanged
-          }
-          onClick={() => void saveAvatarWindowSize()}
-          type="button"
-        >
-          Apply
-        </button>
         {!bridge && (
           <p className="desktop-note">
             Resizing the avatar window is available in the Persona
@@ -228,14 +228,16 @@ export function AppearanceSection({
               overexposed or too dark.
             </p>
           </div>
-          <button
-            className="lighting-reset-button"
-            disabled={busy || !bridge || !selectedModel}
-            onClick={() => void resetLighting()}
-            type="button"
-          >
-            Reset lighting
-          </button>
+          <div className="panel-actions">
+            <button
+              className="btn btn-secondary"
+              disabled={busy || !bridge || !selectedModel}
+              onClick={() => void resetLighting()}
+              type="button"
+            >
+              Reset
+            </button>
+          </div>
         </div>
 
         <div className="lighting-select-row">

--- a/src/components/settings/DeveloperSection.tsx
+++ b/src/components/settings/DeveloperSection.tsx
@@ -59,7 +59,7 @@ export function DeveloperSection({
               values can make movement look unstable or unnatural.
             </p>
             <button
-              className="primary-button"
+              className="btn btn-primary"
               disabled={busy || !bridge}
               onClick={requestDeveloperSettingsAccess}
               type="button"
@@ -80,7 +80,7 @@ export function DeveloperSection({
                 </p>
               </div>
               <button
-                className="lighting-reset-button"
+                className="btn btn-secondary"
                 disabled={
                   busy || !bridge || !developerSettingsModified
                 }

--- a/src/components/settings/ExpressionFields.tsx
+++ b/src/components/settings/ExpressionFields.tsx
@@ -34,9 +34,13 @@ export function ExpressionFields({
 
   return (
     <>
-      <label>
-        Expression <code>expression_name</code>
+      <div className="field">
+        <label className="field-label" htmlFor="action-expression">
+          Expression
+          <code>expression_name</code>
+        </label>
         <select
+          id="action-expression"
           onChange={(event) =>
             onChange({
               expression_name: event.target.value || null,
@@ -51,15 +55,17 @@ export function ExpressionFields({
             </option>
           ))}
         </select>
-        <small>
+        <p className="field-hint">
           Blends a VRM expression over the face while the action plays.
-        </small>
-      </label>
+          {availableExpressions.length === 0 &&
+            ' This model defines none beyond the ones Persona drives itself.'}
+        </p>
+      </div>
       {metadata.expression_name && (
-        <div className="expression-weight-field">
+        <div className="field expression-weight-field">
           <div className="expression-weight-row">
             <label>
-              <span>
+              <span className="field-label">
                 Expression weight <code>expression_weight</code>
               </span>
               <input
@@ -111,9 +117,9 @@ export function ExpressionFields({
               value={metadata.expression_weight}
             />
           </div>
-          <small className="field-hint">
+          <p className="field-hint">
             Between 0.00 (expression off) and 1.00 (full strength).
-          </small>
+          </p>
         </div>
       )}
     </>

--- a/src/components/settings/McpSection.tsx
+++ b/src/components/settings/McpSection.tsx
@@ -31,7 +31,6 @@ export function McpSection({
             </p>
           </div>
           <span className={`mcp-health-badge ${mcpHealth}`}>
-            <i aria-hidden="true" />
             {mcpHealth === 'online'
               ? 'Online'
               : mcpHealth === 'starting'
@@ -40,9 +39,9 @@ export function McpSection({
           </span>
         </div>
 
-        <div className="mcp-status-grid">
-          <article>
-            <span>Health</span>
+        <div className="tiles tiles-quad">
+          <article className="tile">
+            <span className="tile-label">Health</span>
             <strong>
               {mcpHealth === 'online'
                 ? 'Ready'
@@ -58,13 +57,13 @@ export function McpSection({
                 : 'Waiting for the desktop bridge'}
             </small>
           </article>
-          <article>
-            <span>Transport</span>
+          <article className="tile">
+            <span className="tile-label">Transport</span>
             <strong>{mcpStatus?.transport ?? 'Streamable HTTP'}</strong>
             <small>Model Context Protocol</small>
           </article>
-          <article>
-            <span>Access</span>
+          <article className="tile">
+            <span className="tile-label">Access</span>
             <strong>
               {mcpStatus?.local_only === false
                 ? 'Network'
@@ -72,8 +71,8 @@ export function McpSection({
             </strong>
             <small>Bound to 127.0.0.1</small>
           </article>
-          <article>
-            <span>Persona</span>
+          <article className="tile">
+            <span className="tile-label">Persona</span>
             <strong>v{mcpStatus?.version ?? '—'}</strong>
             <small>Server version</small>
           </article>
@@ -96,7 +95,7 @@ export function McpSection({
             </p>
           </div>
           <button
-            className="secondary-button"
+            className="btn btn-secondary"
             disabled={mcpLoading}
             onClick={() => void refreshMcpStatus()}
             type="button"
@@ -105,13 +104,13 @@ export function McpSection({
           </button>
         </div>
 
-        <div className="mcp-copy-field">
+        <div className="code-row">
           <div>
             <span>Server URL</span>
             <code>{mcpServerUrl}</code>
           </div>
           <button
-            className="secondary-button"
+            className="btn btn-secondary"
             onClick={() => void copyText(mcpServerUrl, 'Server URL')}
             type="button"
           >
@@ -119,13 +118,13 @@ export function McpSection({
           </button>
         </div>
 
-        <div className="mcp-copy-field">
+        <div className="code-row">
           <div>
             <span>Codex setup command</span>
             <code>{mcpSetupCommand}</code>
           </div>
           <button
-            className="secondary-button"
+            className="btn btn-secondary"
             onClick={() =>
               void copyText(mcpSetupCommand, 'Setup command')
             }
@@ -151,7 +150,7 @@ export function McpSection({
               audio access.
             </p>
           </div>
-          <span className="file-pill">
+          <span className="chip">
             {mcpStatus?.tools.length ?? 4} tools
           </span>
         </div>
@@ -174,7 +173,7 @@ export function McpSection({
               at least one VRMA clip.
             </p>
           </div>
-          <span className="file-pill">
+          <span className="chip">
             {mcpStatus?.playable_actions.length ?? 0} active
           </span>
         </div>

--- a/src/components/settings/ModelFormDialog.tsx
+++ b/src/components/settings/ModelFormDialog.tsx
@@ -1,0 +1,89 @@
+import { SettingsDialog } from './SettingsDialog';
+
+/**
+ * Naming a model and picking its file, in the same dialog shape actions use.
+ *
+ * The file picker is the submit action rather than a separate step: the native
+ * dialog is where the choice is actually made, and cancelling it leaves this
+ * one open with the name still typed.
+ */
+export function ModelFormDialog({
+  busy,
+  canImport,
+  name,
+  onCancel,
+  onChooseFile,
+  onNameChange,
+}: {
+  busy: boolean;
+  /** False outside the desktop app, where there is no native file picker. */
+  canImport: boolean;
+  name: string;
+  onCancel: () => void;
+  onChooseFile: () => void;
+  onNameChange: (name: string) => void;
+}) {
+  const named = name.trim() !== '';
+
+  return (
+    <SettingsDialog
+      busy={busy}
+      eyebrow="Character library"
+      footer={
+        <>
+          <button
+            className="btn btn-secondary"
+            disabled={busy}
+            onClick={onCancel}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            disabled={busy || !canImport || !named}
+            onClick={onChooseFile}
+            type="button"
+          >
+            Choose VRM file…
+          </button>
+        </>
+      }
+      onClose={onCancel}
+      title="Add a model"
+    >
+      <p className="dialog-lede">
+        Persona copies the VRM you choose into your local library. The original
+        file stays where it is.
+      </p>
+
+      <div className="fields">
+        <div className="field">
+          <label className="field-label" htmlFor="model-name">
+            Model name
+            <code>model_name</code>
+          </label>
+          <input
+            id="model-name"
+            maxLength={80}
+            onChange={(event) => onNameChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && named && canImport) onChooseFile();
+            }}
+            placeholder="e.g. Studio Assistant"
+            value={name}
+          />
+          <p className="field-hint">
+            How the model is listed in your library and in the preview.
+          </p>
+        </div>
+      </div>
+
+      {!canImport && (
+        <p className="desktop-note">
+          Adding a model is available in the Persona desktop app.
+        </p>
+      )}
+    </SettingsDialog>
+  );
+}

--- a/src/components/settings/ModelsSection.tsx
+++ b/src/components/settings/ModelsSection.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+import { RefreshIcon, TrashIcon } from './icons';
+import { ModelFormDialog } from './ModelFormDialog';
 import { VroidCharacterGroup } from './VroidCharacters';
 
 interface ModelsSectionProps {
@@ -9,7 +12,7 @@ interface ModelsSectionProps {
   deleteModel: (model: PersonaModelSettings) => void;
   disconnectVroidHub: () => void;
   heartedVroidCharacters: PersonaVroidHubCharacter[];
-  importModel: () => Promise<void>;
+  importModel: () => Promise<boolean>;
   modelName: string;
   ownVroidCharacters: PersonaVroidHubCharacter[];
   refreshVroidCharacters: () => Promise<void>;
@@ -65,116 +68,124 @@ export function ModelsSection({
   vroidPortraitEpoch,
   vroidStatus,
 }: ModelsSectionProps) {
+  // Adding is a task, not a permanent part of the panel: an always-open form
+  // pushes the library the user actually came to read down the page.
+  const [addingModel, setAddingModel] = useState(false);
+
+  const closeAddModel = () => {
+    setAddingModel(false);
+    setModelName('');
+  };
+
   return (
     <>
+      {addingModel && (
+        <ModelFormDialog
+          busy={busy}
+          canImport={bridge != null}
+          name={modelName}
+          onCancel={closeAddModel}
+          onChooseFile={() => {
+            void importModel().then((imported) => {
+              if (imported) closeAddModel();
+            });
+          }}
+          onNameChange={setModelName}
+        />
+      )}
+
       <section className="settings-panel">
         <div className="panel-heading">
           <div>
-            <h2>Model library</h2>
-            <p>Select a model to inspect it in the preview.</p>
+            <h2>Character library</h2>
+            <p>
+              Pick a model to preview it. The default is the one Persona
+              wears when it starts.
+            </p>
+          </div>
+          <div className="panel-actions">
+            <button
+              className="btn btn-secondary"
+              disabled={busy || !bridge}
+              onClick={() => setAddingModel(true)}
+              type="button"
+            >
+              Add model
+            </button>
           </div>
         </div>
-        <div className="asset-grid">
-          {settings.models.length === 0 && (
-            <div className="empty-library">
-              <strong>No model configured</strong>
-              <p>
-                Add a VRM file below. Persona stays inactive until a
-                model is available and selected as the default.
-              </p>
-            </div>
-          )}
-          {settings.models.map((model) => {
-            const selected = model.id === selectedModel?.id;
-            const isDefault = model.id === settings.default_model_id;
-            return (
-              <article
-                className={`asset-card ${selected ? 'selected' : ''}`}
-                key={model.id}
-              >
-                <button
-                  className="asset-card-main"
-                  onClick={() => setSelectedModelId(model.id)}
-                  type="button"
+
+        {settings.models.length === 0 ? (
+          <div className="empty-library">
+            <strong>No model configured</strong>
+            <p>
+              Add a VRM file to get started. Persona stays inactive until a
+              model is available and selected as the default.
+            </p>
+          </div>
+        ) : (
+          <div className="rows" role="radiogroup" aria-label="Character library">
+            {settings.models.map((model) => {
+              const selected = model.id === selectedModel?.id;
+              const isDefault = model.id === settings.default_model_id;
+              const actionable = !isDefault || model.removable;
+              return (
+                <div
+                  className={`row-wrap ${actionable ? 'row-wrap-actionable' : ''}`}
+                  key={model.id}
                 >
-                  <span className="asset-icon">VRM</span>
-                  <span>
-                    <strong>{model.model_name}</strong>
-                    <small>
-                      {model.origin === 'packaged'
-                        ? 'Packaged model'
-                        : model.origin === 'hub'
-                          ? 'From VRoid Hub'
-                          : 'User model'}
-                    </small>
-                  </span>
-                </button>
-                <div className="asset-card-footer">
-                  {isDefault ? (
-                    <span className="default-badge">Default</span>
-                  ) : (
-                    <button
-                      disabled={busy || !bridge}
-                      onClick={() => void setDefaultModel(model.id)}
-                      type="button"
-                    >
-                      Make default
-                    </button>
-                  )}
-                  <div className="asset-card-actions">
-                    <button
-                      onClick={() => setSelectedModelId(model.id)}
-                      type="button"
-                    >
-                      Preview
-                    </button>
-                    {model.removable && (
+                  <button
+                    aria-checked={selected}
+                    className="row row-selectable"
+                    onClick={() => setSelectedModelId(model.id)}
+                    role="radio"
+                    type="button"
+                  >
+                    <span className="row-mark">VRM</span>
+                    <span className="row-copy">
+                      <strong>{model.model_name}</strong>
+                      <small>
+                        {model.origin === 'packaged'
+                          ? 'Packaged with Persona'
+                          : model.origin === 'hub'
+                            ? 'From VRoid Hub'
+                            : 'Added by you'}
+                      </small>
+                    </span>
+                    <span className="row-trailing">
+                      {isDefault && <span className="chip chip-accent">Default</span>}
+                    </span>
+                  </button>
+                  {actionable && (
+                  <div className="row-actions row-actions-overlay">
+                    {!isDefault && (
                       <button
-                        className="danger-text-button"
+                        className="btn btn-ghost btn-sm"
                         disabled={busy || !bridge}
-                        onClick={() => void deleteModel(model)}
+                        onClick={() => void setDefaultModel(model.id)}
                         type="button"
                       >
-                        Delete
+                        Set default
+                      </button>
+                    )}
+                    {model.removable && (
+                      <button
+                        aria-label={`Delete ${model.model_name}`}
+                        className="btn btn-danger btn-icon"
+                        disabled={busy || !bridge}
+                        onClick={() => void deleteModel(model)}
+                        title={`Delete ${model.model_name}`}
+                        type="button"
+                      >
+                        <TrashIcon />
                       </button>
                     )}
                   </div>
+                  )}
                 </div>
-              </article>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="settings-panel import-panel">
-        <div className="panel-heading">
-          <div>
-            <h2>Add a custom model</h2>
-            <p>Persona copies the selected VRM into your local library.</p>
+              );
+            })}
           </div>
-          <span className="file-pill">.vrm</span>
-        </div>
-        <label>
-          Model name <code>model_name</code>
-          <input
-            maxLength={80}
-            onChange={(event) => setModelName(event.target.value)}
-            placeholder="e.g. Studio Assistant"
-            value={modelName}
-          />
-        </label>
-        <button
-          className="primary-button"
-          disabled={busy || !bridge || !modelName.trim()}
-          onClick={() => void importModel()}
-          type="button"
-        >
-          Choose VRM file
-        </button>
-        {!bridge && (
-          <p className="desktop-note">
-            File import is available in the Persona desktop app.
-          </p>
         )}
       </section>
 
@@ -188,9 +199,42 @@ export function ModelsSection({
               yourself.
             </p>
           </div>
-          {vroidStatus?.connected && (
-            <span className="default-badge">Connected</span>
-          )}
+          <div className="panel-actions">
+            {vroidStatus?.connected && (
+              <>
+                <span className="chip chip-success">Connected</span>
+                <button
+                  className="btn btn-secondary"
+                  disabled={busy || vroidLoading}
+                  onClick={() => void refreshVroidCharacters()}
+                  type="button"
+                >
+                  <RefreshIcon />
+                  {vroidLoading ? 'Refreshing…' : 'Refresh'}
+                </button>
+                <button
+                  className="btn btn-secondary btn-danger-text"
+                  disabled={busy}
+                  onClick={disconnectVroidHub}
+                  type="button"
+                >
+                  Disconnect
+                </button>
+              </>
+            )}
+            {vroidHubBridge &&
+              vroidStatus?.configured &&
+              !vroidStatus.connected && (
+                <button
+                  className="btn btn-primary"
+                  disabled={busy}
+                  onClick={() => void connectVroidHub()}
+                  type="button"
+                >
+                  Connect account
+                </button>
+              )}
+          </div>
         </div>
         {!vroidHubBridge && (
           <p className="desktop-note">
@@ -213,13 +257,13 @@ export function ModelsSection({
                 its redirect URI to the value below, then paste the
                 app&rsquo;s client ID and secret here.
               </p>
-              <div className="mcp-copy-field">
+              <div className="code-row">
                 <div>
                   <span>Redirect URI to register</span>
                   <code>{vroidStatus?.redirect_uri ?? '—'}</code>
                 </div>
                 <button
-                  className="secondary-button"
+                  className="btn btn-secondary"
                   disabled={!vroidStatus}
                   onClick={() =>
                     vroidStatus &&
@@ -262,7 +306,7 @@ export function ModelsSection({
               </div>
               <div className="form-actions">
                 <button
-                  className="primary-button"
+                  className="btn btn-primary"
                   disabled={
                     vroidCredentialsSaving ||
                     !vroidClientIdInput.trim() ||
@@ -277,7 +321,7 @@ export function ModelsSection({
                 </button>
                 {vroidStatus?.configured && (
                   <button
-                    className="secondary-button danger-text-button"
+                    className="btn btn-secondary btn-danger-text"
                     disabled={busy}
                     onClick={clearVroidCredentials}
                     type="button"
@@ -288,16 +332,6 @@ export function ModelsSection({
               </div>
             </div>
           </details>
-        )}
-        {vroidHubBridge && vroidStatus?.configured && !vroidStatus.connected && (
-          <button
-            className="primary-button"
-            disabled={busy}
-            onClick={() => void connectVroidHub()}
-            type="button"
-          >
-            Connect VRoid Hub account
-          </button>
         )}
         {vroidHubBridge && vroidStatus?.connected && (
           <>
@@ -336,24 +370,6 @@ export function ModelsSection({
                 />
               </>
             )}
-            <div className="form-actions">
-              <button
-                className="secondary-button"
-                disabled={busy || vroidLoading}
-                onClick={() => void refreshVroidCharacters()}
-                type="button"
-              >
-                Refresh list
-              </button>
-              <button
-                className="secondary-button danger-text-button"
-                disabled={busy}
-                onClick={disconnectVroidHub}
-                type="button"
-              >
-                Disconnect
-              </button>
-            </div>
           </>
         )}
       </section>

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/**
+ * The window's one modal shape: adding and editing both open this, so the two
+ * are the same task with a different title rather than two different screens.
+ *
+ * Owns what a modal has to own and a caller should not have to repeat — the
+ * backdrop, Escape, the focus trap, returning focus where it came from, and
+ * labelling the dialog by its own heading.
+ */
+export function SettingsDialog({
+  busy = false,
+  children,
+  eyebrow,
+  footer,
+  onClose,
+  title,
+  wide = false,
+}: {
+  /** While true the dialog cannot be dismissed: work is in flight. */
+  busy?: boolean;
+  children: ReactNode;
+  eyebrow: string;
+  footer: ReactNode;
+  onClose: () => void;
+  title: string;
+  /** Forms with several fields get more room than a confirmation does. */
+  wide?: boolean;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    const opener =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    // The first field, so typing can start immediately; the dialog itself when
+    // it holds nothing focusable.
+    const first = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE);
+    (first ?? dialogRef.current)?.focus();
+    return () => opener?.focus();
+  }, []);
+
+  const focusable = (): HTMLElement[] =>
+    [...(dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [])];
+
+  return createPortal(
+    <div
+      className="settings-dialog-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && !busy) onClose();
+      }}
+    >
+      <div
+        aria-busy={busy}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className={`settings-dialog ${wide ? 'settings-dialog-wide' : ''}`}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape' && !busy) {
+            event.preventDefault();
+            onClose();
+            return;
+          }
+          if (event.key !== 'Tab') return;
+          // Wrap at both ends so focus cannot leave the dialog for the page
+          // behind it, which is still rendered and still clickable otherwise.
+          const items = focusable();
+          const first = items[0];
+          const last = items.at(-1);
+          if (!first || !last) return;
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }}
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <div className="settings-dialog-head">
+          <span className="eyebrow">{eyebrow}</span>
+          <h2 id={titleId}>{title}</h2>
+        </div>
+        <div className="settings-dialog-body">{children}</div>
+        <div className="settings-dialog-actions">{footer}</div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/settings/VoiceSection.tsx
+++ b/src/components/settings/VoiceSection.tsx
@@ -1,7 +1,49 @@
+import type { ReactNode } from 'react';
+import { AutomaticIcon, ExternalIcon, RegexIcon, WindowIcon } from './icons';
 import {
   voicePatternRisk,
   voicePatternRiskMessage,
 } from '../../voice-pattern-risk';
+
+interface VoiceModeChoice {
+  description: string;
+  icon: ReactNode;
+  id: PersonaVoiceSourceSettings['mode'];
+  label: string;
+  /** Whether picking it is already a complete instruction Persona can save. */
+  savesImmediately: boolean;
+}
+
+const VOICE_MODES: readonly VoiceModeChoice[] = [
+  {
+    id: 'default',
+    label: 'Automatic',
+    description: 'Detect ChatGPT or Codex output.',
+    icon: <AutomaticIcon />,
+    savesImmediately: true,
+  },
+  {
+    id: 'application',
+    label: 'Application',
+    description: 'Pick a running app or playback stream.',
+    icon: <WindowIcon />,
+    savesImmediately: false,
+  },
+  {
+    id: 'custom',
+    label: 'Advanced',
+    description: 'Match processes with a regular expression.',
+    icon: <RegexIcon />,
+    savesImmediately: false,
+  },
+  {
+    id: 'external',
+    label: 'External',
+    description: 'Receive levels directly from a pipeline.',
+    icon: <ExternalIcon />,
+    savesImmediately: true,
+  },
+];
 
 interface VoiceSectionProps {
   bridge: Window['personaSettings'];
@@ -68,61 +110,33 @@ export function VoiceSection({
 
         <div
           aria-label="Voice source mode"
-          className="voice-mode-grid"
-          role="group"
+          className="choice-grid"
+          role="radiogroup"
         >
-          <button
-            aria-pressed={voiceMode === 'default'}
-            data-testid="voice-mode-default"
-            disabled={busy || !bridge}
-            onClick={() => chooseVoiceMode('default')}
-            type="button"
-          >
-            <span className="voice-mode-icon" aria-hidden="true">
-              A
-            </span>
-            <strong>Automatic</strong>
-            <small>Detect ChatGPT or Codex output.</small>
-          </button>
-          <button
-            aria-pressed={voiceMode === 'application'}
-            data-testid="voice-mode-application"
-            disabled={busy || !bridge}
-            onClick={() => setVoiceMode('application')}
-            type="button"
-          >
-            <span className="voice-mode-icon" aria-hidden="true">
-              ◎
-            </span>
-            <strong>Application</strong>
-            <small>Pick a running app or playback stream.</small>
-          </button>
-          <button
-            aria-pressed={voiceMode === 'custom'}
-            data-testid="voice-mode-custom"
-            disabled={busy || !bridge}
-            onClick={() => setVoiceMode('custom')}
-            type="button"
-          >
-            <span className="voice-mode-icon" aria-hidden="true">
-              .*
-            </span>
-            <strong>Advanced</strong>
-            <small>Match processes with a regular expression.</small>
-          </button>
-          <button
-            aria-pressed={voiceMode === 'external'}
-            data-testid="voice-mode-external"
-            disabled={busy || !bridge}
-            onClick={() => chooseVoiceMode('external')}
-            type="button"
-          >
-            <span className="voice-mode-icon" aria-hidden="true">
-              ↗
-            </span>
-            <strong>External</strong>
-            <small>Receive levels directly from a pipeline.</small>
-          </button>
+          {VOICE_MODES.map((mode) => (
+            <button
+              aria-checked={voiceMode === mode.id}
+              className="choice"
+              data-testid={`voice-mode-${mode.id}`}
+              disabled={busy || !bridge}
+              key={mode.id}
+              onClick={() =>
+                // Automatic and External are complete choices on their own;
+                // the other two need a value before there is anything to save.
+                mode.savesImmediately
+                  ? chooseVoiceMode(mode.id)
+                  : setVoiceMode(mode.id)
+              }
+              role="radio"
+              type="button"
+            >
+              <span className="choice-mark">{mode.icon}</span>
+              <span className="choice-copy">
+                <strong>{mode.label}</strong>
+                <small>{mode.description}</small>
+              </span>
+            </button>
+          ))}
         </div>
       </section>
 
@@ -138,7 +152,7 @@ export function VoiceSection({
               </p>
             </div>
             <button
-              className="secondary-button"
+              className="btn btn-secondary"
               disabled={voiceSourcesLoading || !bridge}
               onClick={() => void refreshVoiceSources()}
               type="button"
@@ -272,7 +286,7 @@ export function VoiceSection({
           </p>
           <div className="panel-actions">
             <button
-              className="primary-button"
+              className="btn btn-primary"
               data-testid="voice-source-save"
               disabled={
                 busy ||
@@ -301,7 +315,7 @@ export function VoiceSection({
               </p>
             </div>
           </div>
-          <div className="mcp-copy-field">
+          <div className="code-row">
             <div>
               <span>Events endpoint</span>
               <code>
@@ -310,7 +324,7 @@ export function VoiceSection({
               </code>
             </div>
             <button
-              className="secondary-button"
+              className="btn btn-secondary"
               onClick={() =>
                 void copyText(
                   voiceCatalog?.events_url ??
@@ -338,7 +352,7 @@ export function VoiceSection({
             <p>Current state of the local voice integration.</p>
           </div>
           <button
-            className="secondary-button"
+            className="btn btn-secondary"
             disabled={voiceSourcesLoading || !bridge}
             onClick={() => void refreshVoiceSources()}
             type="button"
@@ -346,9 +360,9 @@ export function VoiceSection({
             Check status
           </button>
         </div>
-        <div className="voice-status-grid">
-          <article>
-            <span>Mode</span>
+        <div className="tiles">
+          <article className="tile">
+            <span className="tile-label">Mode</span>
             <strong>{voiceHeading}</strong>
             <small>
               {settings.voice_source.mode === 'custom'
@@ -359,8 +373,8 @@ export function VoiceSection({
                     'ChatGPT and Codex'}
             </small>
           </article>
-          <article>
-            <span>Status</span>
+          <article className="tile">
+            <span className="tile-label">Status</span>
             <strong>
               {settings.voice_source.mode === 'external'
                 ? 'Waiting for events'
@@ -376,8 +390,8 @@ export function VoiceSection({
                 'No active output stream'}
             </small>
           </article>
-          <article>
-            <span>Available</span>
+          <article className="tile">
+            <span className="tile-label">Available</span>
             <strong>{voiceCatalog?.sources.length ?? 0}</strong>
             <small>
               {voiceCatalog?.platform === 'linux'

--- a/src/components/settings/VroidCharacters.tsx
+++ b/src/components/settings/VroidCharacters.tsx
@@ -38,17 +38,15 @@ function VroidCharacterPortrait({
 
   if (portrait == null) {
     return (
-      <span aria-hidden="true" className="asset-portrait asset-portrait-empty">
+      <span aria-hidden="true" className="row-mark">
         VRM
       </span>
     );
   }
   return (
-    <img
-      alt={`${character.name} portrait`}
-      className="asset-portrait"
-      src={portrait}
-    />
+    <span className="row-mark">
+      <img alt={`${character.name} portrait`} src={portrait} />
+    </span>
   );
 }
 
@@ -65,22 +63,28 @@ function VroidCharacterCard({
   portraitEpoch: number;
 }) {
   return (
-    <article className="asset-card">
-      <VroidCharacterPortrait character={character} key={portraitEpoch} />
-      <span className="asset-card-main">
-        <span>
+    <div className="row-wrap row-wrap-actionable">
+      <div className="row">
+        <VroidCharacterPortrait character={character} key={portraitEpoch} />
+        <span className="row-copy">
           <strong>{character.name}</strong>
           <small>
             {character.is_downloadable ? 'Downloadable on Hub' : 'Hub only'}
           </small>
         </span>
-      </span>
-      <div className="asset-card-footer">
-        <button disabled={busy} onClick={onSelect} type="button">
-          Use this character
+        <span className="row-trailing" />
+      </div>
+      <div className="row-actions row-actions-overlay">
+        <button
+          className="btn btn-secondary btn-sm"
+          disabled={busy}
+          onClick={onSelect}
+          type="button"
+        >
+          Use
         </button>
       </div>
-    </article>
+    </div>
   );
 }
 
@@ -105,14 +109,14 @@ export function VroidCharacterGroup({
     <div className="vroid-character-group">
       <h3>
         {title}
-        <span className="count-badge">{characters.length}</span>
+        <span className="chip">{characters.length}</span>
       </h3>
       {characters.length === 0 ? (
         <p className="desktop-note">{emptyNote}</p>
       ) : (
         <>
           {note && <p className="desktop-note">{note}</p>}
-          <div className="asset-grid">
+          <div className="rows rows-grid">
             {characters.map((character) => (
               <VroidCharacterCard
                 busy={busy}

--- a/src/components/settings/icons.tsx
+++ b/src/components/settings/icons.tsx
@@ -1,0 +1,122 @@
+/**
+ * The icon set for row actions and control marks.
+ *
+ * All 16×16 on the same 1.4 stroke as the nav glyphs, drawn with
+ * `currentColor` so a button's intent colour carries into its icon without a
+ * second rule. Icon-only buttons must still carry an `aria-label`.
+ */
+import type { ReactNode } from 'react';
+
+function Glyph({ children }: { children: ReactNode }) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.4"
+      viewBox="0 0 16 16"
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function TrashIcon() {
+  return (
+    <Glyph>
+      <path d="M3 4.4h10M6.4 4.4V3.2a.8.8 0 0 1 .8-.8h1.6a.8.8 0 0 1 .8.8v1.2" />
+      <path d="M4.4 4.4l.5 8a1 1 0 0 0 1 .9h4.2a1 1 0 0 0 1-.9l.5-8" />
+      <path d="M6.7 6.9v3.8M9.3 6.9v3.8" />
+    </Glyph>
+  );
+}
+
+export function PlayIcon() {
+  return (
+    <Glyph>
+      <path d="M5.6 3.6 12 8l-6.4 4.4z" />
+    </Glyph>
+  );
+}
+
+export function PlusIcon() {
+  return (
+    <Glyph>
+      <path d="M8 3.4v9.2M3.4 8h9.2" />
+    </Glyph>
+  );
+}
+
+export function CopyIcon() {
+  return (
+    <Glyph>
+      <rect x="5.6" y="5.6" width="7.4" height="7.4" rx="1.4" />
+      <path d="M10.4 3.6a1.4 1.4 0 0 0-1.4-1.2H4.4A1.4 1.4 0 0 0 3 3.8v4.6a1.4 1.4 0 0 0 1.2 1.4" />
+    </Glyph>
+  );
+}
+
+export function RefreshIcon() {
+  return (
+    <Glyph>
+      <path d="M13 8a5 5 0 1 1-1.6-3.7" />
+      <path d="M13.2 2.6v3h-3" />
+    </Glyph>
+  );
+}
+
+export function PencilIcon() {
+  return (
+    <Glyph>
+      <path d="m10.3 3.1 2.6 2.6-7 7-3.2.6.6-3.2z" />
+      <path d="m9.1 4.3 2.6 2.6" />
+    </Glyph>
+  );
+}
+
+export function CheckIcon() {
+  return (
+    <Glyph>
+      <path d="m3.4 8.4 3 3 6.2-6.8" />
+    </Glyph>
+  );
+}
+
+export function AutomaticIcon() {
+  return (
+    <Glyph>
+      <path d="M8 2.4v2M8 11.6v2M2.4 8h2M11.6 8h2M4.1 4.1l1.4 1.4M10.5 10.5l1.4 1.4M11.9 4.1l-1.4 1.4M5.5 10.5l-1.4 1.4" />
+      <circle cx="8" cy="8" r="2.1" />
+    </Glyph>
+  );
+}
+
+export function WindowIcon() {
+  return (
+    <Glyph>
+      <rect x="2.4" y="3.2" width="11.2" height="9.6" rx="1.4" />
+      <path d="M2.4 6.1h11.2" />
+    </Glyph>
+  );
+}
+
+export function RegexIcon() {
+  return (
+    <Glyph>
+      <path d="M8 3.2v5.4M5.5 4.6l5 2.7M10.5 4.6l-5 2.7" />
+      <circle cx="4.4" cy="12" r="0.9" />
+    </Glyph>
+  );
+}
+
+export function ExternalIcon() {
+  return (
+    <Glyph>
+      <path d="M9.4 3h3.6v3.6M12.8 3.2 7.6 8.4" />
+      <path d="M12 9.6v2.6a1.2 1.2 0 0 1-1.2 1.2H3.9a1.2 1.2 0 0 1-1.2-1.2V5.3a1.2 1.2 0 0 1 1.2-1.2h2.7" />
+    </Glyph>
+  );
+}

--- a/src/settings-sections.test.ts
+++ b/src/settings-sections.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   SECTIONS,
+  sectionSummary,
   settingsSection,
+  type SectionSummaryFacts,
   type SettingsSection,
 } from './settings-sections';
 
@@ -48,6 +50,66 @@ describe('settings sections', () => {
   it('refuses a section it does not describe rather than rendering a blank header', () => {
     expect(() => settingsSection('nowhere' as SettingsSection)).toThrow(
       /Unknown settings section/,
+    );
+  });
+});
+
+const FACTS: SectionSummaryFacts = {
+  avatarWindow: { height: 680, width: 430 },
+  characterSize: 1,
+  clipCount: 18,
+  developerEnabled: false,
+  mcp: { playableActions: 2, tools: 4 },
+  modelCount: 3,
+  playableActionCount: 2,
+  voiceHeading: 'Automatic detection',
+};
+
+describe('sectionSummary', () => {
+  it('answers the question each section is actually about', () => {
+    expect(sectionSummary('models', FACTS)).toBe('3 models');
+    expect(sectionSummary('animations', FACTS)).toBe('2 actions · 18 clips');
+    expect(sectionSummary('appearance', FACTS)).toBe('100% · 430×680');
+    expect(sectionSummary('voice', FACTS)).toBe('Automatic detection');
+    expect(sectionSummary('mcp', FACTS)).toBe('4 tools · 2 playable actions');
+    expect(sectionSummary('developer', FACTS)).toBe(
+      'Developer settings locked',
+    );
+  });
+
+  it('never leaves a section without a summary', () => {
+    for (const { id } of SECTIONS) {
+      expect(sectionSummary(id, FACTS)).not.toBe('');
+    }
+  });
+
+  it('agrees with itself on singulars', () => {
+    const one = { ...FACTS, clipCount: 1, modelCount: 1, playableActionCount: 1 };
+    expect(sectionSummary('models', one)).toBe('1 model');
+    expect(sectionSummary('animations', one)).toBe('1 action · 1 clip');
+    expect(sectionSummary('mcp', { ...FACTS, mcp: { playableActions: 1, tools: 1 } })).toBe(
+      '1 tool · 1 playable action',
+    );
+  });
+
+  it('says what is missing rather than counting to zero', () => {
+    expect(sectionSummary('models', { ...FACTS, modelCount: 0 })).toBe(
+      'No model configured',
+    );
+    expect(
+      sectionSummary('animations', { ...FACTS, clipCount: 0, playableActionCount: 0 }),
+    ).toBe('0 actions · no clips');
+  });
+
+  it('waits for the main process before describing MCP', () => {
+    expect(sectionSummary('mcp', { ...FACTS, mcp: null })).toBe(
+      'Local agent connection',
+    );
+  });
+
+  it('rounds the character size the way the control shows it', () => {
+    expect(sectionSummary('appearance', { ...FACTS, characterSize: 1.155 })).toBe(
+      '116% · 430×680',
     );
   });
 });

--- a/src/settings-sections.ts
+++ b/src/settings-sections.ts
@@ -65,3 +65,52 @@ export function settingsSection(
   if (!descriptor) throw new Error(`Unknown settings section: ${section}`);
   return descriptor;
 }
+
+/** The facts a section's header summary can be built from. */
+export interface SectionSummaryFacts {
+  avatarWindow: { height: number; width: number };
+  characterSize: number;
+  clipCount: number;
+  developerEnabled: boolean;
+  mcp: { playableActions: number; tools: number } | null;
+  modelCount: number;
+  playableActionCount: number;
+  voiceHeading: string;
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * The line beside a section's title. Each section answers the question a
+ * reader arriving at it actually has, rather than repeating one library count
+ * across every screen.
+ */
+export function sectionSummary(
+  section: SettingsSection,
+  facts: SectionSummaryFacts,
+): string {
+  switch (section) {
+    case 'models':
+      return facts.modelCount === 0
+        ? 'No model configured'
+        : plural(facts.modelCount, 'model');
+    case 'animations':
+      return facts.clipCount === 0
+        ? `${plural(facts.playableActionCount, 'action')} · no clips`
+        : `${plural(facts.playableActionCount, 'action')} · ${plural(facts.clipCount, 'clip')}`;
+    case 'appearance':
+      return `${Math.round(facts.characterSize * 100)}% · ${facts.avatarWindow.width}×${facts.avatarWindow.height}`;
+    case 'voice':
+      return facts.voiceHeading;
+    case 'mcp':
+      return facts.mcp
+        ? `${plural(facts.mcp.tools, 'tool')} · ${plural(facts.mcp.playableActions, 'playable action')}`
+        : 'Local agent connection';
+    case 'developer':
+      return facts.developerEnabled
+        ? 'Developer settings enabled'
+        : 'Developer settings locked';
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,7 +38,17 @@
   --fs-sm: 12px;
   --fs-md: 13px;
   --fs-lg: 15px;
-  --fs-xl: 20px;
+  --fs-xl: 22px;
+
+  /* Spacing. One scale, so every gap in the window is a multiple of 4. */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 20px;
+  --sp-6: 24px;
+  --sp-7: 32px;
+  --sp-8: 40px;
 
   /* Radii */
   --r-sm: 5px;
@@ -46,6 +56,19 @@
   --r-lg: 10px;
   --r-xl: 14px;
   --r-full: 999px;
+
+  /* Control heights. Every clickable control lands on one of these. */
+  --h-sm: 28px;
+  --h-md: 32px;
+  --h-lg: 36px;
+
+  /* The reading measure for descriptive copy. */
+  --measure: 64ch;
+
+  /* Settings content stops widening past this and centres instead. A label at
+     one edge of a 1600px panel and its control at the other is not a row the
+     eye can pair up. */
+  --content-max: 900px;
 
   /* Motion */
   --ease: cubic-bezier(0.22, 0.61, 0.36, 1);
@@ -307,7 +330,7 @@ button {
 
 .settings-app {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr) minmax(300px, 34%);
+  grid-template-columns: 212px minmax(0, 1fr) minmax(272px, 29%);
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -318,7 +341,7 @@ button {
 }
 
 .settings-app.preview-collapsed {
-  grid-template-columns: 220px minmax(0, 1fr) 44px;
+  grid-template-columns: 212px minmax(0, 1fr) 44px;
 }
 
 /* --- Sidebar ------------------------------------------------------------- */
@@ -399,17 +422,26 @@ button {
   background: var(--accent-soft);
 }
 
-/* Active marker instead of a full accent border. */
+/* Active marker inside the item, so it reads as part of the row rather than
+   as a sliver pinned to the window edge. */
 .settings-sidebar nav button.active::before {
   content: "";
   position: absolute;
   top: 50%;
-  left: -12px;
+  left: 0;
   width: 3px;
-  height: 18px;
+  height: 20px;
   transform: translateY(-50%);
-  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  border-radius: var(--r-full);
   background: var(--accent);
+}
+
+.settings-sidebar nav button.active .settings-nav-copy strong {
+  font-weight: 600;
+}
+
+.settings-sidebar nav button.active .nav-glyph {
+  color: var(--accent-text);
 }
 
 .settings-nav-copy {
@@ -466,15 +498,6 @@ button {
   font-size: var(--fs-xs);
 }
 
-.status-dot,
-.preview-live i {
-  width: 6px;
-  height: 6px;
-  flex: 0 0 auto;
-  border-radius: var(--r-full);
-  background: var(--success);
-}
-
 /* --- Content pane -------------------------------------------------------- */
 
 .settings-content {
@@ -492,16 +515,23 @@ button {
 }
 
 .settings-heading {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 20px;
-  padding: 24px 28px 18px;
+  padding: var(--sp-6) var(--sp-6) var(--sp-4);
+  /* The rule stays full-bleed while its content lines up with the panels. */
   border-bottom: 1px solid var(--border);
 }
 
+.settings-heading-inner {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-5);
+  width: 100%;
+  max-width: var(--content-max);
+  margin-inline: auto;
+}
+
 /* Title first, description underneath — reads as a real page header. */
-.settings-heading > div {
+.settings-heading-inner > div {
   display: flex;
   min-width: 0;
   flex-direction: column-reverse;
@@ -516,7 +546,7 @@ button {
   line-height: 1.25;
 }
 
-.settings-heading .eyebrow {
+.settings-heading-inner .eyebrow {
   color: var(--text-secondary);
   font-size: var(--fs-md);
   font-weight: 400;
@@ -602,29 +632,42 @@ button {
   display: flex;
   flex: 1;
   flex-direction: column;
+  align-items: center;
+  gap: var(--sp-3);
   min-height: 0;
-  padding: 4px 28px 40px;
+  padding: var(--sp-5) var(--sp-6) var(--sp-8);
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
 }
 
-.settings-panel {
-  flex: 0 0 auto;
-  padding: 24px 0;
-  border-bottom: 1px solid var(--border);
+.settings-scroll > * {
+  width: 100%;
+  max-width: var(--content-max);
 }
 
-.settings-panel:last-child {
-  border-bottom: 0;
+/* Every block of settings is a card on the working surface. Hairline rules
+   between sections read as one long document; discrete cards let the eye find
+   the group it wants without reading the headings. */
+.settings-panel {
+  flex: 0 0 auto;
+  padding: var(--sp-5);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  background: var(--bg-card);
 }
 
 .panel-heading {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 16px;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-4);
+}
+
+/* A heading with nothing under it is a label for the panel, not a header. */
+.panel-heading:last-child {
+  margin-bottom: 0;
 }
 
 .panel-heading > div {
@@ -639,10 +682,18 @@ button {
   line-height: 1.35;
 }
 
+/* The trailing side of a panel heading: one action, or a status chip. */
+.panel-actions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--sp-2);
+}
+
 .panel-heading p,
 .desktop-note {
   margin: 4px 0 0;
-  max-width: 62ch;
+  max-width: var(--measure);
   color: var(--text-secondary);
   font-size: var(--fs-sm);
   line-height: 1.55;
@@ -663,7 +714,723 @@ button {
 
 /* 5. Primitives =========================================================== */
 
-/* --- Buttons ------------------------------------------------------------- */
+/* --- Buttons -------------------------------------------------------------
+   One base, four intents, three sizes. Everything clickable that is not a row
+   or a field uses this; the older per-section button rules below are being
+   retired onto it. */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  height: var(--h-md);
+  padding: 0 var(--sp-3);
+  border: 1px solid transparent;
+  border-radius: var(--r-md);
+  color: var(--text-primary);
+  background: transparent;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  transition:
+    color var(--dur) var(--ease),
+    background var(--dur) var(--ease),
+    border-color var(--dur) var(--ease);
+}
+
+.btn-primary {
+  border-color: transparent;
+  color: var(--text-on-accent);
+  background: var(--accent);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.btn-primary:active:not(:disabled) {
+  background: var(--accent-active);
+}
+
+.btn-secondary {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+  background: var(--bg-raised);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.btn-ghost {
+  color: var(--text-secondary);
+  background: transparent;
+}
+
+.btn-ghost:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--fill-hover);
+}
+
+.btn-danger {
+  color: var(--danger-text);
+  background: transparent;
+}
+
+.btn-danger:hover:not(:disabled) {
+  color: var(--danger-text-hover);
+  background: var(--danger-soft);
+}
+
+/* A secondary button whose action is destructive: the frame keeps it grouped
+   with its neighbours, the colour says what it does. */
+.btn-danger-text {
+  color: var(--danger-text);
+}
+
+.btn-danger-text:hover:not(:disabled) {
+  border-color: var(--danger-border);
+  color: var(--danger-text-hover);
+  background: var(--danger-soft);
+}
+
+.btn-sm {
+  height: var(--h-sm);
+  padding: 0 10px;
+  font-size: var(--fs-sm);
+}
+
+.btn-icon {
+  width: var(--h-sm);
+  height: var(--h-sm);
+  padding: 0;
+}
+
+.btn-icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+/* --- Rows ----------------------------------------------------------------
+   The list primitive: a leading mark, a two-line copy block, and a trailing
+   action cluster. Models, animation clips, voice sources, and MCP tools are
+   all this shape, and previously each drew its own. */
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  background: var(--bg-raised);
+}
+
+.row {
+  display: grid;
+  align-items: center;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--sp-3);
+  width: 100%;
+  min-height: 52px;
+  padding: 10px var(--sp-3);
+  border: 0;
+  border-top: 1px solid var(--border);
+  color: inherit;
+  background: transparent;
+  text-align: left;
+  transition: background var(--dur) var(--ease);
+}
+
+.row:first-child {
+  border-top: 0;
+}
+
+.row-selectable {
+  cursor: pointer;
+}
+
+/* The list clips its corners, so an outset focus ring on a row would be cut
+   off. Draw it inside the row instead. */
+.row:focus-visible {
+  outline-offset: -2px;
+}
+
+.row-selectable:hover {
+  background: var(--fill-hover);
+}
+
+/* Selected is carried by colour and a check, never by the check alone: the
+   whole row has to read as chosen at a glance across a long list. */
+.row[aria-checked='true'],
+.row.is-selected {
+  background: var(--accent-soft);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.row[aria-checked='true']:hover,
+.row.is-selected:hover {
+  background: var(--accent-soft-hover);
+}
+
+.row-mark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--text-tertiary);
+  background: var(--fill-subtle);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  overflow: hidden;
+}
+
+.row[aria-checked='true'] .row-mark {
+  border-color: var(--accent-border);
+  color: var(--accent-text);
+  background: var(--accent-soft);
+}
+
+.row-mark img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.row-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.row-copy strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-copy small {
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Trailing actions stay out of the way until the row is pointed at or holds
+   focus, so a long list reads as content rather than a wall of buttons. The
+   badge that says *what a row is* is not an action and always shows. */
+.row-actions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--sp-1);
+  opacity: 0;
+  transition: opacity var(--dur) var(--ease);
+}
+
+.row:hover .row-actions,
+.row:focus-within .row-actions,
+.row-actions:focus-within,
+.row[aria-checked='true'] .row-actions {
+  opacity: 1;
+}
+
+/* Pointer-less input never fires hover, so never hide the actions there. */
+@media (hover: none) {
+  .row-actions {
+    opacity: 1;
+  }
+}
+
+.row-trailing {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--sp-2);
+}
+
+/* A dense list — many short, equal items such as animation clips — reads
+   better as a wrapping grid than as one long column. Each item becomes its own
+   bordered tile, so there are no dividers to reconcile across columns. */
+.rows-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(196px, 1fr));
+  gap: var(--sp-2);
+  border: 0;
+  border-radius: 0;
+  background: none;
+  overflow: visible;
+}
+
+.rows-grid .row-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  background: var(--bg-card);
+}
+
+.rows-grid .row {
+  min-height: 48px;
+  border-top: 0;
+}
+
+.rows-grid .row-wrap-actionable .row {
+  padding-right: 44px;
+}
+
+/* A row whose whole surface selects, so its per-item actions cannot be nested
+   buttons. They ride on top of the trailing edge instead, and the row reserves
+   room for them so nothing is ever covered. */
+.row-wrap {
+  position: relative;
+  display: flex;
+}
+
+.row-wrap .row {
+  flex: 1 1 auto;
+}
+
+/* Row actions occupy the same place as the row's trailing badge and trade with
+   it on hover, so no width is reserved for buttons that are not showing. Rows
+   that carry no actions keep their badge at all times. */
+.row-wrap-actionable .row {
+  padding-right: 128px;
+}
+
+.row-actions-overlay {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+}
+
+.row-wrap:hover .row-actions,
+.row-wrap:focus-within .row-actions {
+  opacity: 1;
+}
+
+.row-wrap-actionable:hover .row-trailing,
+.row-wrap-actionable:focus-within .row-trailing {
+  opacity: 0;
+}
+
+.row-trailing {
+  transition: opacity var(--dur) var(--ease);
+}
+
+/* --- Choice cards --------------------------------------------------------
+   A small set of mutually exclusive modes, each needing a sentence of
+   explanation. Radio semantics, so arrow keys move between them. */
+
+.choice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: var(--sp-2);
+}
+
+.choice {
+  display: grid;
+  align-items: start;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  padding: var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  color: inherit;
+  background: var(--bg-raised);
+  text-align: left;
+  transition:
+    border-color var(--dur) var(--ease),
+    background var(--dur) var(--ease);
+}
+
+.choice:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-raised);
+}
+
+.choice[aria-checked='true'] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+}
+
+.choice:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.choice-mark {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--text-tertiary);
+  background: var(--fill-sunken);
+}
+
+.choice[aria-checked='true'] .choice-mark {
+  border-color: var(--accent-border);
+  color: var(--accent-text);
+  background: var(--accent-soft-hover);
+}
+
+.choice-mark svg {
+  width: 14px;
+  height: 14px;
+}
+
+.choice-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.choice-copy strong {
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  font-weight: 550;
+}
+
+.choice[aria-checked='true'] .choice-copy strong {
+  color: var(--accent-text);
+}
+
+.choice-copy small {
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+/* --- Action cards --------------------------------------------------------
+   One configured animation action: what it is, when Persona runs it, and the
+   clips it can choose from. */
+
+.animation-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.action-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  padding: var(--sp-4);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-raised);
+}
+
+.action-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  min-height: var(--h-sm);
+}
+
+.action-title {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: var(--sp-2);
+}
+
+.action-title strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Card-level actions stay visible: unlike a row in a long list, there are few
+   of these and each card is a destination rather than something scanned past. */
+.action-head-actions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--sp-1);
+}
+
+.action-desc {
+  margin: 0;
+  max-width: var(--measure);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+
+/* --- Metadata list -------------------------------------------------------
+   Label/value pairs where the labels align, so the values read as a column
+   rather than as more prose. */
+
+.meta-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 0;
+}
+
+.meta-list > div {
+  display: grid;
+  align-items: baseline;
+  grid-template-columns: 76px minmax(0, 1fr);
+  gap: var(--sp-2);
+}
+
+.meta-list dt {
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.meta-list dd {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+.row-mark-play svg {
+  width: 14px;
+  height: 14px;
+}
+
+.row-selectable:hover .row-mark-play {
+  border-color: var(--accent-border);
+  color: var(--accent-text);
+}
+
+.empty-clips {
+  margin: 0;
+  padding: var(--sp-3);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-lg);
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+/* --- Stat tiles ----------------------------------------------------------
+   Read-only facts about something running. One grid definition, so the MCP
+   and voice panels no longer disagree about how many fit in a row. */
+
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--sp-2);
+}
+
+/* Four facts wrap to 3 + 1 in an auto-fit grid at this width, stranding the
+   last one. Pair them instead until there is room for the whole row. */
+.tiles-quad {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (min-width: 1400px) {
+  .tiles-quad {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding: var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-raised);
+}
+
+.tile-label {
+  color: var(--text-tertiary);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.tile strong {
+  color: var(--text-primary);
+  font-size: var(--fs-lg);
+  font-weight: 600;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.tile small {
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+}
+
+/* --- Fields --------------------------------------------------------------
+   Label above, control, hint below. Used by every text input, select, and
+   slider so their labels line up across panels. */
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+.field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+  font-weight: 550;
+}
+
+.field-hint {
+  max-width: var(--measure);
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+.field-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--sp-2);
+}
+
+.field-row .field {
+  flex: 1 1 0;
+}
+
+/* --- Chips ---------------------------------------------------------------
+   A short, non-interactive statement about the thing next to it. */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.chip-accent {
+  color: var(--accent-text);
+}
+
+.chip-success {
+  color: var(--success-text);
+}
+
+.chip-danger {
+  color: var(--danger-text);
+}
+
+/* --- Copyable value ------------------------------------------------------ */
+
+.code-row {
+  display: grid;
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--sp-3);
+  padding: 10px var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--fill-sunken);
+}
+
+.code-row > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.code-row span {
+  color: var(--text-tertiary);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.code-row code {
+  overflow-x: auto;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  white-space: nowrap;
+  scrollbar-width: none;
+}
+
+.code-row code::-webkit-scrollbar {
+  display: none;
+}
+
+/* --- Stacks -------------------------------------------------------------- */
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.stack-tight {
+  gap: var(--sp-2);
+}
+
+/* --- Sub-heading inside a panel ------------------------------------------ */
+
+.subhead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.subhead > span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+/* --- Buttons (legacy names, retained while sections migrate) ------------- */
 
 .primary-button {
   display: inline-flex;
@@ -727,46 +1494,6 @@ button {
   cursor: default;
 }
 
-/* Ghost text buttons inside cards — real hit targets, not bare 9px labels. */
-.asset-card-footer button:not(.default-badge),
-.animation-card-actions > button {
-  min-height: 26px;
-  padding: 0 8px;
-  border: 0;
-  border-radius: var(--r-sm);
-  color: var(--text-secondary);
-  background: transparent;
-  font-size: var(--fs-sm);
-  font-weight: 500;
-  white-space: nowrap;
-  transition:
-    color var(--dur) var(--ease),
-    background var(--dur) var(--ease);
-}
-
-.asset-card-footer button:hover:not(:disabled),
-.animation-card-actions > button:hover:not(:disabled) {
-  color: var(--text-primary);
-  background: var(--fill-hover);
-}
-
-.asset-card-footer button:disabled,
-.animation-card-actions > button:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
-.danger-text-button {
-  color: var(--danger-text) !important;
-}
-
-.danger-text-button:hover:not(:disabled) {
-  color: var(--danger-text-hover) !important;
-  background: var(--danger-soft) !important;
-}
-
-.asset-card-actions,
-.animation-card-actions,
 .form-actions {
   display: flex;
   align-items: center;
@@ -778,40 +1505,8 @@ button {
   margin-top: 16px;
 }
 
-/* --- Badges -------------------------------------------------------------- */
-
-.file-pill,
-.default-badge,
-.count-badge {
-  display: inline-flex;
-  align-items: center;
-  height: 22px;
-  padding: 0 9px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-full);
-  color: var(--text-secondary);
-  background: var(--bg-raised);
-  font-size: var(--fs-xs);
-  font-weight: 500;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.default-badge {
-  border-color: var(--accent-border);
-  color: var(--accent-text);
-  background: var(--accent-soft);
-}
-
-.count-badge {
-  height: 20px;
-  padding: 0 7px;
-  color: var(--text-tertiary);
-}
-
 /* --- Fields -------------------------------------------------------------- */
 
-.import-panel label,
 .form-stack label {
   display: flex;
   flex-direction: column;
@@ -823,7 +1518,6 @@ button {
   font-weight: 500;
 }
 
-.import-panel label code,
 .form-stack label code {
   padding: 1px 5px;
   border-radius: var(--r-sm);
@@ -834,7 +1528,6 @@ button {
 }
 
 /* Range inputs bring their own chrome — see .single-range-slider. */
-.import-panel input:not([type="range"]),
 .form-stack input:not([type="range"]),
 .form-stack select,
 .form-stack textarea {
@@ -851,7 +1544,6 @@ button {
     box-shadow var(--dur) var(--ease);
 }
 
-.import-panel input:not([type="range"]),
 .form-stack input:not([type="range"]),
 .form-stack select {
   height: 34px;
@@ -876,20 +1568,17 @@ button {
   line-height: 1.55;
 }
 
-.import-panel input::placeholder,
 .form-stack input::placeholder,
 .form-stack textarea::placeholder {
   color: var(--text-tertiary);
 }
 
-.import-panel input:not([type="range"]):hover,
 .form-stack input:not([type="range"]):hover,
 .form-stack select:hover,
 .form-stack textarea:hover {
   border-color: var(--border-strong);
 }
 
-.import-panel input:not([type="range"]):focus,
 .form-stack input:not([type="range"]):focus,
 .form-stack select:focus,
 .form-stack textarea:focus {
@@ -971,481 +1660,31 @@ button {
   line-height: 1.6;
 }
 
-.asset-grid > .empty-library {
-  grid-column: 1 / -1;
-}
-
 /* 6. Section components =================================================== */
-
-/* --- Model cards --------------------------------------------------------- */
-
-.asset-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
-  gap: 10px;
-}
-
-.asset-card {
-  min-width: 0;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--bg-card);
-  transition:
-    border-color var(--dur) var(--ease),
-    background var(--dur) var(--ease),
-    box-shadow var(--dur) var(--ease);
-}
-
-.asset-card:hover {
-  border-color: var(--border-strong);
-  background: var(--bg-raised);
-}
-
-.asset-card.selected {
-  border-color: var(--accent-border);
-  background: var(--bg-raised);
-  box-shadow: inset 0 0 0 1px var(--accent-border);
-}
-
-.asset-card-main {
-  display: flex;
-  align-items: center;
-  gap: 11px;
-  width: 100%;
-  padding: 13px 14px;
-  border: 0;
-  text-align: left;
-  background: transparent;
-}
-
-.asset-card-main > span:last-child {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-}
-
-.asset-card-main strong {
-  overflow: hidden;
-  color: var(--text-primary);
-  font-size: var(--fs-md);
-  font-weight: 500;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.asset-card-main small {
-  overflow: hidden;
-  margin-top: 2px;
-  color: var(--text-tertiary);
-  font-size: var(--fs-sm);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.asset-icon,
-.clip-file-icon {
-  display: grid;
-  flex: 0 0 auto;
-  place-items: center;
-  border: 1px solid var(--border);
-  color: var(--text-tertiary);
-  background: var(--fill-subtle);
-  font-family: var(--font-mono);
-  font-weight: 500;
-  letter-spacing: 0.02em;
-}
-
-.asset-icon {
-  width: 34px;
-  height: 34px;
-  border-radius: var(--r-md);
-  font-size: var(--fs-xs);
-}
-
-.asset-card.selected .asset-icon {
-  border-color: var(--accent-border);
-  color: var(--accent-text);
-  background: var(--accent-soft);
-}
-
-/* VRoid Hub cards lead with the character's portrait: models are often left
-   unnamed on Hub, so the picture is the only thing that tells them apart. */
-.asset-portrait {
-  display: block;
-  width: 100%;
-  max-height: 220px;
-  aspect-ratio: 4 / 3;
-  border-bottom: 1px solid var(--border);
-  background: var(--fill-subtle);
-  object-fit: cover;
-  /* Hub portraits frame the character centred with headroom above, so bias
-     the crop upwards to keep the face in a box wider than it is tall. */
-  object-position: center 20%;
-}
-
-.asset-portrait-empty {
-  display: grid;
-  place-items: center;
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: var(--fs-xs);
-  font-weight: 500;
-  letter-spacing: 0.02em;
-}
-
-.asset-card-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  min-height: 40px;
-  padding: 6px 10px;
-  border-top: 1px solid var(--border);
-}
 
 /* --- VRoid Hub character groups ------------------------------------------ */
 
-.vroid-character-group {
-  margin-top: 22px;
-}
-
-.vroid-character-group > h3 {
+.vroid-character-group h3 {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 0 0 10px;
+  gap: var(--sp-2);
+  margin: 0 0 var(--sp-2);
+  color: var(--text-primary);
   font-size: var(--fs-md);
   font-weight: 600;
-  letter-spacing: -0.004em;
+}
+
+.vroid-character-group {
+  margin-top: var(--sp-5);
 }
 
 .vroid-character-group > .desktop-note {
-  margin-top: 0;
-}
-
-.vroid-character-group > .desktop-note + .asset-grid {
-  margin-top: 12px;
-}
-
-/* --- Animation action cards ---------------------------------------------- */
-
-.animation-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.animation-card {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--bg-card);
-}
-
-.system-action-card {
-  border-color: var(--border-strong);
-}
-
-.animation-card-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: flex-start;
-  gap: 14px;
-  padding: 14px;
-}
-
-.animation-card-copy {
-  min-width: 0;
-}
-
-.animation-card-copy > div {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
-.animation-card-copy strong {
-  overflow: hidden;
-  color: var(--text-primary);
-  font-size: var(--fs-md);
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.animation-card-copy > div span {
-  flex: 0 0 auto;
-  padding: 1px 7px;
-  border-radius: var(--r-full);
-  color: var(--text-tertiary);
-  background: var(--fill-subtle);
-  font-size: var(--fs-xs);
-  white-space: nowrap;
-}
-
-.system-action-card .animation-card-copy > div span {
-  color: var(--accent-text);
-  background: var(--accent-soft);
-}
-
-.animation-card-copy p {
-  margin: 6px 0 0;
-  max-width: 68ch;
-  color: var(--text-secondary);
-  font-size: var(--fs-sm);
-  line-height: 1.55;
-}
-
-.animation-card-copy small {
-  display: block;
-  margin-top: 4px;
-  max-width: 68ch;
-  color: var(--text-tertiary);
-  font-size: var(--fs-sm);
-  line-height: 1.55;
-}
-
-.animation-card-copy b {
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-
-.animation-card-expression .expression-weight-tag {
-  margin-left: 6px;
-  padding: 1px 5px;
-  border-radius: var(--r-sm);
-  color: var(--text-secondary);
-  background: var(--fill-subtle);
-  font-family: var(--font-mono);
-  font-size: var(--fs-xs);
-  font-variant-numeric: tabular-nums;
-}
-
-.animation-clips {
-  padding: 12px 14px 14px;
-  border-top: 1px solid var(--border);
-  background: var(--fill-sunken);
-}
-
-.animation-clips-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.animation-clips-heading > div {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  min-width: 0;
-}
-
-.animation-clips-heading strong {
-  color: var(--text-secondary);
-  font-size: var(--fs-sm);
-  font-weight: 600;
-}
-
-.animation-clips-heading span {
-  color: var(--text-tertiary);
-  font-size: var(--fs-sm);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.add-clips-button {
-  min-height: 26px;
-}
-
-.empty-clips {
-  margin: 10px 0 0;
-  max-width: 66ch;
-  color: var(--text-tertiary);
-  font-size: var(--fs-sm);
-  line-height: 1.55;
-}
-
-/* --- Clip chips ---------------------------------------------------------- */
-
-.clip-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 8px;
-  margin-top: 12px;
-}
-
-.clip-chip {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  grid-template-areas:
-    "icon name delete"
-    "icon origin delete";
-  align-items: center;
-  column-gap: 10px;
-  min-width: 0;
-  padding: 8px 8px 8px 9px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--bg-card);
-  cursor: pointer;
-  transition:
-    border-color var(--dur) var(--ease),
-    background var(--dur) var(--ease),
-    box-shadow var(--dur) var(--ease);
-}
-
-.clip-chip:hover {
-  border-color: var(--border-strong);
-  background: var(--bg-raised);
-}
-
-.clip-chip.playing {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-  box-shadow: inset 0 0 0 1px var(--accent-border);
-}
-
-.clip-file-icon {
-  grid-area: icon;
-  width: 32px;
-  height: 30px;
-  border-radius: var(--r-sm);
-  font-size: var(--fs-xs);
-  letter-spacing: 0;
-}
-
-.clip-chip.playing .clip-file-icon {
-  border-color: var(--accent-border);
-  color: var(--accent-text);
-  background: var(--accent-soft-hover);
-}
-
-.clip-chip strong {
-  grid-area: name;
-  overflow: hidden;
-  color: var(--text-primary);
-  font-size: var(--fs-sm);
-  font-weight: 500;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.clip-chip small {
-  grid-area: origin;
-  overflow: hidden;
-  color: var(--text-tertiary);
-  font-size: var(--fs-xs);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.clip-delete {
-  grid-area: delete;
-  display: grid;
-  width: 24px;
-  height: 24px;
-  place-items: center;
-  padding: 0;
-  border: 0;
-  border-radius: var(--r-sm);
-  color: var(--text-tertiary);
-  background: transparent;
-  font-size: 15px;
-  line-height: 1;
-  transition:
-    color var(--dur) var(--ease),
-    background var(--dur) var(--ease);
-}
-
-.clip-delete:hover:not(:disabled) {
-  color: var(--danger-text);
-  background: var(--danger-soft);
-}
-
-.clip-delete:disabled {
-  opacity: 0.4;
-  cursor: default;
+  margin: 0 0 var(--sp-2);
 }
 
 /* --- Edit panel --------------------------------------------------------- */
 
-.edit-panel {
-  padding-left: 18px;
-  border-left: 2px solid var(--accent);
-}
-
 /* --- Voice source ------------------------------------------------------- */
-
-.voice-mode-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.voice-mode-grid button {
-  display: grid;
-  grid-template-columns: 30px minmax(0, 1fr);
-  gap: 2px 10px;
-  min-width: 0;
-  padding: 13px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  color: var(--text-secondary);
-  text-align: left;
-  background: var(--bg-card);
-  transition:
-    border-color var(--dur) var(--ease),
-    background var(--dur) var(--ease),
-    color var(--dur) var(--ease);
-}
-
-.voice-mode-grid button:hover:not(:disabled) {
-  color: var(--text-primary);
-  background: var(--bg-raised);
-}
-
-.voice-mode-grid button[aria-pressed="true"] {
-  border-color: var(--accent-border);
-  color: var(--text-primary);
-  background: var(--accent-soft);
-}
-
-.voice-mode-grid button:disabled {
-  opacity: 0.45;
-}
-
-.voice-mode-icon {
-  display: inline-flex;
-  grid-row: 1 / span 2;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--border-strong);
-  border-radius: var(--r-md);
-  color: var(--accent-text);
-  background: var(--bg-raised);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: var(--fs-sm);
-  font-weight: 600;
-}
-
-.voice-mode-grid strong {
-  overflow: hidden;
-  font-size: var(--fs-md);
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.voice-mode-grid small {
-  color: var(--text-tertiary);
-  font-size: var(--fs-xs);
-  line-height: 1.4;
-}
 
 .voice-source-search {
   display: flex;
@@ -1577,48 +1816,6 @@ button {
 .source-state.unavailable {
   color: var(--danger-text);
   background: var(--danger-soft);
-}
-
-.voice-status-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.voice-status-grid article {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  padding: 13px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--bg-card);
-}
-
-.voice-status-grid span {
-  color: var(--text-tertiary);
-  font-size: var(--fs-xs);
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.voice-status-grid strong {
-  overflow: hidden;
-  margin-top: 8px;
-  font-size: var(--fs-lg);
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.voice-status-grid small {
-  overflow: hidden;
-  margin-top: 3px;
-  color: var(--text-tertiary);
-  font-size: var(--fs-xs);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* --- Appearance --------------------------------------------------------- */
@@ -1857,7 +2054,8 @@ button {
 
 .avatar-window-size-row {
   display: flex;
-  gap: 12px;
+  align-items: flex-end;
+  gap: var(--sp-2);
 }
 
 .avatar-window-size-row label {
@@ -1872,9 +2070,13 @@ button {
   font-weight: 500;
 }
 
+.avatar-window-size-row .btn {
+  height: var(--h-lg);
+}
+
 .avatar-window-size-row input {
   width: 100%;
-  height: 34px;
+  height: var(--h-lg);
   padding: 0 11px;
   border: 1px solid var(--border-strong);
   border-radius: var(--r-md);
@@ -2127,22 +2329,6 @@ button {
   font-size: var(--fs-md);
 }
 
-.lighting-reset-button {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--text-tertiary);
-  border-radius: var(--r-md);
-  padding: 5px 12px;
-  font-size: var(--fs-sm);
-  cursor: pointer;
-  transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease);
-}
-
-.lighting-reset-button:hover:not(:disabled) {
-  border-color: var(--accent);
-  color: var(--text-primary);
-}
-
 .lighting-panel :is(button, input, select):disabled {
   cursor: not-allowed;
   opacity: 0.5;
@@ -2196,102 +2382,23 @@ button {
 .mcp-health-badge {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  height: 24px;
   flex: 0 0 auto;
-  padding: 0 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-full);
   color: var(--text-secondary);
-  background: var(--bg-raised);
   font-size: var(--fs-xs);
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
-}
-
-.mcp-health-badge i {
-  width: 6px;
-  height: 6px;
-  flex: 0 0 auto;
-  border-radius: var(--r-full);
-  background: var(--text-tertiary);
 }
 
 .mcp-health-badge.online {
-  border-color: var(--success-border);
   color: var(--success-text);
-  background: var(--success-soft);
 }
 
-.mcp-health-badge.online i {
-  background: var(--success);
-}
-
-.mcp-health-badge.starting i {
-  background: var(--warn);
-  animation: pulse 1.4s var(--ease) infinite;
-}
-
-@keyframes pulse {
-  50% {
-    opacity: 0.35;
-  }
+.mcp-health-badge.starting {
+  color: var(--warn);
 }
 
 .mcp-health-badge.unavailable {
-  border-color: var(--danger-border);
   color: var(--danger-text);
-  background: var(--danger-soft);
-}
-
-.mcp-health-badge.unavailable i {
-  background: var(--danger);
-}
-
-.mcp-status-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.mcp-status-grid article {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  padding: 13px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--bg-card);
-}
-
-.mcp-status-grid span,
-.mcp-copy-field span {
-  color: var(--text-tertiary);
-  font-size: var(--fs-xs);
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.mcp-status-grid strong {
-  overflow: hidden;
-  margin-top: 8px;
-  color: var(--text-primary);
-  font-size: var(--fs-lg);
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.006em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.mcp-status-grid small {
-  overflow: hidden;
-  margin-top: 3px;
-  color: var(--text-tertiary);
-  font-size: var(--fs-sm);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .mcp-error-message {
@@ -2306,10 +2413,10 @@ button {
 }
 
 .settings-disclosure {
-  margin-top: 12px;
+  margin-top: var(--sp-3);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
-  background: var(--bg-card);
+  background: var(--bg-raised);
 }
 
 .settings-disclosure > summary {
@@ -2348,47 +2455,36 @@ button {
 }
 
 .settings-disclosure-body {
-  padding: 0 14px 14px;
+  padding: 0 var(--sp-3) var(--sp-3);
+}
+
+.settings-disclosure-body .form-stack {
+  gap: var(--sp-3);
+}
+
+.settings-disclosure-body input:not([type='range']) {
+  width: 100%;
+  height: var(--h-lg);
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  outline: none;
+  color: var(--text-primary);
+  background: var(--fill-sunken);
+  font-size: var(--fs-md);
+}
+
+.settings-disclosure-body input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .settings-disclosure-body > .desktop-note {
   margin-top: 0;
 }
 
-.settings-disclosure-body > .mcp-copy-field {
-  margin-top: 10px;
-}
-
-.mcp-copy-field {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-  margin-top: 10px;
-  padding: 11px 11px 11px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--bg-card);
-}
-
-.mcp-copy-field > div {
-  display: flex;
-  min-width: 0;
-  flex: 1;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.mcp-copy-field code {
-  overflow: hidden;
-  color: var(--text-primary);
-  font-size: var(--fs-sm);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.mcp-copy-field .secondary-button {
-  flex: 0 0 auto;
+.settings-disclosure-body > .code-row {
+  margin-top: var(--sp-2);
 }
 
 .mcp-tool-list {
@@ -2503,39 +2599,21 @@ button {
 
 .preview-header {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 0 0 14px 30px;
-}
-
-.preview-header > div {
-  min-width: 0;
+  gap: var(--sp-3);
+  height: var(--h-lg);
+  padding: 0 0 var(--sp-3) 30px;
 }
 
 .preview-header strong {
-  display: block;
+  min-width: 0;
   overflow: hidden;
-  margin-top: 3px;
   color: var(--text-primary);
   font-size: var(--fs-md);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.preview-live {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex: 0 0 auto;
-  color: var(--text-tertiary);
-  font-size: var(--fs-xs);
-}
-
-.preview-live i {
-  display: block;
-  animation: pulse 2.4s var(--ease) infinite;
 }
 
 .preview-stage {
@@ -2636,6 +2714,100 @@ button {
   animation: dialog-in 160ms var(--ease);
 }
 
+/* Form dialogs: one column, and a body that scrolls inside the dialog rather
+   than growing it past the window on a short screen. */
+.settings-dialog:not(.settings-dialog-confirmation) {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: min(720px, calc(100vh - 64px));
+  padding: 0;
+}
+
+.settings-dialog-wide {
+  width: min(560px, calc(100vw - 48px));
+}
+
+.settings-dialog:focus {
+  outline: none;
+}
+
+.settings-dialog-head {
+  flex: 0 0 auto;
+  padding: var(--sp-5) var(--sp-5) var(--sp-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-dialog-head h2 {
+  margin: 5px 0 0;
+  font-size: var(--fs-lg);
+  font-weight: 600;
+  letter-spacing: -0.006em;
+  line-height: 1.35;
+}
+
+.settings-dialog-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: var(--sp-5);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.dialog-lede {
+  margin: 0 0 var(--sp-4);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+
+/* Inputs inside a dialog own their full width: the label above them already
+   says what they are, so there is nothing to sit beside. */
+.settings-dialog-body input:not([type='range']),
+.settings-dialog-body textarea,
+.settings-dialog-body select {
+  width: 100%;
+  padding: 8px var(--sp-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  outline: none;
+  color: var(--text-primary);
+  background: var(--fill-sunken);
+  font-size: var(--fs-md);
+  line-height: 1.5;
+  caret-color: var(--accent-text);
+  transition:
+    border-color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease);
+}
+
+.settings-dialog-body input:not([type='range']) {
+  height: var(--h-lg);
+  padding-block: 0;
+}
+
+.settings-dialog-body textarea {
+  min-height: 68px;
+  resize: vertical;
+}
+
+.settings-dialog-body input:focus,
+.settings-dialog-body textarea:focus,
+.settings-dialog-body select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.settings-dialog-body .field-label code {
+  padding: 1px 5px;
+  border-radius: var(--r-sm);
+  color: var(--text-tertiary);
+  background: var(--fill-subtle);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: 400;
+}
+
 @keyframes dialog-in {
   from {
     opacity: 0;
@@ -2730,8 +2902,17 @@ button {
   grid-column: 1 / -1;
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--sp-2);
   margin-top: 6px;
+}
+
+.settings-dialog:not(.settings-dialog-confirmation) .settings-dialog-actions {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: var(--sp-3) var(--sp-5);
+  border-top: 1px solid var(--border);
+  background: var(--fill-sunken);
+  border-radius: 0 0 var(--r-xl) var(--r-xl);
 }
 
 .settings-dialog-actions .secondary-button,
@@ -2797,7 +2978,7 @@ button {
   }
 
   .settings-sidebar nav button.active::before {
-    left: -10px;
+    left: 2px;
   }
 
   .settings-sidebar-status {
@@ -2810,11 +2991,6 @@ button {
   .settings-scroll {
     padding-right: 22px;
     padding-left: 22px;
-  }
-
-  .asset-grid,
-  .clip-list {
-    grid-template-columns: 1fr;
   }
 
   .mcp-tool-list article {


### PR DESCRIPTION
## Summary

- refresh the Settings layout, panel hierarchy, controls, and icons across every section
- move model and animation creation/editing into reusable keyboard-accessible dialogs centered over the full window
- add section-specific summaries and clearer library, voice, appearance, developer, and MCP presentation
- simplify badge-style metadata into plain text and refine responsive spacing

## Validation

- `npm run check`
  - 181 Node tests passed
  - 148 renderer tests passed
  - ESLint, asset validation, production dependency audit, TypeScript, and the Vite production build passed