### PR TITLE
fix(mcp): list the action catalog once in the play_animation contract

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -38,11 +38,24 @@ Persona exposes these tools:
 The animation descriptions are generated from Persona's playable actions.
 Empty actions are omitted until a VRMA clip is added. User uploads, user edits
 to packaged metadata, removals, and packaged-action resets are reflected
-immediately through an MCP tool-list change notification. The
-`play_animation` input remains open to valid action names and checks the live
-library when invoked, so a client that does not refresh tool descriptions can
-still run an action added during the current session. No media paths or
-filesystem access are exposed.
+immediately through an MCP tool-list change notification. The action catalog is
+listed once, in the `play_animation` description; the `animation` argument only
+names what it takes. No media paths or filesystem access are exposed.
+
+The `play_animation` input remains open to valid action names and checks the
+live library when invoked, so a client that does not refresh tool descriptions
+can still run an action added during the current session. This matters because
+the catalog changes while a session is live: `list_animations` always answers
+from the current library, while a cached tool list — and the copy of it already
+in a model's context — can be a revision behind. Leaving the argument open lets
+the fresher of the two win, and nothing unplayable reaches the app regardless: a
+malformed name fails schema validation, and a well-formed one the library does
+not hold is turned away by the handler, which names `list_animations` as the
+next step. Both arrive as `isError` results rather than protocol errors, so the
+text is written for the model to read and act on. Honour the
+tool-list change notification if you can, but treat it as an optimization:
+`list_animations` is the source of truth, and a client that ignores the
+notification entirely still behaves correctly.
 
 With no configured model, window and animation commands remain inactive.
 Persona can still report status while its Settings window is used for initial

--- a/electron/mcp-server.cts
+++ b/electron/mcp-server.cts
@@ -83,17 +83,16 @@ function animationToolDescription(
   ].join('\n');
 }
 
-function animationInputSchema(animations: readonly PlayableAnimation[]) {
-  return z
-    .string()
-    .regex(
-      ANIMATION_NAME_PATTERN,
-      'Animation names use lowercase letters, numbers, and single hyphens.',
-    )
-    .describe(
-      `The installed character action to play.\n${describeAnimations(animations)}`,
-    );
-}
+// The catalog belongs to the tool description and only there; repeating it here
+// shipped the same paragraph to the model twice. The name stays deliberately
+// unconstrained -- docs/INTEGRATIONS.md covers why the live check is the gate.
+const ANIMATION_INPUT_SCHEMA = z
+  .string()
+  .regex(
+    ANIMATION_NAME_PATTERN,
+    'Animation names use lowercase letters, numbers, and single hyphens.',
+  )
+  .describe('The installed character action to play.');
 
 export function createPersonaMcpServer({
   onAnimation,
@@ -118,7 +117,7 @@ export function createPersonaMcpServer({
       title: 'Play Persona animation',
       description: animationToolDescription(animations),
       inputSchema: {
-        animation: animationInputSchema(animations),
+        animation: ANIMATION_INPUT_SCHEMA,
       },
       annotations: {
         readOnlyHint: false,
@@ -209,12 +208,8 @@ export function createPersonaMcpServer({
   );
 
   const refreshAnimationCatalog = (): void => {
-    const currentAnimations = getAnimations();
     animationTool.update({
-      description: animationToolDescription(currentAnimations),
-      paramsSchema: {
-        animation: animationInputSchema(currentAnimations),
-      },
+      description: animationToolDescription(getAnimations()),
     });
   };
 

--- a/electron/mcp-server.test.cts
+++ b/electron/mcp-server.test.cts
@@ -143,8 +143,11 @@ test("Persona MCP exposes and executes the local character tools", async (contex
   const animationInput = toolInputProperty(animationTool, 'animation');
   assert.equal(animationInput.type, "string");
   assert.equal(animationInput.enum, undefined);
-  assert.equal(typeof animationInput.description, 'string');
-  assert.match(String(animationInput.description), /wave-hello/);
+  assert.equal(
+    animationInput.description,
+    'The installed character action to play.',
+  );
+  assert.match(toolDescription(animationTool), /A friendly wave/);
   const windowTool = toolNamed(tools.tools, 'control_window');
   assert.deepEqual(toolInputProperty(windowTool, 'action').enum, WINDOW_ACTIONS);
 
@@ -208,13 +211,13 @@ test("Persona MCP exposes custom animation metadata in its tool contract", async
   await connectClient(client, transport);
   const tool = toolNamed((await client.listTools()).tools, 'play_animation');
 
-  assert.equal(toolInputProperty(tool, 'animation').enum, undefined);
-  assert.match(
-    String(toolInputProperty(tool, 'animation').description),
-    /wave-hello/,
-  );
   assert.match(toolDescription(tool), /A small friendly wave/);
   assert.match(toolDescription(tool), /Use when greeting the user/);
+  assert.equal(
+    JSON.stringify(tool).split('Use when greeting the user').length - 1,
+    1,
+    'The action catalog belongs to one field of the tool definition.',
+  );
 });
 
 test("Persona MCP refreshes animation actions inside an active client session", async (context) => {
@@ -292,9 +295,9 @@ test("Persona MCP refreshes animation actions inside an active client session", 
     'play_animation',
   );
   assert.match(toolDescription(refreshedTool), /finger-gun/);
-  assert.match(
-    String(toolInputProperty(refreshedTool, 'animation').description),
-    /finger-gun/,
+  assert.equal(
+    toolInputProperty(refreshedTool, 'animation').description,
+    'The installed character action to play.',
   );
 });
 


### PR DESCRIPTION
`play_animation` shipped its action catalog twice in every `tools/list`.
`describeAnimations` was called once for the tool description and once for the
`animation` argument's own description; only the first line differed, so 732
bytes went out byte-identical in both. Tool definitions sit in the prompt on
every API call, so the copy was billed and occupied context on each one.

Read off `tools/list` on a running instance with six installed actions(I add 4 actions):

| | before | after |
| --- | --- | --- |
| `play_animation` definition | 2,150 | 1,412 |
| whole `tools/list` (4 tools) | 3,506 | 2,768 |

738 bytes off every call, on the order of 180 tokens.

The catalog stays in the tool description, the field a model weighs when
deciding whether to reach for the tool at all; the argument keeps a one-line
description of what it takes. With nothing catalog-shaped left in it the schema
no longer varies, so it becomes a module constant and `refreshAnimationCatalog`
updates the description alone.

The tests count how many times the catalog appears in the tool definition
rather than asserting it appears in both places.

Verified: `npm run lint`, `npm run test:node` (186), `npm run test:renderer`
(157) and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
