### PR TITLE
feat(settings): lower the character size floor to 40%

### DIFF
--- a/electron/settings-store.cts
+++ b/electron/settings-store.cts
@@ -119,7 +119,7 @@ export const DEFAULT_PACKAGED_LIBRARY_PATH = path.join(
   "assets",
   "library.json",
 );
-export const MIN_CHARACTER_SIZE = 0.7;
+export const MIN_CHARACTER_SIZE = 0.4;
 export const MAX_CHARACTER_SIZE = 1.6;
 export const MIN_AVATAR_WINDOW_WIDTH = 320;
 export const MAX_AVATAR_WINDOW_WIDTH = 2160;

--- a/electron/settings-store.test.cts
+++ b/electron/settings-store.test.cts
@@ -423,6 +423,8 @@ test("validates custom metadata, files, duplicates, and appearance settings", (c
   );
   assert.throws(() => store.setCharacterSize(2), /between/);
   assert.equal(store.setCharacterSize(1.25).character_size, 1.25);
+  assert.equal(store.setCharacterSize(0.4).character_size, 0.4);
+  assert.throws(() => store.setCharacterSize(0.35), /between/);
   assert.throws(() => store.setBodyTransitionMs(49), /between/);
   assert.equal(store.setBodyTransitionMs(400).body_transition_ms, 400);
   assert.throws(() => store.setSpeakingDebounceMs(3001), /between/);

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -399,6 +399,9 @@ export function Scene(props: SceneProps) {
           scale={grounding.scale}
         />
       )}
+      {/* The full-body framing at the 0.4 size floor sits ~12.3 units out
+          for the packaged models in a default 430x680 window; 14 keeps the
+          orbit clamp from swallowing the smallest size. */}
       <OrbitControls
         makeDefault
         enableDamping
@@ -406,7 +409,7 @@ export function Scene(props: SceneProps) {
         enablePan={props.enablePan ?? true}
         enableZoom
         minDistance={1.4}
-        maxDistance={12}
+        maxDistance={14}
         panSpeed={0.7}
         rotateSpeed={0.45}
         screenSpacePanning

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -134,7 +134,7 @@ export function AppearanceSection({
           aria-label="Default character size"
           className="single-range-slider size-slider"
           max="1.6"
-          min="0.7"
+          min="0.4"
           onBlur={(event) =>
             void saveCharacterSize(Number(event.currentTarget.value))
           }
@@ -152,12 +152,12 @@ export function AppearanceSection({
             void saveCharacterSize(Number(event.currentTarget.value))
           }
           step="0.05"
-          style={singleRangeStyle(settings.character_size, 0.7, 1.6)}
+          style={singleRangeStyle(settings.character_size, 0.4, 1.6)}
           type="range"
           value={settings.character_size}
         />
         <div className="slider-labels">
-          <span>70%</span>
+          <span>40%</span>
           <span>Default</span>
           <span>160%</span>
         </div>


### PR DESCRIPTION
Implements the direction from https://github.com/xikhar/persona/issues/66#issuecomment-5455399834. Closes #66.

## Changes

- `MIN_CHARACTER_SIZE` 0.7 → 0.4 in `electron/settings-store.cts`. 0.7 landed with the other library limits in #4 and was never a product floor; since the live camera frames at `1.5 * character_size`, 70% was just a full-body fit, not a reason to refuse a smaller persisted size. Manual zoom is not persisted, so the slider floor is the right fix. Default stays 100%.
- Slider bound (`min`, `singleRangeStyle`) and the `70%` label in `AppearanceSection.tsx` move to 0.4 / 40% in lockstep.
- `OrbitControls` `maxDistance` 12 → 14 in `Scene.tsx`.
- `settings-store.test.cts`: 0.4 accepted, 0.35 rejected (`/between/`).

## The orbit-clamp check

Measured with the packaged models via the app's own load path (`removeUnnecessaryVertices` → `combineMorphs` → `rotateVRM0`) and `calculateFullBodyFraming` at `zoom = 1.5 × 0.4`, default 430×680 window:

| model | framing distance @ 0.4 | clamp 12 | clamp 14 |
|---|---|---|---|
| virena (`models/model.vrm`) | 12.267 | clamped — eats ~2% of the size | fits |
| AvatarSample_A | 11.631 | fits (3% headroom) | fits |

14 keeps roughly 14% headroom over the packaged default model at the new floor. Known limit: an extremely narrow-and-tall window (e.g. 320×1440) computes a still larger framing distance and remains clamped — that predates this change and affects any size there.

## Verification

- `npm test`: 197 node + 161 renderer tests pass
- `tsc -b` and `eslint` pass on the changed files