### PR TITLE
feat: recover an avatar window dragged or panned out of reach

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ macOS the character itself still takes orbit, zoom, and Alt+drag as usual; on
 Linux nothing in the window is clickable while it is on, and the tray menu reads
 **Click-through (whole window)** to say so. Toggle it from the tray menu or from
 **Settings → Appearance**; either way the choice is saved and comes back on the
-next launch. The tray toggle is the way back to an interactive window.
+next launch. The tray toggle is the way back to an interactive window. **Recenter
+Persona** in the same menu is the way back if a pan has carried the character
+out of view.
 
 Persona always provides **Idle** and **Speaking** action slots. They begin
 without media, so the model keeps its normal pose until you add clips. Each
@@ -148,6 +150,10 @@ The window intentionally contains no controls:
 - Left-drag to orbit.
 - Right-drag to pan.
 - Use your window manager's move gesture to reposition the window.
+
+If a pan or a drag leaves the character or the window out of reach, **Recenter
+Persona** in the tray returns the window to its launch corner and re-frames the
+character.
 
 On Hyprland, Persona also applies floating, pinned, topmost, full-opacity,
 no-blur, no-shadow, and decoration-free properties. macOS uses an all-Spaces

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -55,7 +55,7 @@ Treat signed and notarized artifacts as the production release path.
    - no microphone capture, duplicate sound, or saved audio;
    - close hides without quitting;
    - ending voice leaves the window open;
-   - tray show, hide, preview, and quit;
+   - tray show, hide, recenter, preview, and quit;
    - packaged and user model selection;
    - user model and action creation, multi-file VRMA import, preview,
      persistence, clip deletion, and action deletion;

