### PR TITLE
feat(settings): enlarge a VRoid Hub portrait on hover

### DIFF
--- a/src/components/settings/VroidCharacters.tsx
+++ b/src/components/settings/VroidCharacters.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { vroidLicenseRows } from '../../vroid-license-fields';
 import {
+  type PortraitZoomPlacement,
+  portraitZoomPlacement,
+} from '../../vroid-portrait-zoom';
+import {
   cachedVroidPortrait,
   hasCachedVroidPortrait,
   requestVroidPortrait,
@@ -14,6 +18,7 @@ function VroidCharacterPortrait({
   const [portrait, setPortrait] = useState<string | null>(() =>
     cachedVroidPortrait(character.id),
   );
+  const [zoom, setZoom] = useState<PortraitZoomPlacement | null>(null);
 
   useEffect(() => {
     const bridge = window.personaVroidHub;
@@ -36,6 +41,19 @@ function VroidCharacterPortrait({
     };
   }, [character.id, character.portrait_url]);
 
+  // The zoom holds the position the thumbnail had when it opened, so anything
+  // that moves the card underneath it closes the zoom instead.
+  useEffect(() => {
+    if (zoom == null) return;
+    const close = () => setZoom(null);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [zoom]);
+
   if (portrait == null) {
     return (
       <span aria-hidden="true" className="row-mark">
@@ -44,8 +62,25 @@ function VroidCharacterPortrait({
     );
   }
   return (
-    <span className="row-mark">
+    <span
+      className="row-mark row-mark-zoomable"
+      onMouseEnter={(event) =>
+        setZoom(
+          portraitZoomPlacement(event.currentTarget.getBoundingClientRect(), {
+            height: window.innerHeight,
+            width: window.innerWidth,
+          }),
+        )
+      }
+      onMouseLeave={() => setZoom(null)}
+    >
       <img alt={`${character.name} portrait`} src={portrait} />
+      {zoom && (
+        <span aria-hidden="true" className="vroid-portrait-zoom" style={zoom}>
+          <img alt="" src={portrait} />
+          <small>{character.name}</small>
+        </span>
+      )}
     </span>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -901,10 +901,54 @@ button {
   background: var(--accent-soft);
 }
 
-.row-mark img {
+.row-mark > img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.row-mark-zoomable {
+  cursor: zoom-in;
+}
+
+/* Fixed rather than absolute: the card sets overflow: hidden, which would
+   otherwise clip the zoom to the 34px thumbnail. */
+.vroid-portrait-zoom {
+  position: fixed;
+  z-index: 95;
+  display: flex;
+  width: 224px;
+  height: 224px;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-lg);
+  background: var(--bg-overlay);
+  pointer-events: none;
+  box-shadow: var(--shadow-overlay);
+  animation: fade-in 120ms var(--ease);
+}
+
+.vroid-portrait-zoom img {
+  width: 100%;
+  height: auto;
+  min-height: 0;
+  flex: 1 1 auto;
+  border-radius: var(--r-md);
+  object-fit: contain;
+}
+
+.vroid-portrait-zoom small {
+  overflow: hidden;
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  font-weight: 400;
+  letter-spacing: normal;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .row-copy {

--- a/src/vroid-portrait-zoom.test.ts
+++ b/src/vroid-portrait-zoom.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PORTRAIT_ZOOM_SIZE,
+  portraitZoomPlacement,
+} from './vroid-portrait-zoom';
+
+const viewport = { height: 800, width: 1000 };
+
+function thumbnail(left: number, top: number) {
+  return { bottom: top + 34, left, right: left + 34, top };
+}
+
+describe('portraitZoomPlacement', () => {
+  it('sits to the thumbnail’s right, centred on it', () => {
+    expect(portraitZoomPlacement(thumbnail(100, 400), viewport)).toEqual({
+      left: 144,
+      top: 417 - PORTRAIT_ZOOM_SIZE / 2,
+    });
+  });
+
+  it('flips to the thumbnail’s left when the right edge is too close', () => {
+    const placement = portraitZoomPlacement(thumbnail(740, 400), viewport);
+
+    expect(placement.left).toBe(740 - 10 - PORTRAIT_ZOOM_SIZE);
+    expect(placement.left + PORTRAIT_ZOOM_SIZE).toBeLessThan(740);
+  });
+
+  it('keeps the whole zoom on screen for a card at any edge', () => {
+    for (const anchor of [
+      thumbnail(0, 0),
+      thumbnail(0, viewport.height - 34),
+      thumbnail(viewport.width - 34, 0),
+      thumbnail(viewport.width - 34, viewport.height - 34),
+    ]) {
+      const { left, top } = portraitZoomPlacement(anchor, viewport);
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(top).toBeGreaterThanOrEqual(0);
+      expect(left + PORTRAIT_ZOOM_SIZE).toBeLessThanOrEqual(viewport.width);
+      expect(top + PORTRAIT_ZOOM_SIZE).toBeLessThanOrEqual(viewport.height);
+    }
+  });
+
+  it('keeps the top-left corner visible in a window too small to hold it', () => {
+    expect(portraitZoomPlacement(thumbnail(10, 10), { height: 120, width: 120 }))
+      .toEqual({ left: 8, top: 8 });
+  });
+});

--- a/src/vroid-portrait-zoom.ts
+++ b/src/vroid-portrait-zoom.ts
@@ -1,0 +1,40 @@
+/**
+ * Placement for the enlarged portrait a character card shows on hover, kept a
+ * pure function of the two boxes so the rules that hold the zoom on screen can
+ * be checked without a DOM.
+ */
+
+// Kept in step with .vroid-portrait-zoom's box in styles.css.
+export const PORTRAIT_ZOOM_SIZE = 224;
+const GAP = 10;
+const MARGIN = 8;
+
+export interface PortraitZoomPlacement {
+  left: number;
+  top: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  // Order matters: a viewport too small for the zoom puts max below min, and
+  // the top-left corner is the half worth keeping.
+  return Math.max(Math.min(value, max), min);
+}
+
+export function portraitZoomPlacement(
+  anchor: { bottom: number; left: number; right: number; top: number },
+  viewport: { height: number; width: number },
+): PortraitZoomPlacement {
+  const toTheRight = anchor.right + GAP;
+  const left =
+    toTheRight + PORTRAIT_ZOOM_SIZE + MARGIN <= viewport.width
+      ? toTheRight
+      : anchor.left - GAP - PORTRAIT_ZOOM_SIZE;
+  return {
+    left: clamp(left, MARGIN, viewport.width - PORTRAIT_ZOOM_SIZE - MARGIN),
+    top: clamp(
+      (anchor.top + anchor.bottom) / 2 - PORTRAIT_ZOOM_SIZE / 2,
+      MARGIN,
+      viewport.height - PORTRAIT_ZOOM_SIZE - MARGIN,
+    ),
+  };
+}


### PR DESCRIPTION
VRoid Hub character cards show a 34px thumbnail, too small to tell two similar
models apart. Hovering one now shows its portrait at 224px beside the card;
moving the pointer away, scrolling, or resizing dismisses it. Cards with no
portrait are unchanged.

The preview reuses the portrait already cached for the thumbnail, so it costs no
extra request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