--- a/electron/main.cts
+++ b/electron/main.cts
@@ -196,12 +196,9 @@ function debugLog(...values: unknown[]): void {
 }
 
 /**
- * The corner the avatar launches in, on the display the cursor is on.
- *
- * Sized from the settings rather than from `getBounds()`: a resize is applied
- * by the window manager asynchronously on X11, so bounds read straight after
- * `setSize` can still describe the old window and offset the corner by the
- * difference.
+ * The corner the avatar launches in, on the display the cursor is on. Sized
+ * from settings rather than `getBounds()`: an X11 resize lands asynchronously,
+ * so bounds read straight after `setSize` can still describe the old window.
  */
 function avatarCornerPosition(): WindowPosition {
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
@@ -327,11 +324,8 @@ async function hideOverlay(): Promise<void> {
 }
 
 /**
- * Frames the character again from scratch.
- *
- * Deliberately not `sendToRenderer`: that queues the event for replay to a
- * renderer that has not loaded yet, and a renderer still loading will frame the
- * character correctly on its own. A reset replayed after the fact is noise.
+ * Deliberately not `sendToRenderer`: that queues for replay to a renderer that
+ * has not loaded, and one still loading frames the character correctly anyway.
  */
 function sendResetView(): void {
   if (!avatarWindow || avatarWindow.isDestroyed()) return;
@@ -341,32 +335,23 @@ function sendResetView(): void {
 }
 
 /**
- * Puts the avatar back where it starts, in both senses: the window returns to
- * the corner it launches in and the camera re-frames the character. Orbit
- * controls are unbounded and the window is frameless, so a pan and a drag can
- * between them leave nothing on screen to aim a correction at -- which is why
- * this lives on the tray rather than on the window it repairs.
+ * A pan and a drag can between them leave nothing on screen to aim a
+ * correction at, which is why this lives on the tray and not on the window.
  */
 function recenterAvatar(): void {
-  // Sampled once and shared by every path below. Each call reads the cursor
-  // afresh, so a pointer crossing a display boundary between two of them would
-  // aim Electron at one monitor and Hyprland at another.
+  // One sample shared by all three paths below: each read takes the cursor
+  // afresh, and a pointer crossing displays between them would split them.
   const corner = avatarCornerPosition();
-  // Showing the window replays the last recorded placement, which on this path
-  // is the stranded spot being escaped from, and that handler and this function
-  // race to schedule the Hyprland move -- `show` arrives asynchronously on GTK,
-  // and the scheduler is last-writer-wins. Recording the corner up front makes
-  // both of them ask for the same move, so whichever lands is the right one.
+  // Showing the window replays the last placement -- here, the stranded spot
+  // being escaped from -- so aim that path at the corner as well.
   hyprlandLastPosition = corner;
   showOverlay();
   const window = avatarWindow;
   if (!window || window.isDestroyed()) return;
   applyAvatarWindowSize();
   window.setPosition(corner.x, corner.y, false);
-  // Hyprland places floating windows itself, and both options have to be given
-  // rather than left to their defaults: `reposition` is false once the window
-  // has been configured, and a null `position` falls back to the corner of the
-  // monitor the window is currently on -- the one being escaped from.
+  // Neither default is right here: `reposition` is false once the window has
+  // been configured, and a null `position` means the monitor it is stranded on.
   scheduleHyprlandWindowConfiguration({
     force: true,
     position: corner,
@@ -1635,8 +1620,8 @@ if (!app.requestSingleInstanceLock()) {
         return;
       }
       const bounds = avatarWindow.getBounds();
-      // A frameless window offers no titlebar to drag it back with, so a drag
-      // that carried it off every display would leave nothing to grab.
+      // No titlebar to drag it back with, so a drag off every display would
+      // leave nothing to grab.
       const position = clampWindowPosition(
         { ...bounds, x: bounds.x + dx, y: bounds.y + dy },
         screen.getAllDisplays().map((display) => display.workArea),

--- a/electron/main.cts
+++ b/electron/main.cts
@@ -67,6 +67,7 @@ import {
   getHyprlandWindowPlacement,
   type WindowPosition,
 } from './hyprland-window.cjs';
+import { clampWindowPosition } from './window-bounds.cjs';
 import {
   createAudioListener,
   type AudioListener,
@@ -194,15 +195,27 @@ function debugLog(...values: unknown[]): void {
   if (debugEnabled) console.error("[persona]", ...values);
 }
 
-function positionWindow(window: BrowserWindow): void {
+/**
+ * The corner the avatar launches in, on the display the cursor is on.
+ *
+ * Sized from the settings rather than from `getBounds()`: a resize is applied
+ * by the window manager asynchronously on X11, so bounds read straight after
+ * `setSize` can still describe the old window and offset the corner by the
+ * difference.
+ */
+function avatarCornerPosition(): WindowPosition {
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
-  const bounds = window.getBounds();
+  const { width, height } = avatarWindowSize();
   const margin = 24;
-  window.setPosition(
-    Math.round(display.workArea.x + display.workArea.width - bounds.width - margin),
-    Math.round(display.workArea.y + display.workArea.height - bounds.height - margin),
-    false,
-  );
+  return {
+    x: Math.round(display.workArea.x + display.workArea.width - width - margin),
+    y: Math.round(display.workArea.y + display.workArea.height - height - margin),
+  };
+}
+
+function positionWindow(window: BrowserWindow): void {
+  const { x, y } = avatarCornerPosition();
+  window.setPosition(x, y, false);
 }
 
 function hasConfiguredModel(): boolean {
@@ -311,6 +324,55 @@ async function hideOverlay(): Promise<void> {
     hyprlandLastPosition = { x: placement.x, y: placement.y };
   }
   targetWindow.hide();
+}
+
+/**
+ * Frames the character again from scratch.
+ *
+ * Deliberately not `sendToRenderer`: that queues the event for replay to a
+ * renderer that has not loaded yet, and a renderer still loading will frame the
+ * character correctly on its own. A reset replayed after the fact is noise.
+ */
+function sendResetView(): void {
+  if (!avatarWindow || avatarWindow.isDestroyed()) return;
+  if (avatarWindow.webContents.isLoading()) return;
+  const event: AvatarRendererEvent = { type: "reset-view" };
+  avatarWindow.webContents.send("persona:event", event);
+}
+
+/**
+ * Puts the avatar back where it starts, in both senses: the window returns to
+ * the corner it launches in and the camera re-frames the character. Orbit
+ * controls are unbounded and the window is frameless, so a pan and a drag can
+ * between them leave nothing on screen to aim a correction at -- which is why
+ * this lives on the tray rather than on the window it repairs.
+ */
+function recenterAvatar(): void {
+  // Sampled once and shared by every path below. Each call reads the cursor
+  // afresh, so a pointer crossing a display boundary between two of them would
+  // aim Electron at one monitor and Hyprland at another.
+  const corner = avatarCornerPosition();
+  // Showing the window replays the last recorded placement, which on this path
+  // is the stranded spot being escaped from, and that handler and this function
+  // race to schedule the Hyprland move -- `show` arrives asynchronously on GTK,
+  // and the scheduler is last-writer-wins. Recording the corner up front makes
+  // both of them ask for the same move, so whichever lands is the right one.
+  hyprlandLastPosition = corner;
+  showOverlay();
+  const window = avatarWindow;
+  if (!window || window.isDestroyed()) return;
+  applyAvatarWindowSize();
+  window.setPosition(corner.x, corner.y, false);
+  // Hyprland places floating windows itself, and both options have to be given
+  // rather than left to their defaults: `reposition` is false once the window
+  // has been configured, and a null `position` falls back to the corner of the
+  // monitor the window is currently on -- the one being escaped from.
+  scheduleHyprlandWindowConfiguration({
+    force: true,
+    position: corner,
+    reposition: true,
+  });
+  sendResetView();
 }
 
 function destroyOverlayForSetup(): void {
@@ -1077,6 +1139,7 @@ function refreshTrayMenu(): void {
     ? [
         { label: "Show Persona", click: () => showOverlay({ focus: true }) },
         { label: "Hide Persona", click: () => void hideOverlay() },
+        { label: "Recenter Persona", click: recenterAvatar },
         { label: "Settings…", click: showSettings },
         { type: "separator" },
         {
@@ -1572,10 +1635,13 @@ if (!app.requestSingleInstanceLock()) {
         return;
       }
       const bounds = avatarWindow.getBounds();
-      avatarWindow.setPosition(
-        Math.round(bounds.x + dx),
-        Math.round(bounds.y + dy),
+      // A frameless window offers no titlebar to drag it back with, so a drag
+      // that carried it off every display would leave nothing to grab.
+      const position = clampWindowPosition(
+        { ...bounds, x: bounds.x + dx, y: bounds.y + dy },
+        screen.getAllDisplays().map((display) => display.workArea),
       );
+      avatarWindow.setPosition(position.x, position.y);
     });
     // The renderer owns the fine-grained decision, forwarding a silhouette
     // hit-test as the cursor moves. A send has no reply channel to reject

--- a/electron/window-bounds.cts
+++ b/electron/window-bounds.cts
@@ -1,11 +1,7 @@
 /**
- * Keeps a dragged avatar window reachable.
- *
- * The window is frameless, so no window manager offers a titlebar to drag it
- * back with, and Alt+drag over the character is the only way to move it. Put
- * the whole window past the edge of every display and that gesture has nothing
- * left to land on, and nothing is drawn on screen to aim a correction at
- * either. Clamping the destination keeps the window where it can still be seen.
+ * The window is frameless and Alt+drag over the character is the only way to
+ * move it, so a drag that put it past every display would leave nothing on
+ * screen to aim at. Clamping the destination keeps it visible.
  */
 
 export interface ScreenRect {
@@ -21,15 +17,9 @@ export interface WindowPosition {
 }
 
 /**
- * How much of the window has to stay inside a work area.
- *
- * Wide enough to aim at rather than a sliver that is only technically on
- * screen. It does not by itself guarantee the window can be dragged back:
- * Alt+drag lands on the character, and under silhouette click-through a strip
- * of transparent background passes the press to whatever is behind it. What
- * this buys is that the window stays visible and stays partly addressable, so
- * recovery is a drag whenever the character reaches the strip and the tray's
- * recentre otherwise.
+ * How much of the window stays inside a work area. Not a guarantee it can be
+ * dragged back: under silhouette click-through the surviving strip is
+ * transparent and passes the press through, which is what the tray is for.
  */
 export const MIN_VISIBLE_EDGE = 64;
 
@@ -56,11 +46,8 @@ function clamp(value: number, low: number, high: number): number {
 }
 
 /**
- * The position `bounds` should actually be moved to.
- *
- * Every work area is considered rather than only the primary one, so a window
- * living on a second display is judged against the display it is on instead of
- * being dragged back across the desktop for being far from the first.
+ * Every work area is weighed rather than only the primary, so a window living
+ * on a second display is judged against the display it is on.
  */
 export function clampWindowPosition(
   bounds: ScreenRect,
@@ -70,8 +57,7 @@ export function clampWindowPosition(
   const requested = { x: Math.round(bounds.x), y: Math.round(bounds.y) };
   if (workAreas.length === 0) return requested;
 
-  // A window shorter or narrower than the margin can never overlap by the whole
-  // margin, so ask it for as much of itself as there is.
+  // A window smaller than the margin cannot overlap by the whole margin.
   const keepX = Math.min(keep, bounds.width);
   const keepY = Math.min(keep, bounds.height);
 

--- a/electron/window-bounds.cts
+++ b/electron/window-bounds.cts
@@ -1,0 +1,106 @@
+/**
+ * Keeps a dragged avatar window reachable.
+ *
+ * The window is frameless, so no window manager offers a titlebar to drag it
+ * back with, and Alt+drag over the character is the only way to move it. Put
+ * the whole window past the edge of every display and that gesture has nothing
+ * left to land on, and nothing is drawn on screen to aim a correction at
+ * either. Clamping the destination keeps the window where it can still be seen.
+ */
+
+export interface ScreenRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface WindowPosition {
+  x: number;
+  y: number;
+}
+
+/**
+ * How much of the window has to stay inside a work area.
+ *
+ * Wide enough to aim at rather than a sliver that is only technically on
+ * screen. It does not by itself guarantee the window can be dragged back:
+ * Alt+drag lands on the character, and under silhouette click-through a strip
+ * of transparent background passes the press to whatever is behind it. What
+ * this buys is that the window stays visible and stays partly addressable, so
+ * recovery is a drag whenever the character reaches the strip and the tray's
+ * recentre otherwise.
+ */
+export const MIN_VISIBLE_EDGE = 64;
+
+function overlap(
+  start: number,
+  length: number,
+  otherStart: number,
+  otherLength: number,
+): number {
+  return (
+    Math.min(start + length, otherStart + otherLength) -
+    Math.max(start, otherStart)
+  );
+}
+
+function centreDistance(bounds: ScreenRect, area: ScreenRect): number {
+  const dx = bounds.x + bounds.width / 2 - (area.x + area.width / 2);
+  const dy = bounds.y + bounds.height / 2 - (area.y + area.height / 2);
+  return dx * dx + dy * dy;
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+/**
+ * The position `bounds` should actually be moved to.
+ *
+ * Every work area is considered rather than only the primary one, so a window
+ * living on a second display is judged against the display it is on instead of
+ * being dragged back across the desktop for being far from the first.
+ */
+export function clampWindowPosition(
+  bounds: ScreenRect,
+  workAreas: readonly ScreenRect[],
+  keep: number = MIN_VISIBLE_EDGE,
+): WindowPosition {
+  const requested = { x: Math.round(bounds.x), y: Math.round(bounds.y) };
+  if (workAreas.length === 0) return requested;
+
+  // A window shorter or narrower than the margin can never overlap by the whole
+  // margin, so ask it for as much of itself as there is.
+  const keepX = Math.min(keep, bounds.width);
+  const keepY = Math.min(keep, bounds.height);
+
+  const reachable = workAreas.some(
+    (area) =>
+      overlap(bounds.x, bounds.width, area.x, area.width) >= keepX &&
+      overlap(bounds.y, bounds.height, area.y, area.height) >= keepY,
+  );
+  if (reachable) return requested;
+
+  const area = workAreas.reduce((nearest, candidate) =>
+    centreDistance(bounds, candidate) < centreDistance(bounds, nearest)
+      ? candidate
+      : nearest,
+  );
+  return {
+    x: Math.round(
+      clamp(
+        bounds.x,
+        area.x - (bounds.width - keepX),
+        area.x + area.width - keepX,
+      ),
+    ),
+    y: Math.round(
+      clamp(
+        bounds.y,
+        area.y - (bounds.height - keepY),
+        area.y + area.height - keepY,
+      ),
+    ),
+  };
+}

--- a/electron/window-bounds.test.cts
+++ b/electron/window-bounds.test.cts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { MIN_VISIBLE_EDGE, clampWindowPosition } from './window-bounds.cjs';
+
+const primary = { x: 0, y: 0, width: 1920, height: 1040 };
+const secondary = { x: 1920, y: 0, width: 1920, height: 1040 };
+const avatar = { width: 360, height: 540 };
+
+test("leaves a position that is well inside a work area alone", () => {
+  assert.deepEqual(
+    clampWindowPosition({ x: 800, y: 300, ...avatar }, [primary]),
+    { x: 800, y: 300 },
+  );
+});
+
+test("leaves a position that keeps exactly the margin on screen alone", () => {
+  const x = primary.width - MIN_VISIBLE_EDGE;
+  assert.deepEqual(
+    clampWindowPosition({ x, y: 300, ...avatar }, [primary]),
+    { x, y: 300 },
+  );
+});
+
+test("pulls a window dragged off the right edge back to the margin", () => {
+  assert.deepEqual(
+    clampWindowPosition({ x: 4000, y: 300, ...avatar }, [primary]),
+    { x: primary.width - MIN_VISIBLE_EDGE, y: 300 },
+  );
+});
+
+test("pulls a window dragged off the top left back to the margin", () => {
+  assert.deepEqual(
+    clampWindowPosition({ x: -900, y: -900, ...avatar }, [primary]),
+    {
+      x: -(avatar.width - MIN_VISIBLE_EDGE),
+      y: -(avatar.height - MIN_VISIBLE_EDGE),
+    },
+  );
+});
+
+test("clamps only the axis that left the work area", () => {
+  assert.deepEqual(
+    clampWindowPosition({ x: 4000, y: 300, ...avatar }, [primary]),
+    { x: primary.width - MIN_VISIBLE_EDGE, y: 300 },
+  );
+  assert.deepEqual(
+    clampWindowPosition({ x: 800, y: 4000, ...avatar }, [primary]),
+    { x: 800, y: primary.height - MIN_VISIBLE_EDGE },
+  );
+});
+
+test("judges a window on a second display against that display", () => {
+  // Far off the primary, but sitting comfortably on the secondary, so nothing
+  // should drag it back across the desktop.
+  const bounds = { x: 2600, y: 300, ...avatar };
+  assert.deepEqual(clampWindowPosition(bounds, [primary, secondary]), {
+    x: 2600,
+    y: 300,
+  });
+});
+
+test("clamps to the nearest work area rather than the first", () => {
+  assert.deepEqual(
+    clampWindowPosition({ x: 5000, y: 300, ...avatar }, [primary, secondary]),
+    { x: secondary.x + secondary.width - MIN_VISIBLE_EDGE, y: 300 },
+  );
+});
+
+test("keeps a window in the gap between two displays reachable", () => {
+  // Displays stacked with a horizontal offset leave desktop coordinates that
+  // belong to no display at all; a drag through one must still land somewhere
+  // grabbable.
+  const stacked = { x: 400, y: 1040, width: 1280, height: 1000 };
+  const result = clampWindowPosition({ x: -2000, y: 1200, ...avatar }, [
+    primary,
+    stacked,
+  ]);
+  assert.deepEqual(result, {
+    x: stacked.x - (avatar.width - MIN_VISIBLE_EDGE),
+    y: 1200,
+  });
+});
+
+test("asks a window smaller than the margin only for as much as it has", () => {
+  const tiny = { x: 4000, y: 300, width: 40, height: 30 };
+  assert.deepEqual(clampWindowPosition(tiny, [primary]), {
+    x: primary.width - 40,
+    y: 300,
+  });
+});
+
+test("returns the requested position when no display is known", () => {
+  assert.deepEqual(clampWindowPosition({ x: 4000, y: 4000, ...avatar }, []), {
+    x: 4000,
+    y: 4000,
+  });
+});
+
+test("rounds a fractional position", () => {
+  assert.deepEqual(
+    clampWindowPosition({ x: 800.6, y: 300.4, ...avatar }, [primary]),
+    { x: 801, y: 300 },
+  );
+});

--- a/shared/persona-api.d.ts
+++ b/shared/persona-api.d.ts
@@ -122,10 +122,8 @@ export interface ClickThroughEvent extends ClickThroughSnapshot {
 }
 
 /**
- * Asks the renderer to frame the character again from scratch. Orbit controls
- * are unbounded, so a pan can put the character outside the viewport with no
- * way back; the camera is the renderer's to fix, while the window position the
- * same gesture may have wrecked is the main process's.
+ * Asks the renderer to frame the character again. A pan can put it outside the
+ * viewport with no way back, and the camera is the renderer's half of the fix.
  */
 export interface ResetViewEvent {
   type: 'reset-view';

--- a/shared/persona-api.d.ts
+++ b/shared/persona-api.d.ts
@@ -121,12 +121,23 @@ export interface ClickThroughEvent extends ClickThroughSnapshot {
   type: 'click-through';
 }
 
+/**
+ * Asks the renderer to frame the character again from scratch. Orbit controls
+ * are unbounded, so a pan can put the character outside the viewport with no
+ * way back; the camera is the renderer's to fix, while the window position the
+ * same gesture may have wrecked is the main process's.
+ */
+export interface ResetViewEvent {
+  type: 'reset-view';
+}
+
 export type AvatarRendererEvent =
   | BridgeEvent
   | AnimationPlaybackEvent
   | ExpressionHoldEvent
   | ExpressionReleaseEvent
-  | ClickThroughEvent;
+  | ClickThroughEvent
+  | ResetViewEvent;
 
 export interface PersonaLightingSettings {
   tone_mapping: 'none' | 'aces';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,8 +59,8 @@ export function App() {
   } | null>(null);
   const [settings, setSettings] =
     useState<PersonaSettingsSnapshot>(SETTINGS_FALLBACK);
-  // A counter rather than a flag: each reset has to reach the camera even when
-  // the one before it left the framing already correct.
+  // A counter, not a flag: a reset must reach the camera even when the one
+  // before it left the framing correct.
   const [resetRequest, setResetRequest] = useState(0);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,9 @@ export function App() {
   } | null>(null);
   const [settings, setSettings] =
     useState<PersonaSettingsSnapshot>(SETTINGS_FALLBACK);
+  // A counter rather than a flag: each reset has to reach the camera even when
+  // the one before it left the framing already correct.
+  const [resetRequest, setResetRequest] = useState(0);
 
   useEffect(() => {
     const bridge = window.personaBridge;
@@ -109,6 +112,8 @@ export function App() {
         }
       } else if (event.type === 'click-through') {
         setSilhouetteHitTest(event.enabled && event.mode === 'silhouette');
+      } else if (event.type === 'reset-view') {
+        setResetRequest((request) => request + 1);
       }
     });
   }, []);
@@ -201,6 +206,7 @@ export function App() {
         modelUrl={defaultModel.asset_url}
         onAnimationComplete={handleAnimationComplete}
         playback={bodyOverride ? 'once' : 'loop'}
+        resetRequest={resetRequest}
         speaking={speaking}
         bodyTransitionMs={settings.body_transition_ms}
         speakingDebounceMs={settings.speaking_debounce_ms}

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -120,9 +120,7 @@ function FullBodyCamera({
   useLayoutEffect(() => {
     const { camera, controls } = getThreeState();
     // Nothing the user does to the camera is recorded here, so a framing that
-    // matches what was last computed can still be pointing somewhere else
-    // entirely. A bumped request is the one signal that the current view is
-    // wrong however well it matches, and it has to outrank the other three.
+    // matches the last computed one can still be pointing somewhere else.
     const requested = framedRequest.current !== resetRequest;
     if (
       !object ||

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -39,6 +39,8 @@ interface SceneProps {
   modelUrl: string;
   onAnimationComplete: () => void;
   playback: 'loop' | 'once';
+  /** Increments to ask the camera to frame the character again. */
+  resetRequest?: number;
   speaking: boolean;
   bodyTransitionMs: number;
   speakingDebounceMs: number;
@@ -101,22 +103,31 @@ function FullBodyCamera({
   characterSize,
   framingMargin,
   object,
+  resetRequest,
 }: {
   characterSize: number;
   framingMargin: number;
   object: THREE.Object3D | null;
+  resetRequest: number;
 }) {
   const getThreeState = useThree((state) => state.get);
   const controlsReady = useThree((state) => Boolean(state.controls));
   const framedObject = useRef<THREE.Object3D | null>(null);
   const framedCharacterSize = useRef<number | null>(null);
   const framedMargin = useRef<number | null>(null);
+  const framedRequest = useRef(resetRequest);
 
   useLayoutEffect(() => {
     const { camera, controls } = getThreeState();
+    // Nothing the user does to the camera is recorded here, so a framing that
+    // matches what was last computed can still be pointing somewhere else
+    // entirely. A bumped request is the one signal that the current view is
+    // wrong however well it matches, and it has to outrank the other three.
+    const requested = framedRequest.current !== resetRequest;
     if (
       !object ||
-      (framedObject.current === object &&
+      (!requested &&
+        framedObject.current === object &&
         framedCharacterSize.current === characterSize &&
         framedMargin.current === framingMargin) ||
       !(camera instanceof THREE.PerspectiveCamera) ||
@@ -147,7 +158,15 @@ function FullBodyCamera({
     framedObject.current = object;
     framedCharacterSize.current = characterSize;
     framedMargin.current = framingMargin;
-  }, [characterSize, controlsReady, framingMargin, getThreeState, object]);
+    framedRequest.current = resetRequest;
+  }, [
+    characterSize,
+    controlsReady,
+    framingMargin,
+    getThreeState,
+    object,
+    resetRequest,
+  ]);
 
   return null;
 }
@@ -365,6 +384,7 @@ export function Scene(props: SceneProps) {
         characterSize={props.characterSize}
         framingMargin={props.framingMargin ?? 1.12}
         object={avatarScene}
+        resetRequest={props.resetRequest ?? 0}
       />
       <Avatar {...props} onReady={handleAvatarReady} />
       <PassthroughController enabled={props.silhouetteHitTest ?? false} />


### PR DESCRIPTION
Adds a `Recenter Persona` tray item and a bounds clamp on the window-move channel.

Orbit controls are unbounded and Alt+drag moved the window through an unclamped `setPosition`, with nothing in the app to undo either. Under silhouette click-through the two together are a dead end: every pixel the frame draws is alpha 0, so the window passes all clicks through and even Alt+drag can no longer reach it.

Recentring returns the window to its launch corner, re-frames the character and shows it; nothing persisted changes. The clamp stops a drag stranding the window at all, though the strip it preserves is transparent under silhouette mode, so the tray stays the dependable way back.

Closes #63.
